### PR TITLE
fixed main launch file so that the model types aren't hard coded for the camera topics 

### DIFF
--- a/controls/sae_2025_ws/src/uav/launch/launch_params.yaml
+++ b/controls/sae_2025_ws/src/uav/launch/launch_params.yaml
@@ -5,6 +5,7 @@ vision_debug: false
 sim: true
 run_mission: true
 vehicle_type: 0 # 0 for quadrotor, 1 for tiltrotor VTOL, 2 for fixed-wing, 3 for standard VTOL
+model: 'gz_x500_mono_cam_down' # make sure model corresponds to correct vehicle_type
 save_vision: false
 servo_only: false
 camera_offsets: [0, 0, 0] #Should denote the position of the camera relative to the payload mechanism, in meters

--- a/controls/sae_2025_ws/src/uav/launch/main.launch.py
+++ b/controls/sae_2025_ws/src/uav/launch/main.launch.py
@@ -140,18 +140,19 @@ def launch_setup(context, *args, **kwargs):
     )
     
     # Define the PX4 SITL process.
+
+    model = params.get('model')
+    if not model:
+        raise ValueError("Model name must be specified in launch_params.yaml")
+    
     if vehicle_type == 'quadcopter':
         autostart = 4001
-        model = 'gz_x500_mono_cam_down'
     elif vehicle_type == 'tiltrotor_vtol':
         autostart = 4020
-        model = 'gz_tiltrotor'
     elif vehicle_type == 'fixed_wing':
         autostart = 4003
-        model = 'gz_rc_cessna'
     elif vehicle_type == 'standard_vtol':
         autostart = 4004
-        model = 'gz_standard_vtol'
     else:
         raise ValueError(f"Invalid vehicle type: {vehicle_type}")
     

--- a/controls/sae_2025_ws/src/uav/launch/main.launch.py
+++ b/controls/sae_2025_ws/src/uav/launch/main.launch.py
@@ -142,7 +142,7 @@ def launch_setup(context, *args, **kwargs):
     # Define the PX4 SITL process.
     if vehicle_type == 'quadcopter':
         autostart = 4001
-        model = 'gz_x500_mono_cam'
+        model = 'gz_x500_mono_cam_down'
     elif vehicle_type == 'tiltrotor_vtol':
         autostart = 4020
         model = 'gz_tiltrotor'

--- a/controls/sae_2025_ws/src/uav/launch/main.launch.py
+++ b/controls/sae_2025_ws/src/uav/launch/main.launch.py
@@ -142,7 +142,6 @@ def launch_setup(context, *args, **kwargs):
     # Define the PX4 SITL process.
     if vehicle_type == 'quadcopter':
         autostart = 4001
-        # model = 'gz_x500_mono_cam_down'
         model = 'gz_x500_mono_cam'
     elif vehicle_type == 'tiltrotor_vtol':
         autostart = 4020
@@ -167,17 +166,6 @@ def launch_setup(context, *args, **kwargs):
     GZ_CAMERA_TOPIC = f'/world/custom/model/{topic_model_name}_0/link/camera_link/sensor/imager/image'
     GZ_CAMERA_INFO_TOPIC = f'/world/custom/model/{topic_model_name}_0/link/camera_link/sensor/imager/camera_info'
 
-    # Define the ROS-Gazebo bridge for the camera topics.
-    # gz_ros_bridge_camera = ExecuteProcess(
-    #     cmd=['ros2', 'run', 'ros_gz_bridge', 'parameter_bridge',
-    #         f'{GZ_CAMERA_TOPIC}@sensor_msgs/msg/Image[gz.msgs.Image',
-    #         '--ros-args', '--remap', '/world/custom/model/x500_mono_cam_down_0/link/camera_link/sensor/imager/image:=/camera'],
-    #     output='screen',
-    #     cwd=sae_ws_path,
-    #     name='gz_ros_bridge_camera'
-    # )
-    
-    # CORRECTED VERSION
     gz_ros_bridge_camera = ExecuteProcess(
         cmd=['ros2', 'run', 'ros_gz_bridge', 'parameter_bridge',
             # Use the EXACT topic name from gz topic -l

--- a/controls/sae_2025_ws/src/uav/launch/main.launch.py
+++ b/controls/sae_2025_ws/src/uav/launch/main.launch.py
@@ -9,8 +9,6 @@ from launch.event_handlers import OnProcessStart
 from launch_ros.actions import Node
 from uav.utils import vehicle_map
 
-GZ_CAMERA_TOPIC = '/world/custom/model/x500_mono_cam_down_0/link/camera_link/sensor/imager/image'
-GZ_CAMERA_INFO_TOPIC = '/world/custom/model/x500_mono_cam_down_0/link/camera_link/sensor/imager/camera_info'
 HARDCODE_PATH = False
 
 def find_folder(folder_name, search_path):
@@ -144,7 +142,8 @@ def launch_setup(context, *args, **kwargs):
     # Define the PX4 SITL process.
     if vehicle_type == 'quadcopter':
         autostart = 4001
-        model = 'gz_x500_mono_cam_down'
+        # model = 'gz_x500_mono_cam_down'
+        model = 'gz_x500_mono_cam'
     elif vehicle_type == 'tiltrotor_vtol':
         autostart = 4020
         model = 'gz_tiltrotor'
@@ -156,6 +155,7 @@ def launch_setup(context, *args, **kwargs):
         model = 'gz_standard_vtol'
     else:
         raise ValueError(f"Invalid vehicle type: {vehicle_type}")
+    
     px4_sitl = ExecuteProcess(
         cmd=['bash', '-c', f'PX4_GZ_STANDALONE=1 PX4_SYS_AUTOSTART={autostart} PX4_SIM_MODEL={model} PX4_GZ_WORLD=custom ./build/px4_sitl_default/bin/px4'],
         cwd=px4_path,
@@ -163,20 +163,36 @@ def launch_setup(context, *args, **kwargs):
         name='px4_sitl'
     )
 
+    topic_model_name = model[3:]
+    GZ_CAMERA_TOPIC = f'/world/custom/model/{topic_model_name}_0/link/camera_link/sensor/imager/image'
+    GZ_CAMERA_INFO_TOPIC = f'/world/custom/model/{topic_model_name}_0/link/camera_link/sensor/imager/camera_info'
+
     # Define the ROS-Gazebo bridge for the camera topics.
+    # gz_ros_bridge_camera = ExecuteProcess(
+    #     cmd=['ros2', 'run', 'ros_gz_bridge', 'parameter_bridge',
+    #         f'{GZ_CAMERA_TOPIC}@sensor_msgs/msg/Image[gz.msgs.Image',
+    #         '--ros-args', '--remap', '/world/custom/model/x500_mono_cam_down_0/link/camera_link/sensor/imager/image:=/camera'],
+    #     output='screen',
+    #     cwd=sae_ws_path,
+    #     name='gz_ros_bridge_camera'
+    # )
+    
+    # CORRECTED VERSION
     gz_ros_bridge_camera = ExecuteProcess(
         cmd=['ros2', 'run', 'ros_gz_bridge', 'parameter_bridge',
+            # Use the EXACT topic name from gz topic -l
             f'{GZ_CAMERA_TOPIC}@sensor_msgs/msg/Image[gz.msgs.Image',
-            '--ros-args', '--remap', '/world/custom/model/x500_mono_cam_down_0/link/camera_link/sensor/imager/image:=/camera'],
+            '--ros-args', '--remap',
+            # Also use the EXACT topic name for the remap source
+            f'{GZ_CAMERA_TOPIC}:=/camera'],
         output='screen',
         cwd=sae_ws_path,
         name='gz_ros_bridge_camera'
     )
-    
     gz_ros_bridge_camera_info = ExecuteProcess(
         cmd=['ros2', 'run', 'ros_gz_bridge', 'parameter_bridge',
             f'{GZ_CAMERA_INFO_TOPIC}@sensor_msgs/msg/CameraInfo[gz.msgs.CameraInfo',
-            '--ros-args', '--remap', '/world/custom/model/x500_mono_cam_down_0/link/camera_link/sensor/imager/camera_info:=/camera_info'],
+            '--ros-args', '--remap', f'{GZ_CAMERA_INFO_TOPIC}:=/camera_info'],
         output='screen',
         cwd=sae_ws_path,
         name='gz_ros_bridge_camera_info'


### PR DESCRIPTION
for the processes that executed the ros_gz_bridge for the drone camera, the model type was hard coded. This fixes it so that the model type used in the camera topics is the same as the model defined in the launch params yaml