### PR TITLE
camera topic name discrepancy after switching to downloading zipped PX4 models

### DIFF
--- a/controls/sae_2025_ws/src/uav/launch/main.launch.py
+++ b/controls/sae_2025_ws/src/uav/launch/main.launch.py
@@ -11,9 +11,12 @@ from launch_ros.actions import Node
 from uav.utils import vehicle_map, find_folder_with_heuristic, load_launch_parameters, extract_vision_nodes
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.logging import get_logger
 from ament_index_python.packages import get_package_share_directory
 
 def launch_setup(context, *args, **kwargs):
+    logger =  get_logger('main.launch')
+    
     # Load launch parameters from the YAML file.
     params = load_launch_parameters()
     mission_name = params.get('mission_name', 'basic')
@@ -102,11 +105,10 @@ def launch_setup(context, *args, **kwargs):
     else:
         raise ValueError(f"Unknown architecture: {arch}")
 
-    camera_topic_name = (
-        "imager" if platform_type == "x86" else "camera"
-    )  # windows -> 'imager'   mac -> 'camera'
-    GZ_CAMERA_TOPIC = f"/world/custom/model/{topic_model_name}_0/link/camera_link/sensor/{camera_topic_name}/image"
-    GZ_CAMERA_INFO_TOPIC = f"/world/custom/model/{topic_model_name}_0/link/camera_link/sensor/{camera_topic_name}/camera_info"
+    logger.debug(f"Running Architecture: {arch}")
+
+    GZ_CAMERA_TOPIC = f"/world/custom/model/{topic_model_name}_0/link/camera_link/sensor/camera/image"
+    GZ_CAMERA_INFO_TOPIC = f"/world/custom/model/{topic_model_name}_0/link/camera_link/sensor/camera/camera_info"
 
     sae_ws_path = os.path.expanduser(os.getcwd())
     


### PR DESCRIPTION
In our previous method of downloading gz models to ~./simulation-gazebo (copying straight for PX4-Autopilot src code), gazebo published different camera topic paths based on different architectures: (x86 was "imager" and mac was "camera")
swapping to running the `simulation-gazebo --dryrun` method restandardized the camera topics, so we need to "revert" the computer architecture camera topic discrepancies

I decided to keep the architecture determining portion of the code in case we need that in the future for debugging
-also added a 'main.launch' logger