### PR TITLE
Fix/133 rtl mode

### DIFF
--- a/controls/sae_2025_ws/src/uav/uav/ModeManager.py
+++ b/controls/sae_2025_ws/src/uav/uav/ModeManager.py
@@ -101,6 +101,7 @@ class ModeManager(Node):
 
         self.uav.failsafe_trigger = True
         self.uav.failsafe = self.uav.failsafe_px4 or self.uav.failsafe_trigger
+        self.uav.rtl()
 
         response.success = True
         response.message = "Failsafe triggered."
@@ -243,15 +244,9 @@ class ModeManager(Node):
         current_time = time()
         if self.uav.failsafe:
             if not self.uav.emergency_landing:
-                self.uav.hover()
-                self.get_logger().warn("Failsafe: Switching to AUTO_LOITER mode.")
+                self.uav.rtl()
+                self.get_logger().warn("Failsafe: Returning to Launch.")
                 self.uav.emergency_landing = True
-            if (
-                self.uav.nav_state == VehicleStatus.NAVIGATION_STATE_AUTO_LOITER
-                or self.uav.arm_state != VehicleStatus.ARMING_STATE_ARMED
-            ):
-                self.uav.land()  # Initiate the landing procedure.
-                self.get_logger().warn("Failsafe: Initiating landing.")
             return
         if self.servo_only:
             if self.active_mode is None:

--- a/controls/sae_2025_ws/src/uav/uav/UAV.py
+++ b/controls/sae_2025_ws/src/uav/uav/UAV.py
@@ -147,7 +147,11 @@ class UAV(ABC):
                 "param3": PX4CustomSubModeAuto.LOITER.value,
             },
         )
-
+    def rtl(self):
+        self._send_vehicle_command(
+            VehicleCommand.VEHICLE_CMD_DO_SET_MODE,
+            params={'param1': 1.0, 'param2':4.0, 'param3': 5.0}
+        )
     def disarm(self):
         """Send a disarm command to the UAV."""
         self._send_vehicle_command(

--- a/controls/sae_2025_ws/src/uav/uav/UAV.py
+++ b/controls/sae_2025_ws/src/uav/uav/UAV.py
@@ -147,11 +147,17 @@ class UAV(ABC):
                 "param3": PX4CustomSubModeAuto.LOITER.value,
             },
         )
+
     def rtl(self):
         self._send_vehicle_command(
             VehicleCommand.VEHICLE_CMD_DO_SET_MODE,
-            params={'param1': 1.0, 'param2':4.0, 'param3': 5.0}
+            params={
+                "param1": 1.0,
+                "param2": PX4CustomMainMode.AUTO.value,
+                "param3": PX4CustomSubModeAuto.RTL.value,
+            },
         )
+
     def disarm(self):
         """Send a disarm command to the UAV."""
         self._send_vehicle_command(


### PR DESCRIPTION
1. added back the rtl() function in uav to send a vehicle command that sets the correct params for return to launch 
2. call rtl() in two places in modemanager. removed the original landing call because rtl should handle that (?) 