### PR TITLE
Simplify mode target typing

### DIFF
--- a/controls/sae_2025_ws/src/uav/test/test_mission_spec.py
+++ b/controls/sae_2025_ws/src/uav/test/test_mission_spec.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import textwrap
+from typing import Any
 from types import SimpleNamespace
 import sys
 import types
@@ -337,7 +338,7 @@ def test_invalid_mode_target_is_rejected(monkeypatch, mission_target):
         lambda _mode_id, params: params,
     )
 
-    with pytest.raises(ValueError, match="must declare mission_target"):
+    with pytest.raises(ValueError, match="must resolve mission_target"):
         load_mission_spec({"modes": {"start": {"mode": "fake.module.FakeMode"}}})
 
 
@@ -345,9 +346,7 @@ def test_load_mode_class_accepts_module_path(monkeypatch):
     module_name = "uav.modes.payload.PayloadAprilTagApproachMode"
     fake_module = types.ModuleType(module_name)
 
-    class PayloadAprilTagApproachMode(Mode):
-        mission_target = "payload"
-
+    class PayloadAprilTagApproachMode(Mode[Any]):
         def __init__(self, node, vehicle) -> None:
             super().__init__(node, vehicle)
 
@@ -364,7 +363,7 @@ def test_load_mode_class_accepts_module_path(monkeypatch):
     mode_class = load_mode_class("uav.modes.payload.PayloadAprilTagApproachMode")
 
     assert mode_class.__name__ == "PayloadAprilTagApproachMode"
-    assert mode_class.mission_target == "payload"
+    assert issubclass(mode_class, Mode)
 
 
 def test_checked_in_peer_fleet_test_mission_loads_with_peer_union():
@@ -388,11 +387,10 @@ def test_load_mode_class_falls_back_from_class_path(tmp_path, monkeypatch):
         package_name="test_modes",
         module_name="fake_mode",
         body="""
+        from typing import Any
         from uav.modes.Mode import Mode
 
-        class FakeMode(Mode):
-            mission_target = "uav"
-
+        class FakeMode(Mode[Any]):
             def __init__(self, node, vehicle):
                 super().__init__(node, vehicle)
 

--- a/controls/sae_2025_ws/src/uav/test/test_peer_runtime_contract.py
+++ b/controls/sae_2025_ws/src/uav/test/test_peer_runtime_contract.py
@@ -87,6 +87,7 @@ def _install_ros_test_doubles() -> None:
 _install_ros_test_doubles()
 
 from uav.modes.Mode import Mode  # noqa: E402
+from uav.vehicles.Vehicle import Vehicle  # noqa: E402
 from uav.runtime.ModeManager import ModeManager  # noqa: E402
 import uav.runtime.ModeManager as mode_manager_module  # noqa: E402
 from uav.runtime.managed_comms import (  # noqa: E402
@@ -201,7 +202,7 @@ class _FakeLogger:
         pass
 
 
-class _FakeVehicle:
+class _FakeVehicle(Vehicle):
     def __init__(self, name: str = "payload_0") -> None:
         self.name = name
         self.has_camera = False
@@ -401,8 +402,7 @@ def test_build_mode_registry_entry_includes_peer_vehicle_names():
         "registry_peer_vehicle_names",
     )
 
-    class PeerAwareMode(Mode):
-        mission_target = "payload"
+    class PeerAwareMode(Mode[_FakeVehicle]):
         peer_vehicle_names = ("uav_2", "payload_1")
 
         def __init__(self, node, vehicle) -> None:
@@ -420,6 +420,7 @@ def test_build_mode_registry_entry_includes_peer_vehicle_names():
     PeerAwareMode.__module__ = "uav.modes.payload.PeerAwareMode"
     entry = build_mode_registry_entry(PeerAwareMode)
 
+    assert entry.mission_target == "payload"
     assert entry.peer_vehicle_names == ("payload_1", "uav_2")
 
 
@@ -429,8 +430,7 @@ def test_build_mode_registry_entry_allows_peer_mode_without_on_disconnect():
         "registry_peer_vehicle_names",
     )
 
-    class PeerAwareMode(Mode):
-        mission_target = "payload"
+    class PeerAwareMode(Mode[_FakeVehicle]):
         peer_vehicle_names = ("uav_3",)
 
         def __init__(self, node, vehicle) -> None:
@@ -446,6 +446,41 @@ def test_build_mode_registry_entry_allows_peer_mode_without_on_disconnect():
     entry = build_mode_registry_entry(PeerAwareMode)
 
     assert entry.peer_vehicle_names == ("uav_3",)
+
+
+def test_build_mode_registry_entry_allows_direct_generic_mode_base():
+    class DirectMode(Mode[_FakeVehicle]):
+        def __init__(self, node, vehicle) -> None:
+            super().__init__(node, vehicle)
+
+        def on_update(self, time_delta: float) -> None:
+            pass
+
+        def check_status(self) -> str:
+            return "continue"
+
+    DirectMode.__module__ = "uav.modes.payload.DirectMode"
+    entry = build_mode_registry_entry(DirectMode)
+
+    assert entry.mode_id == "payload.DirectMode"
+    assert entry.mission_target == "payload"
+
+
+def test_build_mode_registry_entry_rejects_unsupported_namespace():
+    class UnsupportedNamespaceMode(Mode[_FakeVehicle]):
+        def __init__(self, node, vehicle) -> None:
+            super().__init__(node, vehicle)
+
+        def on_update(self, time_delta: float) -> None:
+            pass
+
+        def check_status(self) -> str:
+            return "continue"
+
+    UnsupportedNamespaceMode.__module__ = "uav.modes.boat.UnsupportedNamespaceMode"
+
+    with pytest.raises(ValueError, match="must live under"):
+        build_mode_registry_entry(UnsupportedNamespaceMode)
 
 
 def test_load_mission_spec_collects_sorted_peer_vehicle_names_union(
@@ -518,8 +553,7 @@ def test_mode_manager_validates_peer_and_shared_entity_namespaces(monkeypatch):
         "manager_create_service",
     )
 
-    class PeerAwareMode(Mode):
-        mission_target = "payload"
+    class PeerAwareMode(Mode[_FakeVehicle]):
         peer_vehicle_names = ("uav_1",)
 
         def __init__(self, node, vehicle) -> None:
@@ -622,8 +656,7 @@ def test_run_active_mode_uses_connection_ready_for_gating():
         "manager_disconnect_runtime",
     )
 
-    class PeerAwareMode(Mode):
-        mission_target = "payload"
+    class PeerAwareMode(Mode[_FakeVehicle]):
         peer_vehicle_names = ("uav_1", "uav_2")
 
         def __init__(self, node, vehicle) -> None:
@@ -676,8 +709,7 @@ def test_run_active_mode_passes_full_connection_status_to_disconnect():
         "manager_disconnect_runtime",
     )
 
-    class PeerAwareMode(Mode):
-        mission_target = "payload"
+    class PeerAwareMode(Mode[_FakeVehicle]):
         peer_vehicle_names = ("uav_1", "uav_2")
 
         def __init__(self, node, vehicle) -> None:
@@ -724,8 +756,7 @@ def test_run_active_mode_passes_full_connection_status_to_disconnect():
 def test_mode_connection_ready_defaults_to_all_declared_peers_connected():
     _xfail_if_missing_peer_features("mode_peer_vehicle_names", "mode_connection_ready")
 
-    class PeerAwareMode(Mode):
-        mission_target = "payload"
+    class PeerAwareMode(Mode[_FakeVehicle]):
         peer_vehicle_names = ("uav_1", "uav_2")
 
         def __init__(self, node, vehicle) -> None:
@@ -753,8 +784,7 @@ def test_peer_client_wrapper_rebinds_on_connection_changes(monkeypatch):
         "manager_create_client",
     )
 
-    class PeerAwareMode(Mode):
-        mission_target = "payload"
+    class PeerAwareMode(Mode[_FakeVehicle]):
         peer_vehicle_names = ("uav_1",)
 
         def __init__(self, node, vehicle) -> None:
@@ -861,8 +891,7 @@ def test_managed_entity_descriptors_use_persistent_and_active_phases(monkeypatch
         "manager_create_publisher",
     )
 
-    class PhaseAwareMode(Mode):
-        mission_target = "payload"
+    class PhaseAwareMode(Mode[_FakeVehicle]):
         peer_vehicle_names = ("uav_1",)
 
         def __init__(self, node, vehicle) -> None:
@@ -923,9 +952,7 @@ def test_shared_state_for_is_keyed_by_canonical_mode_path():
 
     manager = _make_mode_manager()
 
-    class SharedStateMode(Mode):
-        mission_target = "payload"
-
+    class SharedStateMode(Mode[_FakeVehicle]):
         def __init__(self, node, vehicle) -> None:
             super().__init__(node, vehicle)
 
@@ -957,8 +984,7 @@ def test_peer_entity_usage_instrumentation_matches_declared_peers():
         "mode_on_disconnect",
     )
 
-    class InstrumentedPeerMode(Mode):
-        mission_target = "payload"
+    class InstrumentedPeerMode(Mode[_FakeVehicle]):
         peer_vehicle_names = ("payload_1", "uav_2")
 
         def __init__(self, node, vehicle) -> None:

--- a/controls/sae_2025_ws/src/uav/test/test_runtime_behavior.py
+++ b/controls/sae_2025_ws/src/uav/test/test_runtime_behavior.py
@@ -214,6 +214,7 @@ def _install_ros_test_doubles() -> None:
 _install_ros_test_doubles()
 
 from uav.modes.Mode import Mode  # noqa: E402
+from uav.vehicles.Vehicle import Vehicle  # noqa: E402
 from uav.runtime.ModeManager import ModeManager  # noqa: E402
 import uav.runtime.ModeManager as mode_manager_module  # noqa: E402
 import uav.runtime.uav_mission as uav_mission_module  # noqa: E402
@@ -222,12 +223,20 @@ import uav.runtime.payload_mission as payload_mission_module  # noqa: E402
 import uav.runtime.PayloadModeManager as payload_manager_module  # noqa: E402
 
 
-class _ExpectedVehicle:
-    pass
+class _ExpectedVehicle(Vehicle):
+    def __init__(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
 
 
-class _OtherVehicle:
-    pass
+class _OtherVehicle(Vehicle):
+    def __init__(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
 
 
 class _FakeLogger:
@@ -427,9 +436,7 @@ def _require_runtime_support() -> None:
 def test_initialize_mode_happy_path(monkeypatch):
     _require_runtime_support()
 
-    class FakeMode(Mode):
-        mission_target = "uav"
-
+    class FakeMode(Mode[_ExpectedVehicle]):
         def __init__(
             self,
             node,
@@ -473,9 +480,7 @@ def test_initialize_mode_happy_path(monkeypatch):
 def test_initialize_mode_missing_required_parameter(monkeypatch):
     _require_runtime_support()
 
-    class FakeMode(Mode):
-        mission_target = "uav"
-
+    class FakeMode(Mode[_ExpectedVehicle]):
         def __init__(self, node, vehicle: _ExpectedVehicle, required: int) -> None:
             super().__init__(node, vehicle)
             self.required = required
@@ -505,9 +510,7 @@ def test_initialize_mode_missing_required_parameter(monkeypatch):
 def test_initialize_mode_rejects_unexpected_parameter(monkeypatch):
     _require_runtime_support()
 
-    class FakeMode(Mode):
-        mission_target = "uav"
-
+    class FakeMode(Mode[_ExpectedVehicle]):
         def __init__(self, node, vehicle: _ExpectedVehicle, required: int) -> None:
             super().__init__(node, vehicle)
             self.required = required
@@ -539,9 +542,7 @@ def test_initialize_mode_rejects_unexpected_parameter(monkeypatch):
 def test_initialize_mode_rejects_vehicle_type_mismatch(monkeypatch):
     _require_runtime_support()
 
-    class FakeMode(Mode):
-        mission_target = "uav"
-
+    class FakeMode(Mode[_ExpectedVehicle]):
         def __init__(self, node, vehicle: _ExpectedVehicle, required: int) -> None:
             super().__init__(node, vehicle)
             self.required = required

--- a/controls/sae_2025_ws/src/uav/uav/modes/Mode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/Mode.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, ClassVar, Mapping
+from typing import TYPE_CHECKING, ClassVar, Generic, Mapping, TypeVar
 
 from rclpy.node import Node
 
@@ -9,20 +9,21 @@ from uav.runtime.vision_loader import canonical_vision_node_path
 if TYPE_CHECKING:
     from uav.vision_nodes import VisionNode
 
+VehicleT = TypeVar("VehicleT", bound=Vehicle)
 
-class Mode(ABC):
+
+class Mode(Generic[VehicleT], ABC):
     """
     Base class for UAV operational modes within a ROS 2 node.
     Provides a structured template for implementing autonomous behaviors.
     """
 
-    mission_target: ClassVar[str | None] = None
     required_vision_nodes: ClassVar[tuple[object, ...]] = ()
     peer_vehicle_names: ClassVar[tuple[str, ...]] = ()
     requires_camera: ClassVar[bool] = False
     transition_labels: ClassVar[tuple[str, ...]] = ()
 
-    def __init__(self, node: Node, vehicle: Vehicle):
+    def __init__(self, node: Node, vehicle: VehicleT):
         """
         Initialize the mode with a reference to the ROS 2 node.
 
@@ -32,7 +33,7 @@ class Mode(ABC):
         """
         self.node = node
         self.active = False
-        self.vehicle: Vehicle = vehicle
+        self.vehicle: VehicleT = vehicle
         self.pending_requests = {}
 
     @classmethod

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadAprilTagApproachMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadAprilTagApproachMode.py
@@ -30,10 +30,9 @@ class TagObservation:
     area: float
 
 
-class PayloadAprilTagApproachMode(Mode):
+class PayloadAprilTagApproachMode(Mode[Payload]):
     """Drive the payload toward one AprilTag and terminate once close enough."""
 
-    mission_target = "payload"
     required_vision_nodes = ()
     requires_camera = True
     transition_labels = ("done", "tag_lost")
@@ -55,7 +54,6 @@ class PayloadAprilTagApproachMode(Mode):
         completion_state: str = "done",
     ):
         super().__init__(node, vehicle)
-        self.vehicle: Payload = vehicle
         self._completion_state = completion_state
         self.tag_id = None if tag_id is None else int(tag_id)
         self.tag_size_m = float(tag_size_m)

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadColorStringApproachMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadColorStringApproachMode.py
@@ -87,10 +87,9 @@ def _vertical_blob_centroid_area(
     return (best_cx, best_cy, best_area_i)
 
 
-class PayloadColorStringApproachMode(Mode):
+class PayloadColorStringApproachMode(Mode[Payload]):
     """Drive toward a coloured target using HSV blob detection."""
 
-    mission_target = "payload"
     required_vision_nodes = ()
     requires_camera = True
     transition_labels = ()
@@ -114,7 +113,6 @@ class PayloadColorStringApproachMode(Mode):
         use_global_hsv_centroid: bool = False,
     ):
         super().__init__(node, vehicle)
-        self.vehicle: Payload = vehicle
 
         self._lower_hsv = np.array(lower_hsv, dtype=np.uint8)
         self._upper_hsv = np.array(upper_hsv, dtype=np.uint8)

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
@@ -67,8 +67,7 @@ from ..Mode import Mode
 _COLOR_DOMINANCE_RATIO = 1.5
 
 
-class PayloadCornerNavigateMode(Mode):
-    mission_target = "payload"
+class PayloadCornerNavigateMode(Mode[Payload]):
     transition_labels = ("complete",)
     requires_camera = True
 

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
@@ -129,7 +129,7 @@ class TagTransitionRule(TypedDict):
     direction: Literal["cw", "ccw"]
 
 
-class PayloadDLZNavigateMode(Mode):
+class PayloadDLZNavigateMode(Mode[Payload]):
     """
     Navigate the payload along the alternating-colour square border of the DLZ.
 
@@ -165,7 +165,6 @@ class PayloadDLZNavigateMode(Mode):
         Test keys in YAML order — put more-specific rules first.
     """
 
-    mission_target = "payload"
     required_vision_nodes = (PayloadAprilTagNode,)
     transition_labels = ("done",)
     requires_camera = True

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDualApproachMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDualApproachMode.py
@@ -59,10 +59,9 @@ def _color_blob_info(
     return (cx, cy, int(a), bh)
 
 
-class PayloadDualApproachMode(Mode):
+class PayloadDualApproachMode(Mode[Payload]):
     """Approach using AprilTag when visible, HSV colour fallback otherwise."""
 
-    mission_target = "payload"
     required_vision_nodes = ()
     requires_camera = True
     transition_labels = ()
@@ -96,7 +95,6 @@ class PayloadDualApproachMode(Mode):
         compressed_image: bool = False,
     ):
         super().__init__(node, vehicle)
-        self.vehicle: Payload = vehicle
 
         # AprilTag
         self.tag_id = None if tag_id is None else int(tag_id)

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadIdleMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadIdleMode.py
@@ -11,8 +11,7 @@ from ..Mode import Mode
 _FOREVER = 0.0
 
 
-class PayloadIdleMode(Mode):
-    mission_target = "payload"
+class PayloadIdleMode(Mode[Payload]):
     required_vision_nodes = ()
     requires_camera = False
     transition_labels = ("complete",)

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadPeerFleetTestMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadPeerFleetTestMode.py
@@ -25,10 +25,9 @@ from uav.vehicles.Payload import Payload
 from ..Mode import Mode
 
 
-class PayloadPeerFleetTestMode(Mode):
+class PayloadPeerFleetTestMode(Mode[Payload]):
     """Passive multi-payload communication demo for fleet bring-up."""
 
-    mission_target = "payload"
     required_vision_nodes = ()
     peer_vehicle_names = ("payload_0", "payload_1")
     requires_camera = False
@@ -43,7 +42,6 @@ class PayloadPeerFleetTestMode(Mode):
         shared_topic: str = "/shared/peer_test/broadcast",
     ) -> None:
         super().__init__(node, vehicle)
-        self.vehicle: Payload = vehicle
         self.publish_period_s = float(publish_period_s)
         self._local_topic = vehicle.namespaced_path(local_topic)
         self._shared_topic = str(shared_topic).strip() or "/shared/peer_test/broadcast"

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadRetreatMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadRetreatMode.py
@@ -29,7 +29,7 @@ _WHITE_LOWER = np.array([0, 0, 200], dtype=np.uint8)
 _WHITE_UPPER = np.array([180, 30, 255], dtype=np.uint8)
 
 
-class PayloadRetreatMode(Mode):
+class PayloadRetreatMode(Mode[Payload]):
     """
     Drive the payload to the edge of the DLZ, then turn 180° to face the center.
 
@@ -44,7 +44,6 @@ class PayloadRetreatMode(Mode):
     Publishes DriveCommand to the payload's own namespaced command topic.
     """
 
-    mission_target = "payload"
     required_vision_nodes = (PayloadAprilTagNode,)
     transition_labels = ()
 

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadScanForTagMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadScanForTagMode.py
@@ -19,7 +19,7 @@ from ..Mode import Mode
 _TWO_PI = 2.0 * math.pi
 
 
-class PayloadScanForTagMode(Mode):
+class PayloadScanForTagMode(Mode[Payload]):
     """
     Spin in place looking for a specific AprilTag.
 
@@ -29,7 +29,6 @@ class PayloadScanForTagMode(Mode):
                       should reposition and try again
     """
 
-    mission_target = "payload"
     required_vision_nodes = (PayloadAprilTagNode,)
     transition_labels = ("found", "not_found")
     requires_camera = True

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py
@@ -45,7 +45,7 @@ class DriveOutState(Enum):
     DONE = 4
 
 
-class PayloadWaitForDriveOutMode(Mode):
+class PayloadWaitForDriveOutMode(Mode[Payload]):
     """
     Subscribe to the payload camera and detect when the plane has landed on the
     DLZ. Confirmation requires BOTH:
@@ -55,7 +55,6 @@ class PayloadWaitForDriveOutMode(Mode):
     Both conditions must hold continuously for wait_seconds before proceeding.
     """
 
-    mission_target = "payload"
     required_vision_nodes = ()
     requires_camera = True
     transition_labels = ("complete",)
@@ -86,7 +85,6 @@ class PayloadWaitForDriveOutMode(Mode):
         debug: bool = False,
     ):
         super().__init__(node, vehicle)
-        self.vehicle: Payload = vehicle
 
         self._dlz_lower = np.array(dlz_color_lower_hsv, dtype=np.uint8)
         self._dlz_upper = np.array(dlz_color_upper_hsv, dtype=np.uint8)

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/LandingMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/LandingMode.py
@@ -6,12 +6,10 @@ from uav.vehicles.UAV import UAV
 from ..Mode import Mode
 
 
-class LandingMode(Mode):
+class LandingMode(Mode[UAV]):
     """
     A mode for taking off vertically.
     """
-
-    mission_target = "uav"
 
     def __init__(self, node: Node, vehicle: UAV):
         """

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/NavGPSMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/NavGPSMode.py
@@ -6,12 +6,11 @@ from uav.vehicles.UAV import UAV
 from ..Mode import Mode
 
 
-class NavGPSMode(Mode):
+class NavGPSMode(Mode[UAV]):
     """
     A mode for navigating to a GPS coordinate
     """
 
-    mission_target = "uav"
     transition_labels = ("complete",)
 
     # TODO: Create "RELATIVE" navigation system, which initializes direction vectors once in the beginning

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/PayloadDropoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/PayloadDropoffMode.py
@@ -11,12 +11,11 @@ from uav_interfaces.srv import PayloadTracking
 from ..Mode import Mode
 
 
-class PayloadDropoffMode(Mode):
+class PayloadDropoffMode(Mode[UAV]):
     """
     A mode for dropping off the payload.
     """
 
-    mission_target = "uav"
     required_vision_nodes = (PayloadTrackingNode,)
     transition_labels = ("complete",)
 

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/PayloadPickupMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/PayloadPickupMode.py
@@ -8,12 +8,11 @@ from uav_interfaces.srv import PayloadTracking
 from ..Mode import Mode
 
 
-class PayloadPickupMode(Mode):
+class PayloadPickupMode(Mode[UAV]):
     """
     A mode for picking up a payload.
     """
 
-    mission_target = "uav"
     required_vision_nodes = (PayloadTrackingNode,)
     transition_labels = ("complete",)
 

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/ServoDropoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/ServoDropoffMode.py
@@ -7,12 +7,11 @@ from uav.vehicles.UAV import UAV
 from ..Mode import Mode
 
 
-class ServoDropoffMode(Mode):
+class ServoDropoffMode(Mode[UAV]):
     """
     A mode for dropping off the payload.
     """
 
-    mission_target = "uav"
     transition_labels = ("complete",)
 
     def __init__(

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py
@@ -12,13 +12,11 @@ from uav.vehicles.UAV import UAV
 from ..Mode import Mode
 
 
-class WaypointMission(Mode):
+class WaypointMission(Mode[UAV]):
     """
     Simple waypoint mission for testing scoring node.
     Flies through a series of waypoints defined in YAML.
     """
-
-    mission_target = "uav"
 
     def __init__(
         self,

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/TakeoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/TakeoffMode.py
@@ -11,7 +11,7 @@ from uav.vehicles.VTOL import VTOL
 from ...Mode import Mode
 
 
-class TakeoffMode(Mode):
+class TakeoffMode(Mode[VTOL]):
     """
     A VTOL takeoff mode that supports both vertical and runway-style launches.
     """

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/TransitionMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/TransitionMode.py
@@ -7,7 +7,7 @@ from uav.vehicles.VTOL import VTOL
 from ...Mode import Mode
 
 
-class TransitionMode(Mode):
+class TransitionMode(Mode[VTOL]):
     """
     A VTOL-only mode for transitioning between multicopter and fixed-wing flight.
     """

--- a/controls/sae_2025_ws/src/uav/uav/runtime/ModeManager.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/ModeManager.py
@@ -5,7 +5,7 @@ import inspect
 import os
 from pathlib import Path
 from time import time
-from typing import Any, Callable, Iterator, get_type_hints
+from typing import Any, Callable, Iterator, cast, get_type_hints
 
 from rclpy.node import Node
 from std_srvs.srv import Trigger
@@ -57,10 +57,10 @@ class ModeManager(Node):
         peer_stale_timeout_s: float = 0.5,
     ) -> None:
         super().__init__(node_name)
-        self.vehicle = None
-        self.modes = {}
-        self.transitions = {}
-        self.active_mode = None
+        self.vehicle: Any = None
+        self.modes: dict[str, Mode[Any]] = {}
+        self.transitions: dict[str, dict[str, str]] = {}
+        self.active_mode: str | None = None
         self.last_update_time = time()
         self._vision_clients = {}
         self.timer = None
@@ -89,8 +89,8 @@ class ModeManager(Node):
         if self.auto_launch:
             self._auto_launch_timer = self.create_timer(0.1, self._maybe_auto_launch)
 
-    def get_active_mode(self) -> Mode:
-        return self.modes[self.active_mode]
+    def get_active_mode(self) -> Mode[Any]:
+        return self.modes[cast(str, self.active_mode)]
 
     def _now_seconds(self) -> float:
         return self.get_clock().now().nanoseconds * 1e-9
@@ -227,7 +227,7 @@ class ModeManager(Node):
     def _mode_peer_names(self, mode_or_class: object) -> tuple[str, ...]:
         return declared_remote_peer_names(mode_or_class, self._runtime_vehicle_name)
 
-    def _mode_connection_status(self, mode: Mode) -> dict[str, bool]:
+    def _mode_connection_status(self, mode: Mode[Any]) -> dict[str, bool]:
         return relevant_connection_status(
             self._peer_connections.status(),
             peer_vehicle_names=self._mode_peer_names(mode),
@@ -270,11 +270,11 @@ class ModeManager(Node):
     def _instantiate_mode(
         self,
         *,
-        mode_class: type[Mode],
+        mode_class: type[Mode[Any]],
         args: dict[str, Any],
         mode_id: str,
         peer_vehicle_names: tuple[str, ...],
-    ) -> Mode:
+    ) -> Mode[Any]:
         mode_instance = mode_class.__new__(mode_class)
         if not isinstance(mode_instance, mode_class):
             raise TypeError(
@@ -341,7 +341,7 @@ class ModeManager(Node):
             return bool(self._raw_method(f"destroy_{kind}")(entity))
         return getattr(registry, f"destroy_{kind}")(entity)
 
-    def initialize_mode(self, mode_id: str, params: dict) -> Mode:
+    def initialize_mode(self, mode_id: str, params: dict) -> Mode[Any]:
         mode_entry = mode_entry_for_mode_id(mode_id)
         mode_class = load_mode_class(mode_entry.class_path)
         peer_vehicle_names = self._mode_peer_names(mode_class)
@@ -401,7 +401,7 @@ class ModeManager(Node):
             self.add_mode(mode_name, mode)
             self.transitions[mode_name] = mode_info.transitions
 
-    def add_mode(self, mode_name: str, mode_instance: Mode) -> None:
+    def add_mode(self, mode_name: str, mode_instance: Mode[Any]) -> None:
         self.modes[mode_name] = mode_instance
         self.get_logger().info(f"Mode {mode_name} registered.")
 

--- a/controls/sae_2025_ws/src/uav/uav/runtime/ModeManager.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/ModeManager.py
@@ -57,7 +57,7 @@ class ModeManager(Node):
         peer_stale_timeout_s: float = 0.5,
     ) -> None:
         super().__init__(node_name)
-        self.vehicle: Any = None
+        self.vehicle: Vehicle | None = None
         self.modes: dict[str, Mode[Any]] = {}
         self.transitions: dict[str, dict[str, str]] = {}
         self.active_mode: str | None = None
@@ -208,7 +208,10 @@ class ModeManager(Node):
         return self._vision_clients
 
     def _connect_vision_client(self, vision_class):
-        service_name = self.vehicle.vision_service_name(vision_class)
+        vehicle = self.vehicle
+        if vehicle is None:
+            raise ValueError("Vision nodes require an active vehicle camera contract.")
+        service_name = vehicle.vision_service_name(vision_class)
         while True:
             client = super().create_client(vision_class.srv, service_name)
             if client.wait_for_service(timeout_sec=1.0):

--- a/controls/sae_2025_ws/src/uav/uav/runtime/mission_spec.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/mission_spec.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import importlib
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field
@@ -27,6 +27,9 @@ except ModuleNotFoundError:
 VALID_MISSION_TARGETS = {"uav", "payload"}
 _TOP_LEVEL_KEYS = {"modes"}
 _MODE_KEYS = {"mode", "params", "transitions"}
+
+if TYPE_CHECKING:
+    from uav.modes.Mode import Mode
 
 
 class MissionModeDocumentModel(BaseModel):
@@ -54,7 +57,7 @@ def mission_path_for_name(mission_name: str) -> str:
     return str(mission_root() / f"{mission_name}.yaml")
 
 
-def load_mode_class(class_path: str):
+def load_mode_class(class_path: str) -> type["Mode[Any]"]:
     class_name = class_path.rsplit(".", 1)[-1]
     try:
         module = importlib.import_module(class_path)
@@ -202,7 +205,7 @@ def load_mission_spec(path: str | Path | dict[str, Any]) -> MissionSpec:
         mission_target = mode_entry.mission_target
         if mission_target not in VALID_MISSION_TARGETS:
             raise ValueError(
-                f"Mode '{mode_id}' must declare mission_target as one of {sorted(VALID_MISSION_TARGETS)}."
+                f"Mode '{mode_id}' must resolve mission_target as one of {sorted(VALID_MISSION_TARGETS)}."
             )
         mode_targets.add(mission_target)
         vision_nodes.update(mode_entry.required_vision_nodes)

--- a/controls/sae_2025_ws/src/uav/uav/runtime/schema_generator.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/schema_generator.py
@@ -45,10 +45,10 @@ def _is_typed_dict(annotation: object) -> bool:
     )
 
 
-def _iter_mode_classes() -> list[type[Mode]]:
+def _iter_mode_classes() -> list[type[Mode[Any]]]:
     import uav.modes as mode_package
 
-    discovered: dict[str, type[Mode]] = {}
+    discovered: dict[str, type[Mode[Any]]] = {}
     for module_info in pkgutil.walk_packages(
         mode_package.__path__, prefix=f"{mode_package.__name__}."
     ):
@@ -66,6 +66,7 @@ def _iter_mode_classes() -> list[type[Mode]]:
                 isinstance(value, type)
                 and issubclass(value, Mode)
                 and value is not Mode
+                and not inspect.isabstract(value)
                 and value.__module__ == module.__name__
             ):
                 discovered[mode_id_for(value)] = value
@@ -73,7 +74,7 @@ def _iter_mode_classes() -> list[type[Mode]]:
 
 
 def _normalized_annotation(
-    mode_class: type[Mode], *, name: str, annotation: object, default: object
+    mode_class: type[Mode[Any]], *, name: str, annotation: object, default: object
 ) -> object:
     if annotation in (inspect.Parameter.empty, None, Any, object):
         if default not in (inspect.Parameter.empty, None) and type(default) in {
@@ -101,7 +102,7 @@ def _normalized_annotation(
     return annotation
 
 
-def mode_params_model(mode_class: type[Mode]) -> type[BaseModel]:
+def mode_params_model(mode_class: type[Mode[Any]]) -> type[BaseModel]:
     signature = inspect.signature(mode_class.__init__)
     type_hints = get_type_hints(mode_class.__init__)
     field_definitions: dict[str, tuple[object, object]] = {}
@@ -242,7 +243,9 @@ def _normalize_annotation_spec(annotation: object) -> dict[str, Any]:
     raise TypeError(f"Unsupported schema annotation: {annotation!r}")
 
 
-def _field_specs_for_mode(mode_class: type[Mode]) -> tuple[ModeParamFieldSpec, ...]:
+def _field_specs_for_mode(
+    mode_class: type[Mode[Any]],
+) -> tuple[ModeParamFieldSpec, ...]:
     signature = inspect.signature(mode_class.__init__)
     type_hints = get_type_hints(mode_class.__init__)
     fields: list[ModeParamFieldSpec] = []
@@ -276,18 +279,12 @@ def _field_specs_for_mode(mode_class: type[Mode]) -> tuple[ModeParamFieldSpec, .
     return tuple(fields)
 
 
-def build_mode_registry_entry(mode_class: type[Mode]) -> ModeRegistryEntry:
+def build_mode_registry_entry(mode_class: type[Mode[Any]]) -> ModeRegistryEntry:
     mode_id = mode_id_for(mode_class)
     mission_target = mission_target_from_mode_id(mode_id)
     if mission_target not in {"uav", "payload"}:
         raise ValueError(
             f"Mode '{mode_id}' must live under the 'uav' or 'payload' public mode namespace."
-        )
-    declared_target = getattr(mode_class, "mission_target", None)
-    if declared_target is not None and declared_target != mission_target:
-        raise ValueError(
-            f"Mode '{mode_id}' declares mission_target '{declared_target}', "
-            f"but its namespace requires '{mission_target}'."
         )
     peer_vehicle_names = tuple(
         sorted(


### PR DESCRIPTION
Removes per-mode mission_target declarations and derives registry mission targets from public mode namespaces. Updates modes to use Mode[Payload], Mode[UAV], and Mode[VTOL]
  directly.