### PR TITLE
Expose lazy mode package exports to type checkers

### DIFF
--- a/controls/sae_2025_ws/src/uav/uav/modes/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/__init__.py
@@ -1,10 +1,14 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = ["Mode"]
 
 _EXPORTS = {
     "Mode": ".Mode",
 }
+
+if TYPE_CHECKING:
+    from .Mode import Mode
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/__init__.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = [
     "PayloadAprilTagApproachMode",
@@ -6,6 +7,12 @@ __all__ = [
     "PayloadDualApproachMode",
     "PayloadRetreatMode",
 ]
+
+if TYPE_CHECKING:
+    from .PayloadAprilTagApproachMode import PayloadAprilTagApproachMode
+    from .PayloadColorStringApproachMode import PayloadColorStringApproachMode
+    from .PayloadDualApproachMode import PayloadDualApproachMode
+    from .PayloadRetreatMode import PayloadRetreatMode
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/__init__.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = [
     "LandingMode",
@@ -9,6 +10,15 @@ __all__ = [
     "TransitionMode",
     "WaypointMission",
 ]
+
+if TYPE_CHECKING:
+    from .LandingMode import LandingMode
+    from .NavGPSMode import NavGPSMode
+    from .PayloadDropoffMode import PayloadDropoffMode
+    from .PayloadPickupMode import PayloadPickupMode
+    from .ServoDropoffMode import ServoDropoffMode
+    from .TransitionMode import TransitionMode
+    from .WaypointMission import WaypointMission
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/__init__.py
@@ -1,6 +1,11 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = ["TakeoffMode", "TransitionMode"]
+
+if TYPE_CHECKING:
+    from .TakeoffMode import TakeoffMode
+    from .TransitionMode import TransitionMode
 
 
 def __getattr__(name: str):


### PR DESCRIPTION
## Summary
- Add `TYPE_CHECKING` imports for lazy `uav.modes` package exports.
- Preserve runtime lazy loading via `__getattr__`.
- Clear the Pyright/Pylance `reportUnsupportedDunderAll` warnings for mode package initializers.

## Verification
- `npx --yes pyright --project /tmp/pyright-modes --outputjson` now reports `warningCount: 0` for modes with ROS/source paths configured.
- `PYTHONPATH=controls/sae_2025_ws/src/uav python3 -m compileall controls/sae_2025_ws/src/uav/uav/modes/__init__.py controls/sae_2025_ws/src/uav/uav/modes/payload/__init__.py controls/sae_2025_ws/src/uav/uav/modes/uav/__init__.py controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/__init__.py`

Refs #183
Part of #180