### PR TITLE
Type mode exports and manager contracts

### DIFF
--- a/controls/sae_2025_ws/src/uav/uav/modes/Mode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/Mode.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, ClassVar, Generic, Mapping, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Mapping, Protocol, TypeVar, cast
 
 from rclpy.node import Node
 
@@ -10,6 +10,14 @@ if TYPE_CHECKING:
     from uav.vision_nodes import VisionNode
 
 VehicleT = TypeVar("VehicleT", bound=Vehicle)
+
+
+class _ModeManagerNode(Protocol):
+    def get_vision_client(self, vision_node: type["VisionNode"]) -> Any:
+        ...
+
+    def shared_state_for(self, mode_or_class: object) -> dict[str, Any]:
+        ...
 
 
 class Mode(Generic[VehicleT], ABC):
@@ -53,7 +61,7 @@ class Mode(Generic[VehicleT], ABC):
         """
         pass
 
-    def send_request(self, vision_node: type["VisionNode"], request):
+    def send_request(self, vision_node: type["VisionNode"], request: Any):
         """
         Send a request to a service.
 
@@ -64,7 +72,8 @@ class Mode(Generic[VehicleT], ABC):
         service_name = self.vehicle.vision_service_name(vision_node)
         future = self.pending_requests.get(service_name)
         if future is None:
-            client = self.node.get_vision_client(vision_node)
+            node = cast(_ModeManagerNode, self.node)
+            client = node.get_vision_client(vision_node)
             future = client.call_async(request)
             if future is None:
                 return None
@@ -173,7 +182,7 @@ class Mode(Generic[VehicleT], ABC):
         """
         Return persistent ModeManager-owned state for this mode class.
         """
-        return self.node.shared_state_for(self)
+        return cast(_ModeManagerNode, self.node).shared_state_for(self)
 
     def log(self, message: str) -> None:
         """

--- a/controls/sae_2025_ws/src/uav/uav/modes/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/__init__.py
@@ -1,10 +1,14 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = ["Mode"]
 
 _EXPORTS = {
     "Mode": ".Mode",
 }
+
+if TYPE_CHECKING:
+    from .Mode import Mode
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/__init__.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = [
     "PayloadAprilTagApproachMode",
@@ -6,6 +7,12 @@ __all__ = [
     "PayloadDualApproachMode",
     "PayloadRetreatMode",
 ]
+
+if TYPE_CHECKING:
+    from .PayloadAprilTagApproachMode import PayloadAprilTagApproachMode
+    from .PayloadColorStringApproachMode import PayloadColorStringApproachMode
+    from .PayloadDualApproachMode import PayloadDualApproachMode
+    from .PayloadRetreatMode import PayloadRetreatMode
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/__init__.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = [
     "LandingMode",
@@ -9,6 +10,15 @@ __all__ = [
     "TransitionMode",
     "WaypointMission",
 ]
+
+if TYPE_CHECKING:
+    from .LandingMode import LandingMode
+    from .NavGPSMode import NavGPSMode
+    from .PayloadDropoffMode import PayloadDropoffMode
+    from .PayloadPickupMode import PayloadPickupMode
+    from .ServoDropoffMode import ServoDropoffMode
+    from .TransitionMode import TransitionMode
+    from .WaypointMission import WaypointMission
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/__init__.py
@@ -1,6 +1,11 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = ["TakeoffMode", "TransitionMode"]
+
+if TYPE_CHECKING:
+    from .TakeoffMode import TakeoffMode
+    from .TransitionMode import TransitionMode
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/vision_nodes/VisionNode.py
+++ b/controls/sae_2025_ws/src/uav/uav/vision_nodes/VisionNode.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, ClassVar
 import uuid
 
 import cv2
@@ -19,6 +20,8 @@ class VisionNode(Node):
     Provides an interface for handling image streams, processing frames,
     and managing vision-based tasks such as tracking and calibration.
     """
+
+    srv: ClassVar[Any]
 
     @classmethod
     def node_name(cls):


### PR DESCRIPTION
Refs #183.
Refs #184.
Part of #180.

## Summary
- Add `TYPE_CHECKING` imports for lazy `uav.modes` package exports while preserving runtime lazy loading.
- Add a narrow protocol for ModeManager helpers used by base `Mode`.
- Declare the `VisionNode.srv` class contract used by `Mode.send_request`.
- Folded #192 into this PR as a separate commit.

## Verification
- Constituent focused Pyright and compile checks from #192 and #193 passed when created.
