### PR TITLE
Guard payload camera topics before subscribing

### DIFF
--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadAprilTagApproachMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadAprilTagApproachMode.py
@@ -71,18 +71,27 @@ class PayloadAprilTagApproachMode(Mode[Payload]):
         self._detector_cache = AprilTagDetectorCache()
         self._detector = self._detector_cache.get(self.tag_family)
 
+        image_topic = vehicle.image_topic
+        if image_topic is None:
+            raise RuntimeError(f"Vehicle '{vehicle.name}' does not expose an image topic.")
+        camera_info_topic = vehicle.camera_info_topic
+        if camera_info_topic is None:
+            raise RuntimeError(
+                f"Vehicle '{vehicle.name}' does not expose a camera info topic."
+            )
+
         if bool(compressed):
             self.node.create_subscription(
                 CompressedImage,
-                f"{vehicle.image_topic}/compressed",
+                f"{image_topic}/compressed",
                 self._on_compressed_image,
                 1,
             )
         else:
-            self.node.create_subscription(Image, vehicle.image_topic, self._on_image, 1)
+            self.node.create_subscription(Image, image_topic, self._on_image, 1)
 
         self.node.create_subscription(
-            CameraInfo, vehicle.camera_info_topic, self._on_camera_info, 1
+            CameraInfo, camera_info_topic, self._on_camera_info, 1
         )
 
         self._done = False

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadColorStringApproachMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadColorStringApproachMode.py
@@ -130,15 +130,19 @@ class PayloadColorStringApproachMode(Mode[Payload]):
         self._bridge = CvBridge()
         self._latest_image: Optional[Image | CompressedImage] = None
 
+        image_topic = vehicle.image_topic
+        if image_topic is None:
+            raise RuntimeError(f"Vehicle '{vehicle.name}' does not expose an image topic.")
+
         if bool(compressed):
             self.node.create_subscription(
                 CompressedImage,
-                f"{vehicle.image_topic}/compressed",
+                f"{image_topic}/compressed",
                 self._on_image,
                 1,
             )
         else:
-            self.node.create_subscription(Image, vehicle.image_topic, self._on_image, 1)
+            self.node.create_subscription(Image, image_topic, self._on_image, 1)
 
         self._debug_pub = None
         if getattr(self.node, "vision_debug", False):

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDualApproachMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDualApproachMode.py
@@ -140,8 +140,13 @@ class PayloadDualApproachMode(Mode[Payload]):
         else:
             self.node.create_subscription(Image, cam_topic, self._on_image, 1)
 
+        camera_info_topic = vehicle.camera_info_topic
+        if camera_info_topic is None:
+            raise RuntimeError(
+                f"Vehicle '{vehicle.name}' does not expose a camera info topic."
+            )
         self.node.create_subscription(
-            CameraInfo, vehicle.camera_info_topic, self._on_camera_info, 1
+            CameraInfo, camera_info_topic, self._on_camera_info, 1
         )
 
         self._debug_pub = None

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py
@@ -118,15 +118,19 @@ class PayloadWaitForDriveOutMode(Mode[Payload]):
                 1,
             )
 
+        image_topic = vehicle.image_topic
+        if image_topic is None:
+            raise RuntimeError(f"Vehicle '{vehicle.name}' does not expose an image topic.")
+
         if self._compressed:
             self.node.create_subscription(
                 CompressedImage,
-                f"{vehicle.image_topic}/compressed",
+                f"{image_topic}/compressed",
                 self._on_compressed_image,
                 1,
             )
         else:
-            self.node.create_subscription(Image, vehicle.image_topic, self._on_image, 1)
+            self.node.create_subscription(Image, image_topic, self._on_image, 1)
 
         self._done = False
         self._clear_since: Optional[float] = None


### PR DESCRIPTION
## Summary
- Add explicit runtime guards for payload image and camera-info topics before creating subscriptions.
- Reuse narrowed local topic variables so Pylance sees non-optional strings.
- Keep existing camera contract behavior, now with clearer errors if a camera mode receives a vehicle without topics.

## Verification
- `npx --yes pyright --project /tmp/pyright-modes --outputjson` removes exactly the five `str | None` camera-topic diagnostics and adds no new diagnostics.
- `PYTHONPATH=controls/sae_2025_ws/src/uav python3 -m compileall controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadAprilTagApproachMode.py controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadColorStringApproachMode.py controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDualApproachMode.py controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py`

Refs #185
Part of #180