### PR TITLE
Type ROS mode callbacks

### DIFF
--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
@@ -157,7 +157,7 @@ class PayloadCornerNavigateMode(Mode[Payload]):
 
         self._bridge = CvBridge()
         self._image_sub = None
-        self._image: Optional[object] = None
+        self._image: Optional[CompressedImage | Image] = None
         self._annotated_pub = None
 
     # ------------------------------------------------------------------
@@ -265,17 +265,18 @@ class PayloadCornerNavigateMode(Mode[Payload]):
     # ROS callbacks
     # ------------------------------------------------------------------
 
-    def _image_cb(self, msg) -> None:
+    def _image_cb(self, msg: CompressedImage | Image) -> None:
         self._image = msg
 
     def _decode_image(self) -> Optional[np.ndarray]:
-        if self._image is None:
+        image = self._image
+        if image is None:
             return None
         try:
-            if self.compressed_image:
-                buf = np.frombuffer(self._image.data, dtype=np.uint8)
+            if isinstance(image, CompressedImage):
+                buf = np.frombuffer(image.data, dtype=np.uint8)
                 return cv2.imdecode(buf, cv2.IMREAD_COLOR)
-            return self._bridge.imgmsg_to_cv2(self._image, desired_encoding="bgr8")
+            return self._bridge.imgmsg_to_cv2(image, desired_encoding="bgr8")
         except Exception as exc:
             self.node.get_logger().warn(
                 f"PayloadCornerNavigateMode: image decode failed: {exc}"

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
@@ -241,7 +241,7 @@ class PayloadDLZNavigateMode(Mode[Payload]):
 
         self._bridge = CvBridge()
         self._image_sub = None
-        self._image: Optional[object] = None
+        self._image: Optional[CompressedImage | Image] = None
         self._annotated_pub = None
 
     # ------------------------------------------------------------------
@@ -275,17 +275,18 @@ class PayloadDLZNavigateMode(Mode[Payload]):
     # Camera helpers
     # ------------------------------------------------------------------
 
-    def _image_cb(self, msg) -> None:
+    def _image_cb(self, msg: CompressedImage | Image) -> None:
         self._image = msg
 
     def _decode_image(self) -> Optional[np.ndarray]:
-        if self._image is None:
+        image = self._image
+        if image is None:
             return None
         try:
-            if self.compressed_image:
-                buf = np.frombuffer(self._image.data, dtype=np.uint8)
+            if isinstance(image, CompressedImage):
+                buf = np.frombuffer(image.data, dtype=np.uint8)
                 return cv2.imdecode(buf, cv2.IMREAD_COLOR)
-            return self._bridge.imgmsg_to_cv2(self._image, desired_encoding="bgr8")
+            return self._bridge.imgmsg_to_cv2(image, desired_encoding="bgr8")
         except Exception as exc:
             self.node.get_logger().warn(
                 f"PayloadDLZNavigateMode: image decode failed: {exc}"

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadPeerFleetTestMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadPeerFleetTestMode.py
@@ -15,7 +15,7 @@ operator verifies peer discovery, disconnect handling, and reconnect behavior.
 from __future__ import annotations
 
 import json
-from typing import Mapping
+from typing import Callable, Mapping
 
 from rclpy.node import Node
 from std_msgs.msg import String
@@ -69,9 +69,7 @@ class PayloadPeerFleetTestMode(Mode[Payload]):
             peer_name: self.node.create_subscription(
                 String,
                 vehicle.namespaced_path(local_topic, namespace=f"/{peer_name}"),
-                lambda message, peer_name=peer_name: self._on_peer_message(
-                    peer_name, message
-                ),
+                self._peer_message_callback(peer_name),
                 10,
             )
             for peer_name in self._peer_names
@@ -106,6 +104,12 @@ class PayloadPeerFleetTestMode(Mode[Payload]):
         self._peer_message_counts[peer_name] = (
             self._peer_message_counts.get(peer_name, 0) + 1
         )
+
+    def _peer_message_callback(self, peer_name: str) -> Callable[[String], None]:
+        def callback(message: String) -> None:
+            self._on_peer_message(peer_name, message)
+
+        return callback
 
     def _on_shared_message(self, message: String) -> None:
         self._shared_message_count += 1

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadRetreatMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadRetreatMode.py
@@ -11,7 +11,7 @@ Designed for a white DLZ on a green/grass background. No AprilTag library requir
 """
 
 import math
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import cv2
 import numpy as np
@@ -81,7 +81,7 @@ class PayloadRetreatMode(Mode[Payload]):
         self._image_sub = None
         self._info_sub = None
         self._drive_pub = None
-        self._image: Optional[object] = None
+        self._image: Optional[Union[CompressedImage, Image]] = None
 
         self._phase: str = "drive_to_edge"
         self._edge_stable_count: int = 0
@@ -126,15 +126,16 @@ class PayloadRetreatMode(Mode[Payload]):
         self.node.destroy_publisher(self._drive_pub)
 
     def on_update(self, time_delta: float) -> None:
-        if self._done or self._image is None:
+        image = self._image
+        if self._done or image is None:
             return
 
         try:
-            if self.compressed_image:
-                buf = np.frombuffer(self._image.data, dtype=np.uint8)
+            if isinstance(image, CompressedImage):
+                buf = np.frombuffer(image.data, dtype=np.uint8)
                 bgr = cv2.imdecode(buf, cv2.IMREAD_COLOR)
             else:
-                bgr = self._bridge.imgmsg_to_cv2(self._image, desired_encoding="bgr8")
+                bgr = self._bridge.imgmsg_to_cv2(image, desired_encoding="bgr8")
         except Exception as exc:
             self.node.get_logger().warn(
                 f"PayloadRetreatMode: image decode failed: {exc}"
@@ -205,7 +206,7 @@ class PayloadRetreatMode(Mode[Payload]):
     # ROS callbacks
     # ------------------------------------------------------------------
 
-    def _image_cb(self, msg) -> None:
+    def _image_cb(self, msg: Union[CompressedImage, Image]) -> None:
         self._image = msg
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Type image callbacks and cached image fields as `Image | CompressedImage` where modes handle both message shapes.
- Narrow image decoding by the concrete ROS message type before accessing compressed payload bytes.
- Replace the peer-test subscription lambda with a typed callback factory so `String` message typing is preserved.

## Verification
- `npx --yes pyright --project /tmp/pyright-modes --outputjson` drops from 82 to 78 errors on this branch; the four removed diagnostics are the ROS callback/message diagnostics for this bucket.
- `PYTHONPATH=controls/sae_2025_ws/src/uav python3 -m compileall controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadPeerFleetTestMode.py controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadRetreatMode.py`
- `git diff --check`

Refs #187
Part of #180