### PR TITLE
Type mode contracts and payload CV callbacks

### DIFF
--- a/controls/sae_2025_ws/src/uav/uav/modes/Mode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/Mode.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, ClassVar, Generic, Mapping, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Mapping, Protocol, TypeVar, cast
 
 from rclpy.node import Node
 
@@ -10,6 +10,14 @@ if TYPE_CHECKING:
     from uav.vision_nodes import VisionNode
 
 VehicleT = TypeVar("VehicleT", bound=Vehicle)
+
+
+class _ModeManagerNode(Protocol):
+    def get_vision_client(self, vision_node: type["VisionNode"]) -> Any:
+        ...
+
+    def shared_state_for(self, mode_or_class: object) -> dict[str, Any]:
+        ...
 
 
 class Mode(Generic[VehicleT], ABC):
@@ -53,7 +61,7 @@ class Mode(Generic[VehicleT], ABC):
         """
         pass
 
-    def send_request(self, vision_node: type["VisionNode"], request):
+    def send_request(self, vision_node: type["VisionNode"], request: Any):
         """
         Send a request to a service.
 
@@ -64,7 +72,8 @@ class Mode(Generic[VehicleT], ABC):
         service_name = self.vehicle.vision_service_name(vision_node)
         future = self.pending_requests.get(service_name)
         if future is None:
-            client = self.node.get_vision_client(vision_node)
+            node = cast(_ModeManagerNode, self.node)
+            client = node.get_vision_client(vision_node)
             future = client.call_async(request)
             if future is None:
                 return None
@@ -173,7 +182,7 @@ class Mode(Generic[VehicleT], ABC):
         """
         Return persistent ModeManager-owned state for this mode class.
         """
-        return self.node.shared_state_for(self)
+        return cast(_ModeManagerNode, self.node).shared_state_for(self)
 
     def log(self, message: str) -> None:
         """

--- a/controls/sae_2025_ws/src/uav/uav/modes/Mode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/Mode.py
@@ -1,5 +1,14 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, Mapping, Protocol, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Generic,
+    Mapping,
+    Protocol,
+    TypeVar,
+    cast,
+)
 
 from rclpy.node import Node
 
@@ -13,11 +22,9 @@ VehicleT = TypeVar("VehicleT", bound=Vehicle)
 
 
 class _ModeManagerNode(Protocol):
-    def get_vision_client(self, vision_node: type["VisionNode"]) -> Any:
-        ...
+    def get_vision_client(self, vision_node: type["VisionNode"]) -> Any: ...
 
-    def shared_state_for(self, mode_or_class: object) -> dict[str, Any]:
-        ...
+    def shared_state_for(self, mode_or_class: object) -> dict[str, Any]: ...
 
 
 class Mode(Generic[VehicleT], ABC):
@@ -85,9 +92,11 @@ class Mode(Generic[VehicleT], ABC):
 
         response = future.result()
         self.pending_requests.pop(service_name, None)
-        assert type(response) is vision_node.srv.Response, (
-            f"Expected response type {vision_node.srv.Response}, got {type(response)}."
-        )
+        response_type = vision_node.srv.Response
+        if not isinstance(response, response_type):
+            raise TypeError(
+                f"Expected response type {response_type}, got {type(response)}."
+            )
         return response
 
     def on_exit(self) -> None:

--- a/controls/sae_2025_ws/src/uav/uav/modes/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/__init__.py
@@ -1,10 +1,14 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = ["Mode"]
 
 _EXPORTS = {
     "Mode": ".Mode",
 }
+
+if TYPE_CHECKING:
+    from .Mode import Mode
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadAprilTagApproachMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadAprilTagApproachMode.py
@@ -7,6 +7,7 @@ from rclpy.node import Node
 from sensor_msgs.msg import CameraInfo, CompressedImage, Image
 from cv_bridge import CvBridge
 import cv2
+import numpy as np
 
 from uav.vehicles.Payload import Payload
 from uav.vision_nodes.payload_perception_common import (
@@ -104,7 +105,7 @@ class PayloadAprilTagApproachMode(Mode[Payload]):
         if self._latest_camera_info is None:
             self._latest_camera_info = msg
 
-    def _get_bgr_frame(self) -> Optional[object]:
+    def _get_bgr_frame(self) -> Optional[np.ndarray]:
         msg = self._latest_image
         if msg is None:
             return None

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadAprilTagApproachMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadAprilTagApproachMode.py
@@ -72,18 +72,27 @@ class PayloadAprilTagApproachMode(Mode[Payload]):
         self._detector_cache = AprilTagDetectorCache()
         self._detector = self._detector_cache.get(self.tag_family)
 
+        image_topic = vehicle.image_topic
+        if image_topic is None:
+            raise RuntimeError(f"Vehicle '{vehicle.name}' does not expose an image topic.")
+        camera_info_topic = vehicle.camera_info_topic
+        if camera_info_topic is None:
+            raise RuntimeError(
+                f"Vehicle '{vehicle.name}' does not expose a camera info topic."
+            )
+
         if bool(compressed):
             self.node.create_subscription(
                 CompressedImage,
-                f"{vehicle.image_topic}/compressed",
+                f"{image_topic}/compressed",
                 self._on_compressed_image,
                 1,
             )
         else:
-            self.node.create_subscription(Image, vehicle.image_topic, self._on_image, 1)
+            self.node.create_subscription(Image, image_topic, self._on_image, 1)
 
         self.node.create_subscription(
-            CameraInfo, vehicle.camera_info_topic, self._on_camera_info, 1
+            CameraInfo, camera_info_topic, self._on_camera_info, 1
         )
 
         self._done = False

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadColorStringApproachMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadColorStringApproachMode.py
@@ -130,15 +130,19 @@ class PayloadColorStringApproachMode(Mode[Payload]):
         self._bridge = CvBridge()
         self._latest_image: Optional[Image | CompressedImage] = None
 
+        image_topic = vehicle.image_topic
+        if image_topic is None:
+            raise RuntimeError(f"Vehicle '{vehicle.name}' does not expose an image topic.")
+
         if bool(compressed):
             self.node.create_subscription(
                 CompressedImage,
-                f"{vehicle.image_topic}/compressed",
+                f"{image_topic}/compressed",
                 self._on_image,
                 1,
             )
         else:
-            self.node.create_subscription(Image, vehicle.image_topic, self._on_image, 1)
+            self.node.create_subscription(Image, image_topic, self._on_image, 1)
 
         self._debug_pub = None
         if getattr(self.node, "vision_debug", False):

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
@@ -48,9 +48,11 @@ LINE_FOLLOW
 from __future__ import annotations
 
 import math
-from typing import Any, Optional, Tuple, cast
+from collections.abc import Sequence
+from typing import Optional, Tuple, cast
 
 import cv2
+from cv2.typing import MatLike
 import numpy as np
 from cv_bridge import CvBridge
 from rclpy.node import Node
@@ -65,6 +67,15 @@ from ..Mode import Mode
 # least this many times more pixels than the other in the line-follow strip,
 # we treat it as the new dominant colour and trigger a transition.
 _COLOR_DOMINANCE_RATIO = 1.5
+
+
+def _draw_cv_contours(
+    image: np.ndarray,
+    contours: Sequence[MatLike],
+    color: Tuple[int, int, int],
+    thickness: int,
+) -> None:
+    cv2.drawContours(image, contours, -1, color, thickness)
 
 
 class PayloadCornerNavigateMode(Mode[Payload]):
@@ -911,8 +922,11 @@ class PayloadCornerNavigateMode(Mode[Payload]):
         if not contours:
             return
         shift = np.array([[[x_offset, y_offset]]], dtype=np.int32)
-        shifted = [np.asarray(contour, dtype=np.int32) + shift for contour in contours]
-        cv2.drawContours(debug, cast(Any, shifted), -1, color, thickness)
+        shifted: list[MatLike] = [
+            cast(MatLike, np.asarray(contour, dtype=np.int32) + shift)
+            for contour in contours
+        ]
+        _draw_cv_contours(debug, shifted, color, thickness)
 
     def _put_label(
         self,

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
@@ -157,7 +157,7 @@ class PayloadCornerNavigateMode(Mode[Payload]):
 
         self._bridge = CvBridge()
         self._image_sub = None
-        self._image: Optional[object] = None
+        self._image: Optional[CompressedImage | Image] = None
         self._annotated_pub = None
 
     # ------------------------------------------------------------------
@@ -265,17 +265,18 @@ class PayloadCornerNavigateMode(Mode[Payload]):
     # ROS callbacks
     # ------------------------------------------------------------------
 
-    def _image_cb(self, msg) -> None:
+    def _image_cb(self, msg: CompressedImage | Image) -> None:
         self._image = msg
 
     def _decode_image(self) -> Optional[np.ndarray]:
-        if self._image is None:
+        image = self._image
+        if image is None:
             return None
         try:
-            if self.compressed_image:
-                buf = np.frombuffer(self._image.data, dtype=np.uint8)
+            if isinstance(image, CompressedImage):
+                buf = np.frombuffer(image.data, dtype=np.uint8)
                 return cv2.imdecode(buf, cv2.IMREAD_COLOR)
-            return self._bridge.imgmsg_to_cv2(self._image, desired_encoding="bgr8")
+            return self._bridge.imgmsg_to_cv2(image, desired_encoding="bgr8")
         except Exception as exc:
             self.node.get_logger().warn(
                 f"PayloadCornerNavigateMode: image decode failed: {exc}"

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
@@ -48,7 +48,6 @@ LINE_FOLLOW
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
 from typing import Optional, Tuple, cast
 
 import cv2
@@ -67,15 +66,6 @@ from ..Mode import Mode
 # least this many times more pixels than the other in the line-follow strip,
 # we treat it as the new dominant colour and trigger a transition.
 _COLOR_DOMINANCE_RATIO = 1.5
-
-
-def _draw_cv_contours(
-    image: np.ndarray,
-    contours: Sequence[MatLike],
-    color: Tuple[int, int, int],
-    thickness: int,
-) -> None:
-    cv2.drawContours(image, contours, -1, color, thickness)
 
 
 class PayloadCornerNavigateMode(Mode[Payload]):
@@ -926,7 +916,7 @@ class PayloadCornerNavigateMode(Mode[Payload]):
             cast(MatLike, np.asarray(contour, dtype=np.int32) + shift)
             for contour in contours
         ]
-        _draw_cv_contours(debug, shifted, color, thickness)
+        cv2.drawContours(debug, shifted, -1, color, thickness)
 
     def _put_label(
         self,

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
@@ -48,7 +48,7 @@ LINE_FOLLOW
 from __future__ import annotations
 
 import math
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple, cast
 
 import cv2
 import numpy as np
@@ -909,9 +909,9 @@ class PayloadCornerNavigateMode(Mode[Payload]):
         contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
         if not contours:
             return
-        shift = np.array([[[x_offset, y_offset]]])
-        shifted = [c + shift for c in contours]
-        cv2.drawContours(debug, shifted, -1, color, thickness)
+        shift = np.array([[[x_offset, y_offset]]], dtype=np.int32)
+        shifted = [np.asarray(contour, dtype=np.int32) + shift for contour in contours]
+        cv2.drawContours(debug, cast(Any, shifted), -1, color, thickness)
 
     def _put_label(
         self,

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
@@ -125,12 +125,12 @@ def _detect_tape_following(
 
 
 def _shift_contours(
-    contours: Sequence[object],
+    contours: Sequence[np.ndarray],
     x_offset: int,
     y_offset: int,
 ) -> list[np.ndarray]:
     shift = np.array([[[x_offset, y_offset]]], dtype=np.int32)
-    return [np.asarray(contour, dtype=np.int32) + shift for contour in contours]
+    return [contour + shift for contour in contours]
 
 
 class TagTransitionRule(TypedDict):

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Literal, Optional, Tuple
+from typing import Literal, Optional, Sequence, Tuple
 
 from typing_extensions import TypedDict
 
@@ -122,6 +122,15 @@ def _detect_tape_following(
         boundary_angle = 0.0
 
     return True, lateral_error_px, boundary_angle
+
+
+def _shift_contours(
+    contours: Sequence[object],
+    x_offset: int,
+    y_offset: int,
+) -> list[np.ndarray]:
+    shift = np.array([[[x_offset, y_offset]]], dtype=np.int32)
+    return [np.asarray(contour, dtype=np.int32) + shift for contour in contours]
 
 
 class TagTransitionRule(TypedDict):
@@ -306,8 +315,9 @@ class PayloadDLZNavigateMode(Mode[Payload]):
         color: str,
     ) -> np.ndarray:
         if color == "A":
-            mask = cv2.inRange(hsv, self._lower_a, self._upper_a) | cv2.inRange(
-                hsv, self._lower_a2, self._upper_a2
+            mask = cv2.bitwise_or(
+                cv2.inRange(hsv, self._lower_a, self._upper_a),
+                cv2.inRange(hsv, self._lower_a2, self._upper_a2),
             )
         else:
             mask = cv2.inRange(hsv, self._lower_b, self._upper_b)
@@ -679,9 +689,14 @@ class PayloadDLZNavigateMode(Mode[Payload]):
 
         # Contours of the single expected-colour mask — exactly what the
         # detector thresholded on for the centroid.
-        shift = np.array([[[col_start, row_start]]])
         contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-        cv2.drawContours(debug, [c + shift for c in contours], -1, (255, 255, 255), 2)
+        cv2.drawContours(
+            debug,
+            _shift_contours(contours, col_start, row_start),
+            -1,
+            (255, 255, 255),
+            2,
+        )
 
         # Crop boundary (top row, left+right columns) — middle-third bottom-40%.
         col_end = w - col_start
@@ -999,7 +1014,7 @@ class PayloadDLZNavigateMode(Mode[Payload]):
 
         # Draw contours of the target colour mask (offset by the crop origin).
         contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-        shifted = [c + np.array([[[col_start, row_start]]]) for c in contours]
+        shifted = _shift_contours(contours, col_start, row_start)
         cv2.drawContours(debug, shifted, -1, (255, 255, 255), 2)
 
         # Crop boundary — bottom third of the frame, full width.
@@ -1110,13 +1125,13 @@ class PayloadDLZNavigateMode(Mode[Payload]):
         orange_contours, _ = cv2.findContours(
             orange_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
         )
-        shifted_orange = [c + np.array([[[0, strip_start]]]) for c in orange_contours]
+        shifted_orange = _shift_contours(orange_contours, 0, strip_start)
         cv2.drawContours(debug, shifted_orange, -1, (255, 255, 255), 2)
 
         blue_contours, _ = cv2.findContours(
             blue_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
         )
-        shifted_blue = [c + np.array([[[0, strip_start]]]) for c in blue_contours]
+        shifted_blue = _shift_contours(blue_contours, 0, strip_start)
         cv2.drawContours(debug, shifted_blue, -1, (255, 255, 255), 2)
 
         # Strip boundary line

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
@@ -250,7 +250,7 @@ class PayloadDLZNavigateMode(Mode[Payload]):
 
         self._bridge = CvBridge()
         self._image_sub = None
-        self._image: Optional[object] = None
+        self._image: Optional[CompressedImage | Image] = None
         self._annotated_pub = None
 
     # ------------------------------------------------------------------
@@ -284,17 +284,18 @@ class PayloadDLZNavigateMode(Mode[Payload]):
     # Camera helpers
     # ------------------------------------------------------------------
 
-    def _image_cb(self, msg) -> None:
+    def _image_cb(self, msg: CompressedImage | Image) -> None:
         self._image = msg
 
     def _decode_image(self) -> Optional[np.ndarray]:
-        if self._image is None:
+        image = self._image
+        if image is None:
             return None
         try:
-            if self.compressed_image:
-                buf = np.frombuffer(self._image.data, dtype=np.uint8)
+            if isinstance(image, CompressedImage):
+                buf = np.frombuffer(image.data, dtype=np.uint8)
                 return cv2.imdecode(buf, cv2.IMREAD_COLOR)
-            return self._bridge.imgmsg_to_cv2(self._image, desired_encoding="bgr8")
+            return self._bridge.imgmsg_to_cv2(image, desired_encoding="bgr8")
         except Exception as exc:
             self.node.get_logger().warn(
                 f"PayloadDLZNavigateMode: image decode failed: {exc}"

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDualApproachMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDualApproachMode.py
@@ -140,8 +140,13 @@ class PayloadDualApproachMode(Mode[Payload]):
         else:
             self.node.create_subscription(Image, cam_topic, self._on_image, 1)
 
+        camera_info_topic = vehicle.camera_info_topic
+        if camera_info_topic is None:
+            raise RuntimeError(
+                f"Vehicle '{vehicle.name}' does not expose a camera info topic."
+            )
         self.node.create_subscription(
-            CameraInfo, vehicle.camera_info_topic, self._on_camera_info, 1
+            CameraInfo, camera_info_topic, self._on_camera_info, 1
         )
 
         self._debug_pub = None

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadPeerFleetTestMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadPeerFleetTestMode.py
@@ -15,7 +15,7 @@ operator verifies peer discovery, disconnect handling, and reconnect behavior.
 from __future__ import annotations
 
 import json
-from typing import Mapping
+from typing import Callable, Mapping
 
 from rclpy.node import Node
 from std_msgs.msg import String
@@ -69,9 +69,7 @@ class PayloadPeerFleetTestMode(Mode[Payload]):
             peer_name: self.node.create_subscription(
                 String,
                 vehicle.namespaced_path(local_topic, namespace=f"/{peer_name}"),
-                lambda message, peer_name=peer_name: self._on_peer_message(
-                    peer_name, message
-                ),
+                self._peer_message_callback(peer_name),
                 10,
             )
             for peer_name in self._peer_names
@@ -106,6 +104,12 @@ class PayloadPeerFleetTestMode(Mode[Payload]):
         self._peer_message_counts[peer_name] = (
             self._peer_message_counts.get(peer_name, 0) + 1
         )
+
+    def _peer_message_callback(self, peer_name: str) -> Callable[[String], None]:
+        def callback(message: String) -> None:
+            self._on_peer_message(peer_name, message)
+
+        return callback
 
     def _on_shared_message(self, message: String) -> None:
         self._shared_message_count += 1

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadRetreatMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadRetreatMode.py
@@ -11,7 +11,7 @@ Designed for a white DLZ on a green/grass background. No AprilTag library requir
 """
 
 import math
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import cv2
 import numpy as np
@@ -81,7 +81,7 @@ class PayloadRetreatMode(Mode[Payload]):
         self._image_sub = None
         self._info_sub = None
         self._drive_pub = None
-        self._image: Optional[object] = None
+        self._image: Optional[Union[CompressedImage, Image]] = None
 
         self._phase: str = "drive_to_edge"
         self._edge_stable_count: int = 0
@@ -126,15 +126,16 @@ class PayloadRetreatMode(Mode[Payload]):
         self.node.destroy_publisher(self._drive_pub)
 
     def on_update(self, time_delta: float) -> None:
-        if self._done or self._image is None:
+        image = self._image
+        if self._done or image is None:
             return
 
         try:
-            if self.compressed_image:
-                buf = np.frombuffer(self._image.data, dtype=np.uint8)
+            if isinstance(image, CompressedImage):
+                buf = np.frombuffer(image.data, dtype=np.uint8)
                 bgr = cv2.imdecode(buf, cv2.IMREAD_COLOR)
             else:
-                bgr = self._bridge.imgmsg_to_cv2(self._image, desired_encoding="bgr8")
+                bgr = self._bridge.imgmsg_to_cv2(image, desired_encoding="bgr8")
         except Exception as exc:
             self.node.get_logger().warn(
                 f"PayloadRetreatMode: image decode failed: {exc}"
@@ -205,7 +206,7 @@ class PayloadRetreatMode(Mode[Payload]):
     # ROS callbacks
     # ------------------------------------------------------------------
 
-    def _image_cb(self, msg) -> None:
+    def _image_cb(self, msg: Union[CompressedImage, Image]) -> None:
         self._image = msg
 
     # ------------------------------------------------------------------

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py
@@ -178,8 +178,13 @@ class PayloadWaitForDriveOutMode(Mode[Payload]):
             self._prev_gray = gray
             return True
 
-        next_pts, status, _ = cv2.calcOpticalFlowPyrLK(self._prev_gray, gray, pts, None)
+        next_pts, status, _ = cv2.calcOpticalFlowPyrLK(
+            self._prev_gray, gray, pts, pts.copy()
+        )
         self._prev_gray = gray
+
+        if next_pts is None or status is None:
+            return True
 
         good = status.ravel() == 1
         if good.sum() == 0:

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py
@@ -118,15 +118,19 @@ class PayloadWaitForDriveOutMode(Mode[Payload]):
                 1,
             )
 
+        image_topic = vehicle.image_topic
+        if image_topic is None:
+            raise RuntimeError(f"Vehicle '{vehicle.name}' does not expose an image topic.")
+
         if self._compressed:
             self.node.create_subscription(
                 CompressedImage,
-                f"{vehicle.image_topic}/compressed",
+                f"{image_topic}/compressed",
                 self._on_compressed_image,
                 1,
             )
         else:
-            self.node.create_subscription(Image, vehicle.image_topic, self._on_image, 1)
+            self.node.create_subscription(Image, image_topic, self._on_image, 1)
 
         self._done = False
         self._clear_since: Optional[float] = None

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/__init__.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = [
     "PayloadAprilTagApproachMode",
@@ -6,6 +7,12 @@ __all__ = [
     "PayloadDualApproachMode",
     "PayloadRetreatMode",
 ]
+
+if TYPE_CHECKING:
+    from .PayloadAprilTagApproachMode import PayloadAprilTagApproachMode
+    from .PayloadColorStringApproachMode import PayloadColorStringApproachMode
+    from .PayloadDualApproachMode import PayloadDualApproachMode
+    from .PayloadRetreatMode import PayloadRetreatMode
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/__init__.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = [
     "LandingMode",
@@ -9,6 +10,15 @@ __all__ = [
     "TransitionMode",
     "WaypointMission",
 ]
+
+if TYPE_CHECKING:
+    from .LandingMode import LandingMode
+    from .NavGPSMode import NavGPSMode
+    from .PayloadDropoffMode import PayloadDropoffMode
+    from .PayloadPickupMode import PayloadPickupMode
+    from .ServoDropoffMode import ServoDropoffMode
+    from .TransitionMode import TransitionMode
+    from .WaypointMission import WaypointMission
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/__init__.py
@@ -1,6 +1,11 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = ["TakeoffMode", "TransitionMode"]
+
+if TYPE_CHECKING:
+    from .TakeoffMode import TakeoffMode
+    from .TransitionMode import TransitionMode
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/vision_nodes/VisionNode.py
+++ b/controls/sae_2025_ws/src/uav/uav/vision_nodes/VisionNode.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, ClassVar
 import uuid
 
 import cv2
@@ -19,6 +20,8 @@ class VisionNode(Node):
     Provides an interface for handling image streams, processing frames,
     and managing vision-based tasks such as tracking and calibration.
     """
+
+    srv: ClassVar[Any]
 
     @classmethod
     def node_name(cls):


### PR DESCRIPTION
Refs #183.
Refs #184.
Refs #185.
Refs #187.
Refs #188.
Part of #180.

## Summary
- Add type-checker-visible lazy mode package exports while preserving runtime lazy loading.
- Add a narrow protocol for ModeManager helpers and the `VisionNode.srv` contract used by `Mode.send_request`.
- Guard payload image/camera-info topics before creating subscriptions.
- Type image callbacks and cached image fields for raw and compressed ROS image messages.
- Normalize AprilTag/OpenCV frame, contour, mask, and optical-flow handling for Pyright.
- Folded #192, #193, #194, and #196 into this PR as separate commits.

## Verification
- Constituent focused Pyright, compile, and diff checks from the folded mode PRs passed when created.
