### PR TITLE
Guard mode state and residual typing

### DIFF
--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
@@ -48,7 +48,7 @@ LINE_FOLLOW
 from __future__ import annotations
 
 import math
-from typing import Optional, Tuple
+from typing import Optional, Tuple, cast
 
 import cv2
 import numpy as np
@@ -60,6 +60,7 @@ from uav.cv.dlz_convex_hull import build_dlz_hull_mask
 from uav.vehicles.Payload import Payload
 
 from ..Mode import Mode
+from .dlz_navigation_state import DLZDirection, set_dlz_navigation_direction
 
 # Mirrors PayloadColorSquareNode._COLOR_RATIO: when one tape colour has at
 # least this many times more pixels than the other in the line-follow strip,
@@ -113,7 +114,7 @@ class PayloadCornerNavigateMode(Mode[Payload]):
         direction = str(direction).lower().strip()
         if direction not in ("cw", "ccw"):
             raise ValueError(f"direction must be 'cw' or 'ccw', got {direction!r}")
-        self.direction = direction
+        self.direction: DLZDirection = cast(DLZDirection, direction)
 
         self._lower_a = np.array(ccw_lower_hsv, dtype=np.uint8)
         self._upper_a = np.array(ccw_upper_hsv, dtype=np.uint8)
@@ -257,9 +258,7 @@ class PayloadCornerNavigateMode(Mode[Payload]):
         if self._annotated_pub is not None:
             self.node.destroy_publisher(self._annotated_pub)
             self._annotated_pub = None
-        # Expose the resolved travel direction for downstream modes, matching
-        # the convention used by PayloadDLZNavigateMode.on_exit.
-        self.node.dlz_navigate_direction = self.direction
+        set_dlz_navigation_direction(self.node, self.direction)
 
     # ------------------------------------------------------------------
     # ROS callbacks

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadCornerNavigateMode.py
@@ -48,7 +48,7 @@ LINE_FOLLOW
 from __future__ import annotations
 
 import math
-from typing import Optional, Tuple, cast
+from typing import Optional, Tuple
 
 import cv2
 import numpy as np
@@ -60,7 +60,11 @@ from uav.cv.dlz_convex_hull import build_dlz_hull_mask
 from uav.vehicles.Payload import Payload
 
 from ..Mode import Mode
-from .dlz_navigation_state import DLZDirection, set_dlz_navigation_direction
+from .dlz_navigation_state import (
+    DLZDirection,
+    parse_dlz_direction,
+    set_dlz_navigation_direction,
+)
 
 # Mirrors PayloadColorSquareNode._COLOR_RATIO: when one tape colour has at
 # least this many times more pixels than the other in the line-follow strip,
@@ -111,10 +115,10 @@ class PayloadCornerNavigateMode(Mode[Payload]):
         tape_align_stable_frames: int = 3,
     ):
         super().__init__(node, vehicle)
-        direction = str(direction).lower().strip()
-        if direction not in ("cw", "ccw"):
+        direction_value = parse_dlz_direction(direction)
+        if direction_value is None:
             raise ValueError(f"direction must be 'cw' or 'ccw', got {direction!r}")
-        self.direction: DLZDirection = cast(DLZDirection, direction)
+        self.direction: DLZDirection = direction_value
 
         self._lower_a = np.array(ccw_lower_hsv, dtype=np.uint8)
         self._upper_a = np.array(ccw_upper_hsv, dtype=np.uint8)

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Literal, Optional, Tuple, cast
+from typing import Literal, Optional, Tuple
 
 from typing_extensions import TypedDict
 
@@ -21,6 +21,8 @@ from ..Mode import Mode
 from .dlz_navigation_state import (
     DLZDirection,
     DLZStartPhase,
+    parse_dlz_direction,
+    parse_dlz_start_phase,
     set_dlz_navigation_direction,
 )
 
@@ -38,8 +40,6 @@ _TURN_CENTER_TOL_PX = 50.0  # lateral error tolerance (px)
 _TURN_CENTER_MIN_PX = 150  # minimum tape pixels to trust centering
 _TURN_STABLE_FRAMES = 2  # consecutive centred frames before locking
 _TURN_MAX_RAD = 2.0 * math.pi  # safety timeout (radians)
-
-_VALID_START_PHASES = ("wait_for_plane", "scan_tags", "line_follow")
 
 # ---------------------------------------------------------------------------
 # Inline colour detection. HSV bounds are now constructor parameters (see
@@ -205,19 +205,19 @@ class PayloadDLZNavigateMode(Mode[Payload]):
         cw_upper_hsv2: list[int] = (255, 255, 255),
     ):
         super().__init__(node, vehicle)
-        direction_value = str(direction).lower().strip()
-        if direction_value not in ("cw", "ccw"):
+        direction_value = parse_dlz_direction(direction)
+        if direction_value is None:
+            raise ValueError(f"direction must be 'cw' or 'ccw', got {direction!r}")
+        start_phase_value = parse_dlz_start_phase(start_phase)
+        if start_phase_value is None:
             raise ValueError(
-                f"direction must be 'cw' or 'ccw', got {direction_value!r}"
-            )
-        start_phase_value = str(start_phase).lower().strip()
-        if start_phase_value not in _VALID_START_PHASES:
-            raise ValueError(
-                f"start_phase must be one of {_VALID_START_PHASES}, got {start_phase_value!r}"
+                "start_phase must be one of "
+                "'wait_for_plane', 'scan_tags', or 'line_follow', "
+                f"got {start_phase!r}"
             )
 
         # Fallback defaults (overwritten by table lookup at runtime)
-        self._default_direction: DLZDirection = cast(DLZDirection, direction_value)
+        self._default_direction: DLZDirection = direction_value
         self._default_target_transitions = int(target_transitions)
         self.direction: DLZDirection = self._default_direction
 
@@ -232,7 +232,7 @@ class PayloadDLZNavigateMode(Mode[Payload]):
         self.tag_transition_table = dict(tag_transition_table or {})
         self.detect_frames = int(detect_frames)
         self.scan_duration_s = float(scan_duration_s)
-        self.start_phase = cast(DLZStartPhase, start_phase_value)
+        self.start_phase = start_phase_value
         self.tag_size_m = float(tag_size_m)
         self.tag_family = str(tag_family) if tag_family else DEFAULT_TAG_FAMILY
         self.compressed_image = bool(compressed_image)
@@ -517,12 +517,13 @@ class PayloadDLZNavigateMode(Mode[Payload]):
         )
         entry = self._match_table(self._seen_tag_ids)
         if entry is not None:
-            entry_direction = str(entry["direction"]).lower().strip()
-            if entry_direction not in ("cw", "ccw"):
+            entry_direction = parse_dlz_direction(entry["direction"])
+            if entry_direction is None:
                 raise ValueError(
-                    f"tag_transition_table direction must be 'cw' or 'ccw', got {entry_direction!r}"
+                    "tag_transition_table direction must be 'cw' or 'ccw', "
+                    f"got {entry['direction']!r}"
                 )
-            self.direction = cast(DLZDirection, entry_direction)
+            self.direction = entry_direction
             self.target_transitions = int(entry["transitions"])
             self.log(
                 f"PayloadDLZNavigateMode: table match → direction={self.direction}  "

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadDLZNavigateMode.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Literal, Optional, Tuple
+from typing import Literal, Optional, Tuple, cast
 
 from typing_extensions import TypedDict
 
@@ -18,6 +18,11 @@ from uav.vision_nodes.payload_perception_common import DEFAULT_TAG_FAMILY
 from uav_interfaces.srv import PayloadAprilTagState
 
 from ..Mode import Mode
+from .dlz_navigation_state import (
+    DLZDirection,
+    DLZStartPhase,
+    set_dlz_navigation_direction,
+)
 
 # Corner-turn vision thresholds (mirrors PayloadCornerNavigateMode defaults)
 _CORNER_CENTER_TOL_PX = 75.0  # lateral error tolerance (px)
@@ -173,7 +178,7 @@ class PayloadDLZNavigateMode(Mode[Payload]):
         self,
         node: Node,
         vehicle: Payload,
-        direction: Literal["cw", "ccw"] = "ccw",
+        direction: DLZDirection = "ccw",
         target_transitions: int = 1,
         turn_angular_speed: float = 0.5,
         corner_angular_speed: float = 0.3,
@@ -186,9 +191,7 @@ class PayloadDLZNavigateMode(Mode[Payload]):
         tag_transition_table: dict[str, TagTransitionRule] | None = None,
         detect_frames: int = 5,
         scan_duration_s: float = 1.0,
-        start_phase: Literal[
-            "wait_for_plane", "scan_tags", "line_follow"
-        ] = "wait_for_plane",
+        start_phase: DLZStartPhase = "wait_for_plane",
         tag_size_m: float = 0.0508,
         tag_family: str = DEFAULT_TAG_FAMILY,
         compressed_image: bool = False,
@@ -202,18 +205,21 @@ class PayloadDLZNavigateMode(Mode[Payload]):
         cw_upper_hsv2: list[int] = (255, 255, 255),
     ):
         super().__init__(node, vehicle)
-        direction = str(direction).lower().strip()
-        if direction not in ("cw", "ccw"):
-            raise ValueError(f"direction must be 'cw' or 'ccw', got {direction!r}")
-        start_phase = str(start_phase).lower().strip()
-        if start_phase not in _VALID_START_PHASES:
+        direction_value = str(direction).lower().strip()
+        if direction_value not in ("cw", "ccw"):
             raise ValueError(
-                f"start_phase must be one of {_VALID_START_PHASES}, got {start_phase!r}"
+                f"direction must be 'cw' or 'ccw', got {direction_value!r}"
+            )
+        start_phase_value = str(start_phase).lower().strip()
+        if start_phase_value not in _VALID_START_PHASES:
+            raise ValueError(
+                f"start_phase must be one of {_VALID_START_PHASES}, got {start_phase_value!r}"
             )
 
         # Fallback defaults (overwritten by table lookup at runtime)
-        self._default_direction = direction
+        self._default_direction: DLZDirection = cast(DLZDirection, direction_value)
         self._default_target_transitions = int(target_transitions)
+        self.direction: DLZDirection = self._default_direction
 
         self.turn_angular_speed = float(turn_angular_speed)
         self.corner_angular_speed = float(corner_angular_speed)
@@ -226,7 +232,7 @@ class PayloadDLZNavigateMode(Mode[Payload]):
         self.tag_transition_table = dict(tag_transition_table or {})
         self.detect_frames = int(detect_frames)
         self.scan_duration_s = float(scan_duration_s)
-        self.start_phase = start_phase
+        self.start_phase = cast(DLZStartPhase, start_phase_value)
         self.tag_size_m = float(tag_size_m)
         self.tag_family = str(tag_family) if tag_family else DEFAULT_TAG_FAMILY
         self.compressed_image = bool(compressed_image)
@@ -359,7 +365,7 @@ class PayloadDLZNavigateMode(Mode[Payload]):
                 f"PayloadDLZNavigateMode: annotated publish failed: {exc}"
             )
 
-    def _match_table(self, seen_ids: set[int]) -> Optional[dict]:
+    def _match_table(self, seen_ids: set[int]) -> Optional[TagTransitionRule]:
         """
         Match seen tag IDs against tag_transition_table.
         Key format: comma-separated AND-groups, each group pipe-separated ORs.
@@ -456,9 +462,7 @@ class PayloadDLZNavigateMode(Mode[Payload]):
         if self._annotated_pub is not None:
             self.node.destroy_publisher(self._annotated_pub)
             self._annotated_pub = None
-        # Expose the resolved travel direction so PayloadScanForTagMode can
-        # spin in the same direction as the DLZ navigation just travelled.
-        self.node.dlz_navigate_direction = self.direction
+        set_dlz_navigation_direction(self.node, self.direction)
 
     # ------------------------------------------------------------------
     # Phase: WAIT_FOR_PLANE
@@ -513,7 +517,12 @@ class PayloadDLZNavigateMode(Mode[Payload]):
         )
         entry = self._match_table(self._seen_tag_ids)
         if entry is not None:
-            self.direction = str(entry["direction"]).lower().strip()
+            entry_direction = str(entry["direction"]).lower().strip()
+            if entry_direction not in ("cw", "ccw"):
+                raise ValueError(
+                    f"tag_transition_table direction must be 'cw' or 'ccw', got {entry_direction!r}"
+                )
+            self.direction = cast(DLZDirection, entry_direction)
             self.target_transitions = int(entry["transitions"])
             self.log(
                 f"PayloadDLZNavigateMode: table match → direction={self.direction}  "

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadRetreatMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadRetreatMode.py
@@ -122,8 +122,10 @@ class PayloadRetreatMode(Mode[Payload]):
         self._publish_drive(0.0, 0.0)
         if self.camera_debug:
             cv2.destroyWindow("PayloadRetreatMode")
-        self.node.destroy_subscription(self._image_sub)
-        self.node.destroy_publisher(self._drive_pub)
+        if self._image_sub is not None:
+            self.node.destroy_subscription(self._image_sub)
+        if self._drive_pub is not None:
+            self.node.destroy_publisher(self._drive_pub)
 
     def on_update(self, time_delta: float) -> None:
         if self._done or self._image is None:

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadScanForTagMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadScanForTagMode.py
@@ -15,6 +15,7 @@ from uav.vision_nodes.payload_perception_common import DEFAULT_TAG_FAMILY
 from uav_interfaces.srv import PayloadAprilTagState
 
 from ..Mode import Mode
+from .dlz_navigation_state import get_dlz_navigation_direction
 
 _TWO_PI = 2.0 * math.pi
 
@@ -60,7 +61,7 @@ class PayloadScanForTagMode(Mode[Payload]):
         # Match spin direction to however PayloadDLZNavigateMode was travelling.
         # CCW travel → positive angular (spin left/CCW).
         # CW  travel → negative angular (spin right/CW).
-        nav_direction = getattr(self.node, "dlz_navigate_direction", None)
+        nav_direction = get_dlz_navigation_direction(self.node)
         if nav_direction == "cw":
             self._signed_spin_speed = -self.spin_angular_speed
         else:

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py
@@ -330,8 +330,9 @@ class PayloadWaitForDriveOutMode(Mode[Payload]):
                 )
             elif self._dr_future.done():
                 result = self._dr_future.result()
+                success = bool(result is not None and result.success)
                 self.log(
-                    f"obstruction retreat done success={result.success} — resuming DLZ watch"
+                    f"obstruction retreat done success={success} — resuming DLZ watch"
                 )
                 self._dr_future = None
                 # Reset optical-flow so motion from the retreat doesn't linger
@@ -347,8 +348,9 @@ class PayloadWaitForDriveOutMode(Mode[Payload]):
                 )
             elif self._dr_future.done():
                 result = self._dr_future.result()
+                success = bool(result is not None and result.success)
                 self.log(
-                    f"PayloadWaitForDriveOutMode: reverse done success={result.success} — settling"
+                    f"PayloadWaitForDriveOutMode: reverse done success={success} — settling"
                 )
                 self._dr_future = None
                 self.state = DriveOutState.TURNING
@@ -363,8 +365,9 @@ class PayloadWaitForDriveOutMode(Mode[Payload]):
                 )
             elif self._dr_future.done():
                 result = self._dr_future.result()
+                success = bool(result is not None and result.success)
                 self.log(
-                    f"PayloadWaitForDriveOutMode: turn done success={result.success} — terminating"
+                    f"PayloadWaitForDriveOutMode: turn done success={success} — terminating"
                 )
                 self._dr_future = None
                 self._done = True

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/dlz_navigation_state.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/dlz_navigation_state.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, cast
+from typing import Literal, Protocol, TypeGuard, cast
 
 DLZDirection = Literal["cw", "ccw"]
 DLZStartPhase = Literal["wait_for_plane", "scan_tags", "line_follow"]
@@ -8,15 +8,43 @@ DLZStartPhase = Literal["wait_for_plane", "scan_tags", "line_follow"]
 _DLZ_STATE_KEY = "payload.dlz_navigation"
 _DIRECTION_KEY = "direction"
 
+_VALID_DIRECTIONS: tuple[DLZDirection, ...] = ("cw", "ccw")
+_VALID_START_PHASES: tuple[DLZStartPhase, ...] = (
+    "wait_for_plane",
+    "scan_tags",
+    "line_follow",
+)
+
+
+class _SharedStateProvider(Protocol):
+    def shared_state_for(self, mode_or_class: object) -> object: ...
+
+
+def _supports_shared_state(node: object) -> TypeGuard[_SharedStateProvider]:
+    return callable(getattr(node, "shared_state_for", None))
+
 
 def _shared_state_for(node: object) -> dict[str, object]:
-    shared_state_for = getattr(node, "shared_state_for", None)
-    if not callable(shared_state_for):
+    if not _supports_shared_state(node):
         return {}
-    state = shared_state_for(_DLZ_STATE_KEY)
+    state = node.shared_state_for(_DLZ_STATE_KEY)
     if isinstance(state, dict):
         return cast(dict[str, object], state)
     return {}
+
+
+def parse_dlz_direction(value: object) -> DLZDirection | None:
+    direction = str(value).lower().strip()
+    if direction in _VALID_DIRECTIONS:
+        return cast(DLZDirection, direction)
+    return None
+
+
+def parse_dlz_start_phase(value: object) -> DLZStartPhase | None:
+    start_phase = str(value).lower().strip()
+    if start_phase in _VALID_START_PHASES:
+        return cast(DLZStartPhase, start_phase)
+    return None
 
 
 def set_dlz_navigation_direction(node: object, direction: DLZDirection) -> None:
@@ -24,7 +52,4 @@ def set_dlz_navigation_direction(node: object, direction: DLZDirection) -> None:
 
 
 def get_dlz_navigation_direction(node: object) -> DLZDirection | None:
-    value = _shared_state_for(node).get(_DIRECTION_KEY)
-    if value in ("cw", "ccw"):
-        return cast(DLZDirection, value)
-    return None
+    return parse_dlz_direction(_shared_state_for(node).get(_DIRECTION_KEY))

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/dlz_navigation_state.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/dlz_navigation_state.py
@@ -26,11 +26,13 @@ def _supports_shared_state(node: object) -> TypeGuard[_SharedStateProvider]:
 
 def _shared_state_for(node: object) -> dict[str, object]:
     if not _supports_shared_state(node):
-        return {}
+        raise TypeError("DLZ navigation state requires node.shared_state_for().")
     state = node.shared_state_for(_DLZ_STATE_KEY)
     if isinstance(state, dict):
         return cast(dict[str, object], state)
-    return {}
+    raise TypeError(
+        f"DLZ navigation shared state must be a dict, got {type(state).__name__}."
+    )
 
 
 def parse_dlz_direction(value: object) -> DLZDirection | None:

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/dlz_navigation_state.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/dlz_navigation_state.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Literal, cast
+
+DLZDirection = Literal["cw", "ccw"]
+DLZStartPhase = Literal["wait_for_plane", "scan_tags", "line_follow"]
+
+_DLZ_STATE_KEY = "payload.dlz_navigation"
+_DIRECTION_KEY = "direction"
+
+
+def _shared_state_for(node: object) -> dict[str, object]:
+    shared_state_for = getattr(node, "shared_state_for", None)
+    if not callable(shared_state_for):
+        return {}
+    state = shared_state_for(_DLZ_STATE_KEY)
+    if isinstance(state, dict):
+        return cast(dict[str, object], state)
+    return {}
+
+
+def set_dlz_navigation_direction(node: object, direction: DLZDirection) -> None:
+    _shared_state_for(node)[_DIRECTION_KEY] = direction
+
+
+def get_dlz_navigation_direction(node: object) -> DLZDirection | None:
+    value = _shared_state_for(node).get(_DIRECTION_KEY)
+    if value in ("cw", "ccw"):
+        return cast(DLZDirection, value)
+    return None

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/dlz_navigation_state.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/dlz_navigation_state.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Protocol, TypeGuard, cast
+from typing import Literal, cast
 
 DLZDirection = Literal["cw", "ccw"]
 DLZStartPhase = Literal["wait_for_plane", "scan_tags", "line_follow"]
@@ -8,26 +8,12 @@ DLZStartPhase = Literal["wait_for_plane", "scan_tags", "line_follow"]
 _DLZ_STATE_KEY = "payload.dlz_navigation"
 _DIRECTION_KEY = "direction"
 
-_VALID_DIRECTIONS: tuple[DLZDirection, ...] = ("cw", "ccw")
-_VALID_START_PHASES: tuple[DLZStartPhase, ...] = (
-    "wait_for_plane",
-    "scan_tags",
-    "line_follow",
-)
-
-
-class _SharedStateProvider(Protocol):
-    def shared_state_for(self, mode_or_class: object) -> object: ...
-
-
-def _supports_shared_state(node: object) -> TypeGuard[_SharedStateProvider]:
-    return callable(getattr(node, "shared_state_for", None))
-
 
 def _shared_state_for(node: object) -> dict[str, object]:
-    if not _supports_shared_state(node):
+    shared_state_for = getattr(node, "shared_state_for", None)
+    if not callable(shared_state_for):
         raise TypeError("DLZ navigation state requires node.shared_state_for().")
-    state = node.shared_state_for(_DLZ_STATE_KEY)
+    state = shared_state_for(_DLZ_STATE_KEY)
     if isinstance(state, dict):
         return cast(dict[str, object], state)
     raise TypeError(
@@ -37,15 +23,21 @@ def _shared_state_for(node: object) -> dict[str, object]:
 
 def parse_dlz_direction(value: object) -> DLZDirection | None:
     direction = str(value).lower().strip()
-    if direction in _VALID_DIRECTIONS:
-        return cast(DLZDirection, direction)
+    if direction == "cw":
+        return "cw"
+    if direction == "ccw":
+        return "ccw"
     return None
 
 
 def parse_dlz_start_phase(value: object) -> DLZStartPhase | None:
     start_phase = str(value).lower().strip()
-    if start_phase in _VALID_START_PHASES:
-        return cast(DLZStartPhase, start_phase)
+    if start_phase == "wait_for_plane":
+        return "wait_for_plane"
+    if start_phase == "scan_tags":
+        return "scan_tags"
+    if start_phase == "line_follow":
+        return "line_follow"
     return None
 
 

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/NavGPSMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/NavGPSMode.py
@@ -5,6 +5,10 @@ from uav.vehicles.UAV import UAV
 
 from ..Mode import Mode
 
+Coordinate = tuple[float, float, float]
+CoordinateSystem = Literal["GPS", "LOCAL"]
+Waypoint = tuple[Coordinate, float, CoordinateSystem]
+
 
 class NavGPSMode(Mode[UAV]):
     """
@@ -20,9 +24,7 @@ class NavGPSMode(Mode[UAV]):
         self,
         node: Node,
         vehicle: UAV,
-        coordinates: list[
-            tuple[tuple[float, float, float], float, Literal["GPS", "LOCAL"]]
-        ],
+        coordinates: list[Waypoint],
         margin: float = 1,
     ):
         """
@@ -37,11 +39,11 @@ class NavGPSMode(Mode[UAV]):
         """
         super().__init__(node, vehicle)
         self.coordinates = coordinates
-        self.goal = None
+        self.goal: Coordinate | None = None
         self.margin = margin
         self.index = -1
-        self.coordinate_system = None
-        self.target = None
+        self.coordinate_system: CoordinateSystem | None = None
+        self.target: Coordinate | None = None
         self.wait_time = 0.0
 
     def on_update(self, time_delta: float) -> None:
@@ -49,7 +51,11 @@ class NavGPSMode(Mode[UAV]):
         Periodic logic for setting gps coord.
         """
         dist = 0
-        if self.index != -1:
+        if (
+            self.index != -1
+            and self.coordinate_system is not None
+            and self.goal is not None
+        ):
             dist = self.vehicle.distance_to_waypoint(self.coordinate_system, self.goal)
 
         # Determine if we're waiting at a waypoint (lock yaw to prevent spinning)
@@ -71,7 +77,7 @@ class NavGPSMode(Mode[UAV]):
             )
 
         # Consolidated debug output - single line with all information
-        if self.index != -1 and self.target is not None:
+        if self.index != -1 and self.target is not None and self.goal is not None:
             curr_pos = self.vehicle.get_local_position()
             curr_gps = self.vehicle.get_gps()
             yaw = (
@@ -118,6 +124,8 @@ class NavGPSMode(Mode[UAV]):
                     self.index
                 ]
                 self.target = self.get_local_target()
+                if self.target is None:
+                    return
                 self.log(
                     f"Moving to waypoint {self.index + 1}/{len(self.coordinates)}: {self.goal} (wait time: {self.wait_time}s)"
                 )
@@ -128,20 +136,27 @@ class NavGPSMode(Mode[UAV]):
                 )
                 self.wait_time -= time_delta
 
-    def get_local_target(self) -> tuple[float, float, float]:
+    def get_local_target(self) -> Coordinate | None:
         """
         Get the local target of the UAV.
 
         Returns:
             tuple[float, float, float]: The local target of the UAV.
         """
+        goal = self.goal
+        if goal is None:
+            self.log("Waiting for waypoint before computing local target.")
+            return None
+
         if self.coordinate_system == "GPS":
-            local_target = self.vehicle.gps_to_local(self.goal)
+            local_target = self.vehicle.gps_to_local(goal)
+            if local_target is None:
+                self.log("Waiting for GPS origin before computing local target.")
+                return None
             return local_target
         elif self.coordinate_system == "LOCAL":
             # LOCAL coordinates are already in NED frame relative to origin
-            local_target = tuple(float(x) for x in self.goal)
-            return local_target
+            return (float(goal[0]), float(goal[1]), float(goal[2]))
         else:
             raise ValueError(f"Invalid coordinate system {self.coordinate_system}")
 

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/PayloadDropoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/PayloadDropoffMode.py
@@ -39,8 +39,8 @@ class PayloadDropoffMode(Mode[UAV]):
 
         self.response = None
         self.done = False
-        self.offsets = offsets
-        self.camera_offsets = self.vehicle.camera_offsets
+        self.offsets = (0.0, 0.0, 0.0) if offsets is None else offsets
+        self.camera_offsets = tuple(self.vehicle.camera_offsets)
         self.mode = (
             0  # 0 for uav centering, 1 for landing, 2 for retracting, 3 for taking off
         )
@@ -49,8 +49,14 @@ class PayloadDropoffMode(Mode[UAV]):
         """
         Periodic logic for lowering payload and handling obstacles.
         """
+        roll = self.vehicle.roll
+        pitch = self.vehicle.pitch
+        if roll is None or pitch is None:
+            self.log("Waiting for attitude data.")
+            return
+
         # If UAV is unstable, skip the update
-        if self.vehicle.roll > 0.1 or self.vehicle.pitch > 0.1:
+        if roll > 0.1 or pitch > 0.1:
             self.log("Roll or pitch detected. Waiting for stabilization.")
             return
 
@@ -70,9 +76,15 @@ class PayloadDropoffMode(Mode[UAV]):
                 self.done = True
             return
 
+        local_position = self.vehicle.get_local_position()
+        yaw = self.vehicle.yaw
+        if local_position is None or yaw is None:
+            self.log("Waiting for local position and yaw data.")
+            return
+
         request = PayloadTracking.Request()
-        request.altitude = -self.vehicle.get_local_position()[2]
-        request.yaw = float(self.vehicle.yaw)
+        request.altitude = -local_position[2]
+        request.yaw = float(yaw)
         request.payload_color = "pink"
         response = self.send_request(PayloadTrackingNode, request)
 

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/PayloadPickupMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/PayloadPickupMode.py
@@ -37,14 +37,26 @@ class PayloadPickupMode(Mode[UAV]):
         """
         Periodic logic for lowering payload and handling obstacles.
         """
+        roll = self.vehicle.roll
+        pitch = self.vehicle.pitch
+        if roll is None or pitch is None:
+            self.log("Waiting for attitude data.")
+            return
+
         # If UAV is unstable, skip the update
-        if self.vehicle.roll > 0.1 or self.vehicle.pitch > 0.1:
+        if roll > 0.1 or pitch > 0.1:
             self.log("Roll or pitch detected. Waiting for stabilization.")
             return
 
+        local_position = self.vehicle.get_local_position()
+        yaw = self.vehicle.yaw
+        if local_position is None or yaw is None:
+            self.log("Waiting for local position and yaw data.")
+            return
+
         request = PayloadTracking.Request()
-        request.altitude = -self.vehicle.get_local_position()[2]
-        request.yaw = float(self.vehicle.yaw)
+        request.altitude = -local_position[2]
+        request.yaw = float(yaw)
         request.payload_color = self.color
         response = self.send_request(PayloadTrackingNode, request)
 
@@ -84,7 +96,7 @@ class PayloadPickupMode(Mode[UAV]):
                 and np.abs(direction[1]) < request.altitude / 50
             ):
                 if request.altitude < 0.5:
-                    self.goal_pos = self.vehicle.get_local_position()
+                    self.goal_pos = local_position
                     return
                 else:
                     direction = [0, 0, request.altitude / self.altitude_constant]

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py
@@ -5,16 +5,16 @@ from rclpy.node import Node
 from px4_msgs.msg import TrajectorySetpoint
 import math
 import time
-from typing import Sequence, cast
+from typing import List, Optional, cast
 
 from uav.vehicles.UAV import UAV
 
 from ..Mode import Mode
 
-Waypoint = tuple[float, float, float]
 
-
-def _coerce_waypoints(waypoints: Sequence[Sequence[float]] | None) -> list[Waypoint]:
+def _coerce_waypoints(
+    waypoints: Optional[List[List[float]]],
+) -> list[tuple[float, float, float]]:
     if waypoints is None:
         return []
     return [
@@ -33,7 +33,7 @@ class WaypointMission(Mode[UAV]):
         self,
         node: Node,
         vehicle: UAV,
-        waypoints: Sequence[Sequence[float]] | None = None,
+        waypoints: Optional[List[List[float]]] = None,
         waypoint_tolerance: float = 0.5,
         speed: float = 1.0,
         loiter_time: float = 1.0,
@@ -177,15 +177,15 @@ def main(args=None):
     uav = cast(UAV, DummyUAV())
 
     # Test waypoints
-    test_waypoints = [
-        [0, 0, 2],  # Takeoff
-        [2, 0, 2],  # Hoop 1
-        [4, 0, 2],  # Hoop 2
-        [6, 0, 2],  # Hoop 3
-        [8, 0, 2],  # Hoop 4
-        [10, 0, 2],  # Hoop 5
-        [0, 0, 2],  # Return
-        [0, 0, 0],  # Land
+    test_waypoints: List[List[float]] = [
+        [0.0, 0.0, 2.0],  # Takeoff
+        [2.0, 0.0, 2.0],  # Hoop 1
+        [4.0, 0.0, 2.0],  # Hoop 2
+        [6.0, 0.0, 2.0],  # Hoop 3
+        [8.0, 0.0, 2.0],  # Hoop 4
+        [10.0, 0.0, 2.0],  # Hoop 5
+        [0.0, 0.0, 2.0],  # Return
+        [0.0, 0.0, 0.0],  # Land
     ]
 
     WaypointMission(node, uav, waypoints=test_waypoints)

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py
@@ -12,17 +12,6 @@ from uav.vehicles.UAV import UAV
 from ..Mode import Mode
 
 
-def _coerce_waypoints(
-    waypoints: Optional[List[List[float]]],
-) -> list[tuple[float, float, float]]:
-    if waypoints is None:
-        return []
-    return [
-        (float(waypoint[0]), float(waypoint[1]), float(waypoint[2]))
-        for waypoint in waypoints
-    ]
-
-
 class WaypointMission(Mode[UAV]):
     """
     Simple waypoint mission for testing scoring node.
@@ -42,7 +31,10 @@ class WaypointMission(Mode[UAV]):
         super().__init__(node, vehicle)
 
         # Mission parameters
-        self.waypoints = _coerce_waypoints(waypoints)
+        self.waypoints = [
+            (float(waypoint[0]), float(waypoint[1]), float(waypoint[2]))
+            for waypoint in (waypoints or [])
+        ]
         self.current_waypoint = 0
         self.waypoint_tolerance = waypoint_tolerance
         self.speed = speed

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py
@@ -5,11 +5,22 @@ from rclpy.node import Node
 from px4_msgs.msg import TrajectorySetpoint
 import math
 import time
-from typing import List
+from typing import Sequence, cast
 
 from uav.vehicles.UAV import UAV
 
 from ..Mode import Mode
+
+Waypoint = tuple[float, float, float]
+
+
+def _coerce_waypoints(waypoints: Sequence[Sequence[float]] | None) -> list[Waypoint]:
+    if waypoints is None:
+        return []
+    return [
+        (float(waypoint[0]), float(waypoint[1]), float(waypoint[2]))
+        for waypoint in waypoints
+    ]
 
 
 class WaypointMission(Mode[UAV]):
@@ -22,7 +33,7 @@ class WaypointMission(Mode[UAV]):
         self,
         node: Node,
         vehicle: UAV,
-        waypoints: List[List[float]] = None,
+        waypoints: Sequence[Sequence[float]] | None = None,
         waypoint_tolerance: float = 0.5,
         speed: float = 1.0,
         loiter_time: float = 1.0,
@@ -31,7 +42,7 @@ class WaypointMission(Mode[UAV]):
         super().__init__(node, vehicle)
 
         # Mission parameters
-        self.waypoints = waypoints or []
+        self.waypoints = _coerce_waypoints(waypoints)
         self.current_waypoint = 0
         self.waypoint_tolerance = waypoint_tolerance
         self.speed = speed
@@ -163,7 +174,7 @@ def main(args=None):
         def arm(self):
             pass
 
-    uav = DummyUAV()
+    uav = cast(UAV, DummyUAV())
 
     # Test waypoints
     test_waypoints = [

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/TakeoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/vtol/TakeoffMode.py
@@ -115,9 +115,16 @@ class TakeoffMode(Mode[VTOL]):
                 "FW takeoff Step 2: transition complete. Starting disarm->takeoff->arm sequence."
             )
 
-            lat = self.vehicle.global_position.lat
-            lon = self.vehicle.global_position.lon
-            alt = self.vehicle.global_position.alt
+            global_position = self.vehicle.global_position
+            if global_position is None:
+                self.node.get_logger().info(
+                    "FW takeoff: Waiting for global position before runway takeoff."
+                )
+                return
+
+            lat = global_position.lat
+            lon = global_position.lon
+            alt = global_position.alt
             self.node.get_logger().info(f"Current GPS: {lat}, {lon}, {alt}")
 
             if (

--- a/controls/sae_2025_ws/src/uav/uav/runtime/schema_generator.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/schema_generator.py
@@ -62,9 +62,14 @@ def _iter_mode_classes() -> list[type[Mode[Any]]]:
             )
             continue
         for value in vars(module).values():
+            if not isinstance(value, type):
+                continue
+            try:
+                is_mode_class = issubclass(value, Mode)
+            except TypeError:
+                continue
             if (
-                isinstance(value, type)
-                and issubclass(value, Mode)
+                is_mode_class
                 and value is not Mode
                 and not inspect.isabstract(value)
                 and value.__module__ == module.__name__


### PR DESCRIPTION
Refs #189.
Refs #190.
Refs #191.
Part of #180.

## Summary
- Guard optional UAV attitude, yaw, local position, global position, and payload dropoff offsets before use.
- Replace dynamic DLZ navigation handoff state with a typed shared-state helper.
- Clean up residual payload retreat, dead-reckon, and WaypointMission typing.
- Keep the schema scanner from treating helper typing objects as modes.
- Folded #199 and #200 into this PR as separate commits.

## Verification
- Constituent focused Pyright, compile, schema-generator, and diff checks from #198, #199, and #200 passed when created.
