### PR TITLE
Clean up residual mode typing

### DIFF
--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadRetreatMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadRetreatMode.py
@@ -122,8 +122,10 @@ class PayloadRetreatMode(Mode[Payload]):
         self._publish_drive(0.0, 0.0)
         if self.camera_debug:
             cv2.destroyWindow("PayloadRetreatMode")
-        self.node.destroy_subscription(self._image_sub)
-        self.node.destroy_publisher(self._drive_pub)
+        if self._image_sub is not None:
+            self.node.destroy_subscription(self._image_sub)
+        if self._drive_pub is not None:
+            self.node.destroy_publisher(self._drive_pub)
 
     def on_update(self, time_delta: float) -> None:
         if self._done or self._image is None:

--- a/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py
@@ -330,8 +330,9 @@ class PayloadWaitForDriveOutMode(Mode[Payload]):
                 )
             elif self._dr_future.done():
                 result = self._dr_future.result()
+                success = bool(result is not None and result.success)
                 self.log(
-                    f"obstruction retreat done success={result.success} — resuming DLZ watch"
+                    f"obstruction retreat done success={success} — resuming DLZ watch"
                 )
                 self._dr_future = None
                 # Reset optical-flow so motion from the retreat doesn't linger
@@ -347,8 +348,9 @@ class PayloadWaitForDriveOutMode(Mode[Payload]):
                 )
             elif self._dr_future.done():
                 result = self._dr_future.result()
+                success = bool(result is not None and result.success)
                 self.log(
-                    f"PayloadWaitForDriveOutMode: reverse done success={result.success} — settling"
+                    f"PayloadWaitForDriveOutMode: reverse done success={success} — settling"
                 )
                 self._dr_future = None
                 self.state = DriveOutState.TURNING
@@ -363,8 +365,9 @@ class PayloadWaitForDriveOutMode(Mode[Payload]):
                 )
             elif self._dr_future.done():
                 result = self._dr_future.result()
+                success = bool(result is not None and result.success)
                 self.log(
-                    f"PayloadWaitForDriveOutMode: turn done success={result.success} — terminating"
+                    f"PayloadWaitForDriveOutMode: turn done success={success} — terminating"
                 )
                 self._dr_future = None
                 self._done = True

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py
@@ -5,16 +5,16 @@ from rclpy.node import Node
 from px4_msgs.msg import TrajectorySetpoint
 import math
 import time
-from typing import Sequence, cast
+from typing import List, Optional, cast
 
 from uav.vehicles.UAV import UAV
 
 from ..Mode import Mode
 
-Waypoint = tuple[float, float, float]
 
-
-def _coerce_waypoints(waypoints: Sequence[Sequence[float]] | None) -> list[Waypoint]:
+def _coerce_waypoints(
+    waypoints: Optional[List[List[float]]],
+) -> list[tuple[float, float, float]]:
     if waypoints is None:
         return []
     return [
@@ -33,7 +33,7 @@ class WaypointMission(Mode[UAV]):
         self,
         node: Node,
         vehicle: UAV,
-        waypoints: Sequence[Sequence[float]] | None = None,
+        waypoints: Optional[List[List[float]]] = None,
         waypoint_tolerance: float = 0.5,
         speed: float = 1.0,
         loiter_time: float = 1.0,
@@ -177,15 +177,15 @@ def main(args=None):
     uav = cast(UAV, DummyUAV())
 
     # Test waypoints
-    test_waypoints = [
-        [0, 0, 2],  # Takeoff
-        [2, 0, 2],  # Hoop 1
-        [4, 0, 2],  # Hoop 2
-        [6, 0, 2],  # Hoop 3
-        [8, 0, 2],  # Hoop 4
-        [10, 0, 2],  # Hoop 5
-        [0, 0, 2],  # Return
-        [0, 0, 0],  # Land
+    test_waypoints: List[List[float]] = [
+        [0.0, 0.0, 2.0],  # Takeoff
+        [2.0, 0.0, 2.0],  # Hoop 1
+        [4.0, 0.0, 2.0],  # Hoop 2
+        [6.0, 0.0, 2.0],  # Hoop 3
+        [8.0, 0.0, 2.0],  # Hoop 4
+        [10.0, 0.0, 2.0],  # Hoop 5
+        [0.0, 0.0, 2.0],  # Return
+        [0.0, 0.0, 0.0],  # Land
     ]
 
     WaypointMission(node, uav, waypoints=test_waypoints)

--- a/controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py
@@ -5,11 +5,22 @@ from rclpy.node import Node
 from px4_msgs.msg import TrajectorySetpoint
 import math
 import time
-from typing import List
+from typing import Sequence, cast
 
 from uav.vehicles.UAV import UAV
 
 from ..Mode import Mode
+
+Waypoint = tuple[float, float, float]
+
+
+def _coerce_waypoints(waypoints: Sequence[Sequence[float]] | None) -> list[Waypoint]:
+    if waypoints is None:
+        return []
+    return [
+        (float(waypoint[0]), float(waypoint[1]), float(waypoint[2]))
+        for waypoint in waypoints
+    ]
 
 
 class WaypointMission(Mode[UAV]):
@@ -22,7 +33,7 @@ class WaypointMission(Mode[UAV]):
         self,
         node: Node,
         vehicle: UAV,
-        waypoints: List[List[float]] = None,
+        waypoints: Sequence[Sequence[float]] | None = None,
         waypoint_tolerance: float = 0.5,
         speed: float = 1.0,
         loiter_time: float = 1.0,
@@ -31,7 +42,7 @@ class WaypointMission(Mode[UAV]):
         super().__init__(node, vehicle)
 
         # Mission parameters
-        self.waypoints = waypoints or []
+        self.waypoints = _coerce_waypoints(waypoints)
         self.current_waypoint = 0
         self.waypoint_tolerance = waypoint_tolerance
         self.speed = speed
@@ -163,7 +174,7 @@ def main(args=None):
         def arm(self):
             pass
 
-    uav = DummyUAV()
+    uav = cast(UAV, DummyUAV())
 
     # Test waypoints
     test_waypoints = [


### PR DESCRIPTION
## Summary
- Guard optional payload retreat publishers/subscriptions before destroying them.
- Handle `None` dead-reckon future results before logging service success.
- Normalize WaypointMission inputs to fixed float triples while keeping schema-supported constructor annotations, and cast the standalone dummy vehicle used only in the local test harness.

## Verification
- `npx --yes pyright --project /tmp/pyright-modes --outputjson` drops from 82 to 74 errors on this branch; the remaining WaypointMission item is the package export warning covered by #183.
- `PYTHONPATH=controls/sae_2025_ws/src/uav python3 -m compileall controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadRetreatMode.py controls/sae_2025_ws/src/uav/uav/modes/payload/PayloadWaitForDriveOutMode.py controls/sae_2025_ws/src/uav/uav/modes/uav/WaypointMission.py`
- `source /opt/ros/humble/setup.bash && source controls/sae_2025_ws/install/setup.bash && PYTHONPATH=controls/sae_2025_ws/src/uav:$PYTHONPATH python3 -m uav.runtime.schema_generator --check`
- `git diff --check`

Refs #191
Part of #180