### PR TITLE
Type UAV public exports and launch helpers

### DIFF
--- a/controls/sae_2025_ws/src/uav/launch/main.launch.py
+++ b/controls/sae_2025_ws/src/uav/launch/main.launch.py
@@ -228,7 +228,7 @@ def _single_vehicle_config(context, params: dict) -> tuple[dict, dict | None]:
     airframe_id = None
     if mission_spec.is_uav:
         airframe_id = _resolve_airframe_id(params.get("airframe", "quadcopter"))
-        vehicle_class, _, airframe_model = get_airframe_details(px4_path, airframe_id)
+        vehicle_class, airframe_model = get_airframe_details(px4_path, airframe_id)
         vehicle_class_name = vehicle_class.name
         if not model:
             model = airframe_model

--- a/controls/sae_2025_ws/src/uav/launch/vehicle_stack.launch.py
+++ b/controls/sae_2025_ws/src/uav/launch/vehicle_stack.launch.py
@@ -19,6 +19,7 @@ from launch_ros.actions import Node
 
 from uav.runtime.mission_spec import MissionSpec, mission_path_for_name
 from uav.runtime.vision_loader import load_vision_class
+from uav.vehicles.AirframeClass import AirframeClass
 from uav.utils import (
     camel_to_snake,
     find_folder_with_heuristic,
@@ -151,9 +152,13 @@ def _resolve_airframe_id(config: dict) -> int:
             raise ValueError(f"Unknown airframe name: {airframe_value}") from exc
 
 
-def _resolve_uav_airframe(config: dict, px4_path: str) -> tuple[object, int, str]:
+def _resolve_uav_airframe(
+    config: dict, px4_path: str
+) -> tuple[AirframeClass, int, str]:
     airframe_id = _resolve_airframe_id(config)
     vehicle_class, model_name = get_airframe_details(px4_path, airframe_id)
+    if not isinstance(vehicle_class, AirframeClass):
+        raise ValueError(f"Unexpected airframe class: {vehicle_class!r}.")
     model = str(config.get("model", "")).strip() or model_name
     return vehicle_class, int(airframe_id), model
 
@@ -267,12 +272,13 @@ def _build_camera_actions(
 ) -> list:
     save_vision = save_vision_milliseconds > 0
     actions = []
+    vehicle_name = str(camera_contract["vehicle_name"])
 
     if sim:
         actions.extend(
             _sim_camera_bridge_actions(
                 world_name=sim_world_name,
-                vehicle_name=str(camera_contract["vehicle_name"]),
+                vehicle_name=vehicle_name,
                 sim_entity_name=sim_entity_name,
                 mission_target=str(camera_contract["mission_target"]),
             )
@@ -350,8 +356,8 @@ def _build_camera_actions(
         Node(
             package="uav",
             executable="camera",
-            namespace=camera_contract["vehicle_name"],
-            name=f"{camera_contract['vehicle_name']}_camera",
+            namespace=vehicle_name,
+            name=f"{vehicle_name}_camera",
             output="screen",
             parameters=[camera_parameters],
         )
@@ -371,8 +377,8 @@ def _build_camera_actions(
             Node(
                 package="uav",
                 executable=executable,
-                namespace=camera_contract["vehicle_name"],
-                name=f"{camera_contract['vehicle_name']}_{executable}",
+                namespace=vehicle_name,
+                name=f"{vehicle_name}_{executable}",
                 output="screen",
                 parameters=[
                     {
@@ -594,8 +600,8 @@ def launch_setup(context, *args, **kwargs):
     ) or _resolve_force_camera(config, logger=logger)
 
     px4_path = ""
-    vehicle_class = None
-    autostart = None
+    vehicle_class: AirframeClass | None = None
+    autostart: int | None = None
     model = str(config.get("model", "")).strip()
     if mission_spec.is_uav:
         px4_path = find_folder_with_heuristic(
@@ -645,8 +651,11 @@ def launch_setup(context, *args, **kwargs):
             "v4l2_camera will fall back to its default camera_info behavior."
         )
 
-    camera_actions = (
-        _build_camera_actions(
+    camera_actions = []
+    if requires_camera:
+        if camera_contract is None:
+            raise ValueError(f"Vehicle '{vehicle_name}' requires a camera contract.")
+        camera_actions = _build_camera_actions(
             mission_spec=mission_spec,
             camera_contract=camera_contract,
             vision_nodes=list(mission_spec.vision_nodes),
@@ -657,9 +666,6 @@ def launch_setup(context, *args, **kwargs):
             debug_vision_node=debug_vision_node,
             save_vision_milliseconds=save_vision_milliseconds,
         )
-        if requires_camera
-        else []
-    )
 
     mission_node = Node(
         package="uav",
@@ -732,6 +738,10 @@ def launch_setup(context, *args, **kwargs):
         actions.append(_middleware_action(sim=sim, config=config))
 
     if mission_spec.is_uav and launch_px4_sitl:
+        if autostart is None:
+            raise ValueError(
+                f"Vehicle '{vehicle_name}' cannot launch PX4 SITL without a valid UAV airframe."
+            )
         actions.append(
             _px4_sitl_action(
                 px4_path=px4_path,

--- a/controls/sae_2025_ws/src/uav/setup.py
+++ b/controls/sae_2025_ws/src/uav/setup.py
@@ -2,6 +2,7 @@ from glob import glob
 import os
 from pathlib import Path
 import sys
+from typing import Protocol, cast
 
 from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py as _build_py
@@ -10,6 +11,10 @@ from setuptools.command.install import install as _install
 
 package_name = "uav"
 _SCHEMA_REGISTRY_REFRESHED = False
+
+
+class _CommandWithRun(Protocol):
+    def run(self) -> None: ...
 
 
 def _missing_pydantic_v2(exc: ImportError) -> bool:
@@ -44,9 +49,9 @@ def _refresh_mode_schema_registry() -> None:
 
 
 class _RefreshSchemaRegistryMixin:
-    def run(self):
+    def run(self) -> None:
         _refresh_mode_schema_registry()
-        super().run()
+        cast(_CommandWithRun, super()).run()
 
 
 class build_py(_RefreshSchemaRegistryMixin, _build_py):

--- a/controls/sae_2025_ws/src/uav/setup.py
+++ b/controls/sae_2025_ws/src/uav/setup.py
@@ -2,7 +2,6 @@ from glob import glob
 import os
 from pathlib import Path
 import sys
-from typing import Protocol, cast
 
 from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py as _build_py
@@ -11,10 +10,6 @@ from setuptools.command.install import install as _install
 
 package_name = "uav"
 _SCHEMA_REGISTRY_REFRESHED = False
-
-
-class _CommandWithRun(Protocol):
-    def run(self) -> None: ...
 
 
 def _missing_pydantic_v2(exc: ImportError) -> bool:
@@ -48,22 +43,22 @@ def _refresh_mode_schema_registry() -> None:
     _SCHEMA_REGISTRY_REFRESHED = True
 
 
-class _RefreshSchemaRegistryMixin:
+class build_py(_build_py):
     def run(self) -> None:
         _refresh_mode_schema_registry()
-        cast(_CommandWithRun, super()).run()
+        super().run()
 
 
-class build_py(_RefreshSchemaRegistryMixin, _build_py):
-    pass
+class develop(_develop):
+    def run(self) -> None:
+        _refresh_mode_schema_registry()
+        super().run()
 
 
-class develop(_RefreshSchemaRegistryMixin, _develop):
-    pass
-
-
-class install(_RefreshSchemaRegistryMixin, _install):
-    pass
+class install(_install):
+    def run(self) -> None:
+        _refresh_mode_schema_registry()
+        super().run()
 
 
 setup(

--- a/controls/sae_2025_ws/src/uav/uav/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/__init__.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = ["AirframeClass", "Payload", "Vehicle", "UAV", "VTOL", "Multicopter"]
 
@@ -10,6 +11,14 @@ _EXPORTS = {
     "VTOL": ".vehicles.VTOL",
     "Multicopter": ".vehicles.Multicopter",
 }
+
+if TYPE_CHECKING:
+    from .vehicles.AirframeClass import AirframeClass
+    from .vehicles.Multicopter import Multicopter
+    from .vehicles.Payload import Payload
+    from .vehicles.UAV import UAV
+    from .vehicles.VTOL import VTOL
+    from .vehicles.Vehicle import Vehicle
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/runtime/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/__init__.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = [
     "MissionSpec",
@@ -39,6 +40,28 @@ _EXPORTS = {
     "UAVModeManager": ".UAVModeManager",
     "PayloadModeManager": ".PayloadModeManager",
 }
+
+if TYPE_CHECKING:
+    from .ModeManager import ModeManager
+    from .PayloadModeManager import PayloadModeManager
+    from .UAVModeManager import UAVModeManager
+    from .fleet_spec import FleetDocumentModel, load_fleet_document
+    from .mission_spec import (
+        MissionDocumentModel,
+        MissionSpec,
+        ModeSpec,
+        load_mission_spec,
+        load_mode_class,
+        mission_path_for_name,
+    )
+    from .schema import (
+        fleet_document_schema,
+        mission_document_schema,
+        mode_entry_for_class_path,
+        mode_entry_for_mode_id,
+        mode_registry_entries,
+        schema_registry_document,
+    )
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/vehicles/__init__.py
+++ b/controls/sae_2025_ws/src/uav/uav/vehicles/__init__.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 __all__ = [
     "AirframeClass",
@@ -8,6 +9,14 @@ __all__ = [
     "VTOL",
     "Multicopter",
 ]
+
+if TYPE_CHECKING:
+    from .AirframeClass import AirframeClass
+    from .Multicopter import Multicopter
+    from .Payload import Payload
+    from .UAV import UAV
+    from .VTOL import VTOL
+    from .Vehicle import Vehicle
 
 
 def __getattr__(name: str):

--- a/controls/sae_2025_ws/src/uav/uav/vehicles/px4_modes.py
+++ b/controls/sae_2025_ws/src/uav/uav/vehicles/px4_modes.py
@@ -1,5 +1,8 @@
 # Adapted from: https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/commander/px4_custom_mode.h
+from __future__ import annotations
+
 from enum import Enum
+from typing import TypeAlias
 
 
 class FloatEnum(Enum):
@@ -49,13 +52,23 @@ class PX4CustomSubModePosctl(FloatEnum):
     SLOW = 2.0
 
 
+PX4ModeValue: TypeAlias = (
+    int | float | PX4CustomMainMode | PX4CustomSubModeAuto | PX4CustomSubModePosctl
+)
+
+
 class PX4CustomMode:
-    def __init__(self, main_mode=0, sub_mode=0, reserved=0):
+    def __init__(
+        self,
+        main_mode: PX4ModeValue = 0,
+        sub_mode: PX4ModeValue = 0,
+        reserved: int = 0,
+    ) -> None:
         self.reserved = reserved
         self.main_mode = main_mode
         self.sub_mode = sub_mode
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<PX4CustomMode main_mode={self.main_mode} sub_mode={self.sub_mode}>"
 
 
@@ -87,7 +100,7 @@ NAVIGATION_STATE_EXTERNAL7 = 24.0
 NAVIGATION_STATE_EXTERNAL8 = 25.0
 
 
-def get_px4_custom_mode(nav_state):
+def get_px4_custom_mode(nav_state: float) -> PX4CustomMode:
     """Translate a navigation state into a PX4 custom mode."""
     custom_mode = PX4CustomMode()
 


### PR DESCRIPTION
Refs #202.
Fixes #204.
Fixes #206.
Fixes #222.
Part of #201.

## Summary
- Export top-level UAV/runtime symbols expected by type checkers.
- Type PX4 custom mode values.
- Type UAV launch and setup helper entry points.
- Folded #203 and #223 into this PR as separate commits to reduce PR noise.

## Verification
- Constituent focused Pyright, compile, ruff, and pytest checks from #203, #205, and #223 passed when created.
- Integrated workspace Pyright baseline after condensation: 161 files analyzed, 0 errors, 0 warnings.
