### PR TITLE
Use relative imports in UAV CV helpers

### DIFF
--- a/controls/sae_2025_ws/src/uav/uav/cv/calibrate.py
+++ b/controls/sae_2025_ws/src/uav/uav/cv/calibrate.py
@@ -1,8 +1,8 @@
 import numpy as np
 import cv2
 import scipy.stats as stats
-from recalibrate import detect_contour
-from confidence import confidence
+from .recalibrate import detect_contour
+from .confidence import confidence
 
 
 def calibrate(frame):

--- a/controls/sae_2025_ws/src/uav/uav/cv/track.py
+++ b/controls/sae_2025_ws/src/uav/uav/cv/track.py
@@ -1,9 +1,9 @@
 import numpy as np
 import cv2
-from calibrate import calibrate
-from recalibrate import recalibrate
-from threshold import threshold
-from confidence import confidence
+from .calibrate import calibrate
+from .recalibrate import recalibrate
+from .threshold import threshold
+from .confidence import confidence
 
 range = ((0, 0, 180), (225, 225, 255))
 
@@ -19,6 +19,8 @@ def process_video(input_path: str):
     cap = cv2.VideoCapture(input_path)
 
     opened, first_frame = cap.read()
+    if not opened or first_frame is None:
+        raise ValueError(f"Could not read first frame from {input_path}")
 
     prev_frame = first_frame
     prev_center = (0, 0)
@@ -26,21 +28,24 @@ def process_video(input_path: str):
     threshold_range = calibrate(first_frame)
 
     while cap.isOpened():
-        _, frame = cap.read()
+        ok, frame = cap.read()
+        if not ok or frame is None:
+            break
 
         if recalibrate(frame, prev_frame, range):
             threshold_range = calibrate(frame)
 
         points, center = threshold(threshold_range, prev_center, frame)
 
-        new_points = [conversion(p, 100) for p in points]
-        print(new_points)
+        if points is not None and center is not None:
+            new_points = [conversion(p, 100) for p in points]
+            print(new_points)
 
-        conf = confidence(points, -1, *frame[:2])
-        print(f"{conf:.2f}, {center}")
+            conf = confidence(points, -1, *frame.shape[:2])
+            print(f"{conf:.2f}, {center}")
+            prev_center = center
 
         prev_frame = frame
-        prev_center = center
 
         if cv2.waitKey(1) & 0xFF == ord("q"):
             break


### PR DESCRIPTION
## Summary
- Convert legacy UAV CV helper imports to package-relative imports.
- Guard failed video reads in the legacy tracker helper.
- Skip contour conversion/confidence when the helper does not find a contour, and pass image dimensions via `frame.shape`.

## Verification
- `source /opt/ros/humble/setup.bash && export PYTHONPATH=$PWD/controls/sae_2025_ws/src/uav:$PYTHONPATH && npx --yes pyright controls/sae_2025_ws/src/uav/uav/cv/calibrate.py controls/sae_2025_ws/src/uav/uav/cv/track.py --outputjson`
- `python3 -m compileall controls/sae_2025_ws/src/uav/uav/cv/calibrate.py controls/sae_2025_ws/src/uav/uav/cv/track.py`
- `ruff check controls/sae_2025_ws/src/uav/uav/cv/calibrate.py controls/sae_2025_ws/src/uav/uav/cv/track.py`
- `ruff format --check controls/sae_2025_ws/src/uav/uav/cv/calibrate.py controls/sae_2025_ws/src/uav/uav/cv/track.py`

Refs #208
Part of #201