### PR TITLE
Keep payload plot animation in module state

### DIFF
--- a/controls/sae_2025_ws/src/payload/test/plot_motor_state.py
+++ b/controls/sae_2025_ws/src/payload/test/plot_motor_state.py
@@ -19,6 +19,8 @@ from rclpy.node import Node
 
 from payload_interfaces.msg import MotorState
 
+_ANIMATION: FuncAnimation | None = None
+
 
 class MotorStatePlotter(Node):
     def __init__(self, topic: str, window_sec: float) -> None:
@@ -128,7 +130,8 @@ def main() -> None:
         return left_set_line, left_meas_line, right_set_line, right_meas_line
 
     interval_ms = max(1, int(1000.0 / args.refresh_hz))
-    fig._animation = FuncAnimation(fig, update, interval=interval_ms, blit=False)
+    global _ANIMATION
+    _ANIMATION = FuncAnimation(fig, update, interval=interval_ms, blit=False)
 
     try:
         plt.show()


### PR DESCRIPTION
## Summary
- Keep the payload motor-state plot animation alive in module state.
- Remove the ad hoc private `Figure._animation` assignment that Pyright flags.

## Verification
- `source /opt/ros/humble/setup.bash && source /home/ubuntu/monorepo/controls/sae_2025_ws/install/setup.bash && export PYTHONPATH=$PWD/controls/sae_2025_ws/src/payload:$PYTHONPATH && npx --yes pyright controls/sae_2025_ws/src/payload/test/plot_motor_state.py --outputjson`
- `python3 -m compileall controls/sae_2025_ws/src/payload/test/plot_motor_state.py`
- `ruff check controls/sae_2025_ws/src/payload/test/plot_motor_state.py`
- `ruff format --check controls/sae_2025_ws/src/payload/test/plot_motor_state.py`

Refs #212
Part of #201