### PR TITLE
Normalize ROS launch typing

### DIFF
--- a/controls/sae_2025_ws/src/payload/launch/payload.launch.py
+++ b/controls/sae_2025_ws/src/payload/launch/payload.launch.py
@@ -1,5 +1,7 @@
 from ament_index_python.packages import get_package_share_directory
 import os
+from typing import Any
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
@@ -17,7 +19,7 @@ def launch_setup(context):
     controller_override = LaunchConfiguration("controller").perform(context)
     payload_node_name = sim_entity_name or vehicle_name
 
-    parameters = [payload_params_path]
+    parameters: list[Any] = [payload_params_path]
     if controller_override:
         parameters.append({"controller": controller_override})
 

--- a/controls/sae_2025_ws/src/sim/launch/sim.launch.py
+++ b/controls/sae_2025_ws/src/sim/launch/sim.launch.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+from typing import Any
 
 import launch
 from launch import LaunchDescription
@@ -133,7 +134,7 @@ def launch_setup(context, *args, **kwargs):
     server_config_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "server.config"
     )
-    gz_sim_env = {
+    gz_sim_env: dict[Any, Any] = {
         "GZ_SIM_RESOURCE_PATH": os.path.join(model_store, "models"),
         "GZ_SIM_SERVER_CONFIG_PATH": server_config_path,
     }


### PR DESCRIPTION
## Summary
- Annotate the payload launch parameter list so mixed config-file and override entries keep the intended launch shape.
- Widen the sim launch Gazebo environment map to the Launch API substitution shape expected by Pyright.

## Verification
- `source /opt/ros/humble/setup.bash && source /home/ubuntu/monorepo/controls/sae_2025_ws/install/setup.bash && export PYTHONPATH=$PWD/controls/sae_2025_ws/src/sim:$PWD/controls/sae_2025_ws/src/payload:$PYTHONPATH && npx --yes pyright controls/sae_2025_ws/src/sim/launch/sim.launch.py controls/sae_2025_ws/src/payload/launch/payload.launch.py --outputjson`
- `python3 -m compileall controls/sae_2025_ws/src/sim/launch/sim.launch.py controls/sae_2025_ws/src/payload/launch/payload.launch.py`
- `ruff check controls/sae_2025_ws/src/sim/launch/sim.launch.py controls/sae_2025_ws/src/payload/launch/payload.launch.py`
- `ruff format --check controls/sae_2025_ws/src/sim/launch/sim.launch.py controls/sae_2025_ws/src/payload/launch/payload.launch.py`

Refs #214
Part of #201