### PR TITLE
Type ROS support package helpers

### DIFF
--- a/controls/sae_2025_ws/src/payload/launch/payload.launch.py
+++ b/controls/sae_2025_ws/src/payload/launch/payload.launch.py
@@ -1,5 +1,7 @@
 from ament_index_python.packages import get_package_share_directory
 import os
+from typing import Any
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
@@ -17,7 +19,7 @@ def launch_setup(context):
     controller_override = LaunchConfiguration("controller").perform(context)
     payload_node_name = sim_entity_name or vehicle_name
 
-    parameters = [payload_params_path]
+    parameters: list[Any] = [payload_params_path]
     if controller_override:
         parameters.append({"controller": controller_override})
 

--- a/controls/sae_2025_ws/src/payload/test/plot_motor_state.py
+++ b/controls/sae_2025_ws/src/payload/test/plot_motor_state.py
@@ -19,6 +19,8 @@ from rclpy.node import Node
 
 from payload_interfaces.msg import MotorState
 
+_ANIMATION: FuncAnimation | None = None
+
 
 class MotorStatePlotter(Node):
     def __init__(self, topic: str, window_sec: float) -> None:
@@ -128,7 +130,8 @@ def main() -> None:
         return left_set_line, left_meas_line, right_set_line, right_meas_line
 
     interval_ms = max(1, int(1000.0 / args.refresh_hz))
-    fig._animation = FuncAnimation(fig, update, interval=interval_ms, blit=False)
+    global _ANIMATION
+    _ANIMATION = FuncAnimation(fig, update, interval=interval_ms, blit=False)
 
     try:
         plt.show()

--- a/controls/sae_2025_ws/src/sim/launch/sim.launch.py
+++ b/controls/sae_2025_ws/src/sim/launch/sim.launch.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+from typing import Any
 
 import launch
 from launch import LaunchDescription
@@ -133,7 +134,7 @@ def launch_setup(context, *args, **kwargs):
     server_config_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "server.config"
     )
-    gz_sim_env = {
+    gz_sim_env: dict[Any, Any] = {
         "GZ_SIM_RESOURCE_PATH": os.path.join(model_store, "models"),
         "GZ_SIM_SERVER_CONFIG_PATH": server_config_path,
     }

--- a/controls/sae_2025_ws/src/sim/sim/orchestration.py
+++ b/controls/sae_2025_ws/src/sim/sim/orchestration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -124,8 +125,8 @@ def resolve_stage_world(
     *,
     world_name: str,
     mission_stage: str | None = "",
-    world_overrides: dict[str, Any] | None = None,
-    logger=None,
+    world_overrides: object | None = None,
+    logger: logging.Logger | None = None,
 ) -> dict[str, Any]:
     resolved_world_name = str(world_name).strip()
     if not resolved_world_name:
@@ -141,7 +142,7 @@ def resolve_stage_world(
 
     sim_stage_params, sim_config_path = load_sim_parameters(
         resolved_world_name,
-        logger=logger,
+        logger=logger or logging.getLogger(__name__),
         competition_name=resolved_world_name,
         mission_stage=resolved_stage,
     )

--- a/controls/sae_2025_ws/src/sim/sim/scoring/HoopScore.py
+++ b/controls/sae_2025_ws/src/sim/sim/scoring/HoopScore.py
@@ -151,13 +151,12 @@ class HoopScoringNode(ScoringNode):
             # rclpy.spin_until_future_complete(self, future)
             # rclpy.spin_until_future_complete(self, future)
 
-            if future.result() is None:
+            response = future.result()
+            if response is None:
                 self.get_logger().error(
                     f"'list_hoops' failed with exception: {future.exception()}"
                 )
                 raise RuntimeError("Service call to 'list_hoops' failed")
-
-            response = future.result()
 
             # Expecting response.hoops to be a list of HoopPose messages
             self.hoop_poses = []

--- a/controls/sae_2025_ws/src/sim/sim/utils.py
+++ b/controls/sae_2025_ws/src/sim/sim/utils.py
@@ -237,6 +237,7 @@ def find_package_resource(
             return path
 
     # Fallback to installed location (for production/deployed packages)
+    installed_path: Path | None = None
     try:
         from ament_index_python.packages import get_package_share_directory
 
@@ -264,9 +265,6 @@ def find_package_resource(
             logger.debug(f"Could not get package share directory: {e}")
 
     # If not found, raise error
-    all_paths = source_paths + [
-        installed_path if "installed_path" in locals() else "N/A"
-    ]
     resource_name = relative_path.name if relative_path.name else str(relative_path)
     raise FileNotFoundError(
         f"{resource_type.capitalize()} '{resource_name}' not found. "

--- a/controls/sae_2025_ws/src/sim/sim/world_gen/HoopCourse.py
+++ b/controls/sae_2025_ws/src/sim/sim/world_gen/HoopCourse.py
@@ -23,7 +23,7 @@ class CourseStyle(ABC):
         uav: Tuple[float, float, float],
         num_hoops: int,
         max_dist: int,
-        height: int,
+        height: float,
         rng: Optional[random.Random] = None,
     ):
         self.dlz = dlz
@@ -48,7 +48,7 @@ class AscentCourse(CourseStyle):
         uav: Tuple[float, float, float],
         num_hoops: int,
         max_dist: int,
-        start_height: int,
+        start_height: float,
         rng: Optional[random.Random] = None,
     ):
         super().__init__(dlz, uav, num_hoops, max_dist, start_height, rng)
@@ -107,7 +107,7 @@ class DescentCourse(CourseStyle):
         uav: Tuple[float, float, float],
         num_hoops: int,
         max_dist: int,
-        start_height: int,
+        start_height: float,
         rng: Optional[random.Random] = None,
     ):
         super().__init__(dlz, uav, num_hoops, max_dist, start_height, rng)
@@ -169,7 +169,7 @@ class SlalomCourse(CourseStyle):
         num_hoops: int,
         max_dist: int,
         width: int,
-        height: int,
+        height: float,
         rng: Optional[random.Random] = None,
     ):
         super().__init__(dlz, uav, num_hoops, max_dist, height, rng)
@@ -417,7 +417,7 @@ class HoopCourseNode(WorldNode):
         num_hoops: int,
         max_dist: int,
         template_world: str,
-        height: int,
+        height: float,
         physics: Optional[dict] = None,
         output_filename: Optional[str] = None,
         seed: Optional[int] = None,
@@ -551,7 +551,7 @@ class HoopCourseNode(WorldNode):
             )
         return dlz_entities
 
-    def generate_world(self) -> None:
+    def generate_world(self) -> bool:
         """
         Generate the world file with hoops and DLZs.
 
@@ -567,7 +567,7 @@ class HoopCourseNode(WorldNode):
 
             if self.course.lower() == "previous":
                 self.get_logger().info("Using previous world configuration")
-                return
+                return True
 
             elif self.course.lower() == "ascent":
                 course = AscentCourse(

--- a/controls/sae_2025_ws/src/sim/test/test_orchestration.py
+++ b/controls/sae_2025_ws/src/sim/test/test_orchestration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 
 package_root = Path(__file__).resolve().parents[1]
 if str(package_root) not in sys.path:
@@ -350,8 +351,9 @@ def test_resolve_stage_world_loads_specific_stage_and_merges_world_overrides(
 
 
 def test_resolve_stage_world_rejects_non_mapping_overrides():
+    bad_overrides: Any = ["bad"]
     try:
-        resolve_stage_world(world_name="sae", world_overrides=["bad"])
+        resolve_stage_world(world_name="sae", world_overrides=bad_overrides)
     except ValueError as exc:
         assert "world_overrides must be a mapping" in str(exc)
     else:

--- a/controls/sae_2025_ws/src/udp_bridge/udp_bridge/bridge_node.py
+++ b/controls/sae_2025_ws/src/udp_bridge/udp_bridge/bridge_node.py
@@ -31,6 +31,7 @@ Packet wire format
     Bytes 3-6  : sequence number (big-endian uint32)
 """
 
+from collections.abc import Sequence
 import socket
 import struct
 import threading
@@ -51,6 +52,61 @@ _PING_INTERVAL_S = 1.0
 _DEFAULT_PEER_TTL_S = 3.0  # 3× ping interval — tolerates 2 dropped pings
 
 
+def _parameter_value(node: Node, name: str) -> object:
+    return node.get_parameter(name).value
+
+
+def _int_parameter(node: Node, name: str) -> int:
+    value = _parameter_value(node, name)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"Parameter {name!r} must be an integer.")
+    return value
+
+
+def _int_list_parameter(node: Node, name: str) -> list[int]:
+    value = _parameter_value(node, name)
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"Parameter {name!r} must be an integer array.")
+
+    result: list[int] = []
+    for item in value:
+        if isinstance(item, bool) or not isinstance(item, int):
+            raise ValueError(f"Parameter {name!r} must contain only integers.")
+        result.append(item)
+    return result
+
+
+def _str_parameter(node: Node, name: str) -> str:
+    value = _parameter_value(node, name)
+    if not isinstance(value, str):
+        raise ValueError(f"Parameter {name!r} must be a string.")
+    return value
+
+
+def _str_list_parameter(
+    node: Node, name: str, *, default: list[str] | None = None
+) -> list[str]:
+    value = _parameter_value(node, name)
+    if value is None and default is not None:
+        return list(default)
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"Parameter {name!r} must be a string array.")
+
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"Parameter {name!r} must contain only strings.")
+        result.append(item)
+    return result
+
+
+def _float_parameter(node: Node, name: str) -> float:
+    value = _parameter_value(node, name)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"Parameter {name!r} must be numeric.")
+    return float(value)
+
+
 class BridgeNode(Node):
     def __init__(self):
         super().__init__("udp_bridge")
@@ -61,11 +117,11 @@ class BridgeNode(Node):
         self.declare_parameter("topics", rclpy.Parameter.Type.STRING_ARRAY)
         self.declare_parameter("peer_ttl", _DEFAULT_PEER_TTL_S)
 
-        self._my_port: int = self.get_parameter("my_port").value
-        all_ports: list[int] = list(self.get_parameter("all_ports").value)
-        self._broadcast_ip: str = self.get_parameter("broadcast_ip").value
+        self._my_port = _int_parameter(self, "my_port")
+        all_ports = _int_list_parameter(self, "all_ports")
+        self._broadcast_ip = _str_parameter(self, "broadcast_ip")
         self._peer_ports: list[int] = [p for p in all_ports if p != self._my_port]
-        self._peer_ttl: float = float(self.get_parameter("peer_ttl").value)
+        self._peer_ttl = _float_parameter(self, "peer_ttl")
         self._ping_seq = 0
         self._stop = threading.Event()
 
@@ -79,8 +135,7 @@ class BridgeNode(Node):
         self._in_publishers: list = []  # indexed by topic_id
         self._out_subscribers: list = []  # keep refs so they aren't GC'd
 
-        _topics_raw = self.get_parameter("topics").value
-        topics_param: list[str] = list(_topics_raw) if _topics_raw is not None else []
+        topics_param = _str_list_parameter(self, "topics", default=[])
         for i, entry in enumerate(topics_param):
             if ":" not in entry:
                 raise ValueError(


### PR DESCRIPTION
Refs #210.
Refs #212.
Refs #214.
Refs #216.
Part of #201.

## Summary
- Add typed ROS parameter extraction helpers for UDP bridge configuration.
- Keep the payload motor-state plot animation alive in module state.
- Normalize payload/sim launch typing for mixed launch API values.
- Tighten sim package typing around world overrides, resource lookup, scoring, and world generation.
- Folded #211, #213, and #215 into this PR as separate commits.

## Verification
- Constituent focused Pyright, compile, ruff, and sim pytest checks passed when created.
- Integrated sim pytest after condensation: 23 passed, 0 failed.
