### PR TITLE
Type integration backend and deploy helpers

### DIFF
--- a/controls/sae_2025_ws/src/integration/backend/config.py
+++ b/controls/sae_2025_ws/src/integration/backend/config.py
@@ -30,6 +30,22 @@ def _normalize_fleet_file(value: object) -> str:
     return Path(raw.replace("\\", "/")).name.strip()
 
 
+def _optional_float(value: object, *, field: str) -> float | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float | str):
+        raise ValueError(f"{field} must be numeric when provided.")
+    return float(value)
+
+
+def _optional_int(value: object, *, field: str) -> int | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float | str):
+        raise ValueError(f"{field} must be an integer when provided.")
+    return int(value)
+
+
 @dataclass(slots=True)
 class OperatorConfig:
     github_repo: str
@@ -608,21 +624,16 @@ class BuildSourceRecord:
             name=str(payload.get("name", "")).strip(),
             date=str(payload.get("date", "")).strip(),
             download_url=str(payload.get("download_url", "")).strip(),
-            size_mb=(
-                float(payload["size_mb"])
-                if payload.get("size_mb") not in (None, "")
-                else None
-            ),
+            size_mb=_optional_float(payload.get("size_mb"), field="size_mb"),
             branch=str(payload.get("branch", "")).strip(),
             artifact_name=str(payload.get("artifact_name", "")).strip(),
             workflow_name=str(payload.get("workflow_name", "")).strip(),
             workflow_event=str(payload.get("workflow_event", "")).strip(),
             workflow_conclusion=str(payload.get("workflow_conclusion", "")).strip(),
             local_artifact_path=str(payload.get("local_artifact_path", "")).strip(),
-            local_artifact_size_bytes=(
-                int(payload["local_artifact_size_bytes"])
-                if payload.get("local_artifact_size_bytes") not in (None, "")
-                else None
+            local_artifact_size_bytes=_optional_int(
+                payload.get("local_artifact_size_bytes"),
+                field="local_artifact_size_bytes",
             ),
             codebase_root=str(payload.get("codebase_root", "")).strip(),
             fleet_file=fleet_file,

--- a/controls/sae_2025_ws/src/integration/backend/discovery.py
+++ b/controls/sae_2025_ws/src/integration/backend/discovery.py
@@ -29,7 +29,7 @@ _DISCOVERY_SNAPSHOT: dict[str, dict[str, object]] = {}
 
 def _require_zeroconf():
     try:
-        from zeroconf import IPVersion, ServiceBrowser, ServiceListener, Zeroconf
+        from zeroconf import IPVersion, ServiceBrowser, ServiceListener, Zeroconf  # pyright: ignore[reportMissingImports]
     except ModuleNotFoundError as exc:
         raise RuntimeError(
             "Missing Python dependency `zeroconf`. "
@@ -91,10 +91,29 @@ def _snapshot_key(hostname: str) -> str:
     return normalized or (hostname or "").strip().lower()
 
 
+def _float_snapshot_value(
+    entry: dict[str, object], key: str, *, default: float = 0.0
+) -> float:
+    value = entry.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int | float | str):
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def _string_sequence_value(entry: dict[str, object], key: str) -> list[str]:
+    value = entry.get(key, [])
+    if not isinstance(value, list | tuple | set):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
 def _mark_snapshot_stale(now_monotonic: float | None = None) -> None:
     now_value = now_monotonic if now_monotonic is not None else time.monotonic()
     for key, entry in list(_DISCOVERY_SNAPSHOT.items()):
-        last_seen = float(entry.get("last_seen_monotonic", 0.0) or 0.0)
+        last_seen = _float_snapshot_value(entry, "last_seen_monotonic")
         age = (
             now_value - last_seen if last_seen else _DISCOVERY_STALE_WINDOW_SECONDS + 1
         )
@@ -107,7 +126,7 @@ def _mark_snapshot_stale(now_monotonic: float | None = None) -> None:
 def _prune_snapshot(now_monotonic: float | None = None) -> None:
     now_value = now_monotonic if now_monotonic is not None else time.monotonic()
     for key, entry in list(_DISCOVERY_SNAPSHOT.items()):
-        last_seen = float(entry.get("last_seen_monotonic", 0.0) or 0.0)
+        last_seen = _float_snapshot_value(entry, "last_seen_monotonic")
         age = (
             now_value - last_seen if last_seen else _DISCOVERY_STALE_WINDOW_SECONDS + 1
         )
@@ -142,7 +161,7 @@ def _update_snapshot(discovered: list[_DiscoveredService]) -> None:
         if key in fresh_keys:
             entry["discovery_stale"] = False
             continue
-        last_seen = float(entry.get("last_seen_monotonic", 0.0) or 0.0)
+        last_seen = _float_snapshot_value(entry, "last_seen_monotonic")
         age = (
             now_monotonic - last_seen
             if last_seen
@@ -169,7 +188,7 @@ def _snapshot_cards(ctx: AppContext) -> list[dict[str, object]]:
                     entry.get("hardware_id") or _snapshot_key(hostname) or hostname
                 ),
                 "hostname": hostname,
-                "addresses": list(entry.get("addresses", []) or []),
+                "addresses": _string_sequence_value(entry, "addresses"),
                 "service_name": entry.get("service_name"),
                 "service_type": entry.get("service_type"),
                 "last_seen_at": entry.get("last_seen_at"),
@@ -264,7 +283,7 @@ def _resolve_socket_addresses(hostname: str) -> set[str]:
         for info in socket.getaddrinfo(hostname, None, family=socket.AF_UNSPEC):
             sockaddr = info[4]
             if isinstance(sockaddr, tuple) and sockaddr:
-                addresses.add(sockaddr[0])
+                addresses.add(str(sockaddr[0]))
     except OSError:
         return set()
     return addresses
@@ -300,7 +319,7 @@ def _browse_services_zeroconf(timeout_s: float) -> list[_DiscoveredService]:
                 self.found[key] = record
             addresses = info.parsed_addresses(IPVersion.All) or []
             for address in addresses:
-                record.addresses.add(address)
+                record.addresses.add(str(address))
 
     zeroconf = Zeroconf(ip_version=IPVersion.All)
     listener = Listener(zeroconf)

--- a/controls/sae_2025_ws/src/integration/backend/routers/config.py
+++ b/controls/sae_2025_ws/src/integration/backend/routers/config.py
@@ -8,6 +8,7 @@ from ..context import AppContext
 from ..models import (
     ConfigResponse,
     MessageResponse,
+    OperatorConfigPayload,
 )
 
 
@@ -17,7 +18,9 @@ def build_router(ctx: AppContext) -> APIRouter:
     @router.get("", response_model=ConfigResponse)
     async def get_config() -> ConfigResponse:
         return ConfigResponse(
-            config=ctx.operator_config.to_safe_dict(),
+            config=OperatorConfigPayload.model_validate(
+                ctx.operator_config.to_safe_dict()
+            ),
         )
 
     @router.post("", response_model=MessageResponse)

--- a/controls/sae_2025_ws/src/integration/backend/routers/discovery.py
+++ b/controls/sae_2025_ws/src/integration/backend/routers/discovery.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from ..context import AppContext
-from ..models import HardwareDiscoveryResponse
+from ..models import HardwareDiscoveryResponse, LiveHardwareDeviceResponse
 
 
 def build_router(ctx: AppContext) -> APIRouter:
@@ -15,7 +15,13 @@ def build_router(ctx: AppContext) -> APIRouter:
 
         try:
             devices = await discovery.live_hardware_cards(ctx)
-            return HardwareDiscoveryResponse(success=True, devices=devices)
+            return HardwareDiscoveryResponse(
+                success=True,
+                devices=[
+                    LiveHardwareDeviceResponse.model_validate(device)
+                    for device in devices
+                ],
+            )
         except Exception as exc:
             return HardwareDiscoveryResponse(success=False, error=str(exc))
 

--- a/controls/sae_2025_ws/src/integration/backend/routers/inventory.py
+++ b/controls/sae_2025_ws/src/integration/backend/routers/inventory.py
@@ -109,20 +109,32 @@ def build_router(ctx: AppContext) -> APIRouter:
                 replace_existing=str(replace_existing or "").strip().lower()
                 in {"1", "true", "yes", "on"},
             )
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
         except json.JSONDecodeError as exc:
             raise HTTPException(
                 status_code=400,
                 detail="Inventory import file must be valid JSON.",
             ) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        imported_count_value = summary.get("targets_imported", 0)
+        imported_count = (
+            imported_count_value if isinstance(imported_count_value, int) else 0
+        )
+        target_ids_value = summary.get("target_ids", [])
+        target_ids = (
+            [str(target_id) for target_id in target_ids_value]
+            if isinstance(target_ids_value, list)
+            else []
+        )
+        active_target_id_value = summary.get("active_target_id")
+        active_target_id = (
+            active_target_id_value if isinstance(active_target_id_value, str) else None
+        )
 
         return InventoryMutationResponse(
-            output=(
-                f"Imported {summary['targets_imported']} target(s): "
-                + ", ".join(summary["target_ids"])
-            ),
-            active_target_id=summary["active_target_id"],
+            output=(f"Imported {imported_count} target(s): " + ", ".join(target_ids)),
+            active_target_id=active_target_id,
         )
 
     return router

--- a/controls/sae_2025_ws/src/integration/backend/services/__init__.py
+++ b/controls/sae_2025_ws/src/integration/backend/services/__init__.py
@@ -1,4 +1,11 @@
 from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from . import deploy as deploy
+    from . import fleet as fleet
+    from . import mission as mission
+    from . import wifi as wifi
 
 __all__ = ["wifi", "deploy", "mission", "fleet"]
 
@@ -10,7 +17,7 @@ _EXPORTS = {
 }
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     module_path = _EXPORTS.get(name)
     if module_path is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/controls/sae_2025_ws/src/integration/backend/services/deploy.py
+++ b/controls/sae_2025_ws/src/integration/backend/services/deploy.py
@@ -13,14 +13,27 @@ import xml.etree.ElementTree as ET
 import zipfile
 from copy import deepcopy
 from pathlib import Path
+from typing import TypedDict
 
 import yaml
 
 from ..context import AppContext, TargetContext
-from ..mission_compat import load_mission_spec_compat
-from ..models import RuntimeNetworkPolicyOverride
+from ..mission_compat import MissionSpecCompat, load_mission_spec_compat
+from ..models import ApSelection, NetworkRole, RuntimeNetworkPolicyOverride
 from uav.runtime.fleet_spec import load_fleet_document
-from uav.runtime.mission_spec import MissionSpec
+from uav.runtime.mission_spec import MissionSpec  # noqa: F401
+
+
+class _FleetNetworkPolicy(TypedDict):
+    network_role: NetworkRole | None
+    allowed_ap_vehicles: list[str]
+    ap_selection: ApSelection | None
+
+
+class _FleetCatalogCachePayload(TypedDict):
+    catalog: dict[str, Path]
+    source: str | None
+
 
 _ARTIFACT_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 _SOURCE_BUNDLE_EXTENSIONS = (".tar.gz", ".tgz", ".zip")
@@ -54,7 +67,7 @@ _FLEET_CATALOG_CACHE_TTL_SECONDS = 60.0
 _COMMIT_SUBJECT_CACHE_TTL_SECONDS = 1800.0
 _WORKFLOW_RUN_CACHE_TTL_SECONDS = 1800.0
 _BUILD_LIST_CACHE: dict[tuple[object, ...], tuple[float, dict[str, object]]] = {}
-_FLEET_CATALOG_CACHE: dict[str, tuple[float, dict[str, object]]] = {}
+_FLEET_CATALOG_CACHE: dict[str, tuple[float, _FleetCatalogCachePayload]] = {}
 _COMMIT_SUBJECT_CACHE: dict[str, tuple[float, str | None]] = {}
 _WORKFLOW_RUN_CACHE: dict[str, tuple[float, dict[str, object] | None]] = {}
 
@@ -105,14 +118,24 @@ def _normalize_vehicle_name(value: object) -> str:
     return str(value or "").strip()
 
 
-def _normalize_network_role(value: object) -> str | None:
+def _normalize_network_role(value: object) -> NetworkRole | None:
     candidate = str(value or "").strip().lower()
-    return candidate if candidate in {"default", "ap", "client"} else None
+    if candidate == "default":
+        return "default"
+    if candidate == "ap":
+        return "ap"
+    if candidate == "client":
+        return "client"
+    return None
 
 
-def _normalize_ap_selection(value: object) -> str | None:
+def _normalize_ap_selection(value: object) -> ApSelection | None:
     candidate = str(value or "").strip().lower()
-    return candidate if candidate in {"ordered_then_strongest", "strongest"} else None
+    if candidate == "ordered_then_strongest":
+        return "ordered_then_strongest"
+    if candidate == "strongest":
+        return "strongest"
+    return None
 
 
 def _normalize_vehicle_name_list(value: object) -> list[str]:
@@ -144,11 +167,16 @@ def _normalize_vehicle_name_list(value: object) -> list[str]:
     return normalized
 
 
+def _fleet_vehicle_entries(shared_fleet: dict[str, object]) -> list[dict[str, object]]:
+    vehicles = shared_fleet.get("vehicles", [])
+    if not isinstance(vehicles, list):
+        return []
+    return [vehicle for vehicle in vehicles if isinstance(vehicle, dict)]
+
+
 def _fleet_vehicle_names(shared_fleet: dict[str, object]) -> list[str]:
     names: list[str] = []
-    for vehicle in shared_fleet.get("vehicles", []) or []:
-        if not isinstance(vehicle, dict):
-            continue
+    for vehicle in _fleet_vehicle_entries(shared_fleet):
         name = _normalize_vehicle_name(vehicle.get("name"))
         if name:
             names.append(name)
@@ -157,7 +185,7 @@ def _fleet_vehicle_names(shared_fleet: dict[str, object]) -> list[str]:
 
 def _fleet_network_policy_from_merged_vehicle(
     merged_vehicle: dict[str, object],
-) -> dict[str, object]:
+) -> _FleetNetworkPolicy:
     return {
         "network_role": _normalize_network_role(merged_vehicle.get("network_role")),
         "allowed_ap_vehicles": _normalize_vehicle_name_list(
@@ -170,11 +198,9 @@ def _fleet_network_policy_from_merged_vehicle(
 def _fleet_network_policy_lookup(
     shared_fleet: dict[str, object],
     fleet_defaults: dict[str, object],
-) -> dict[str, dict[str, object]]:
-    policies: dict[str, dict[str, object]] = {}
-    for vehicle in shared_fleet.get("vehicles", []) or []:
-        if not isinstance(vehicle, dict):
-            continue
+) -> dict[str, _FleetNetworkPolicy]:
+    policies: dict[str, _FleetNetworkPolicy] = {}
+    for vehicle in _fleet_vehicle_entries(shared_fleet):
         name = _normalize_vehicle_name(vehicle.get("name"))
         if not name:
             continue
@@ -188,8 +214,8 @@ def _fleet_allowed_ap_vehicle_names(
     *,
     shared_fleet: dict[str, object],
     vehicle_name: str,
-    vehicle_policy: dict[str, object],
-    policy_lookup: dict[str, dict[str, object]],
+    vehicle_policy: _FleetNetworkPolicy,
+    policy_lookup: dict[str, _FleetNetworkPolicy],
 ) -> list[str]:
     explicit = [
         candidate
@@ -249,7 +275,7 @@ def _resolve_fleet_allowed_ap_hosts(
     *,
     target_ctx: TargetContext,
     vehicle_name: str,
-    policy_lookup: dict[str, dict[str, object]],
+    policy_lookup: dict[str, _FleetNetworkPolicy],
     candidate_vehicles: list[str],
     error_prefix: str,
     empty_resolution_message: str,
@@ -846,7 +872,7 @@ def _build_list_cache_set(
 
 def _fleet_catalog_cache_get(
     cache_key: str, *, allow_stale: bool = False
-) -> dict[str, object] | None:
+) -> _FleetCatalogCachePayload | None:
     cached = _FLEET_CATALOG_CACHE.get(cache_key)
     if cached is None:
         return None
@@ -858,8 +884,8 @@ def _fleet_catalog_cache_get(
 
 
 def _fleet_catalog_cache_set(
-    cache_key: str, payload: dict[str, object]
-) -> dict[str, object]:
+    cache_key: str, payload: _FleetCatalogCachePayload
+) -> _FleetCatalogCachePayload:
     cached_payload = deepcopy(payload)
     _FLEET_CATALOG_CACHE[cache_key] = (monotonic(), cached_payload)
     return deepcopy(cached_payload)
@@ -905,6 +931,8 @@ def _github_error_message(
     response = getattr(exc, "response", None)
     status_code = getattr(response, "status_code", None)
     if status_code != 403:
+        return None
+    if response is None:
         return None
 
     message = ""
@@ -1108,8 +1136,8 @@ def _runtime_vehicle_from_config(
         "auto_launch": _bool_value(merged_vehicle.get("auto_launch"), default=False),
         "debug": _bool_value(merged_vehicle.get("debug"), default=False),
         "vision_debug": _bool_value(merged_vehicle.get("vision_debug"), default=False),
-        "save_vision_milliseconds": int(
-            merged_vehicle.get("save_vision_milliseconds", 0) or 0
+        "save_vision_milliseconds": _int_value(
+            merged_vehicle.get("save_vision_milliseconds"), default=0
         ),
         "servo_only": _bool_value(merged_vehicle.get("servo_only"), default=False),
         "camera_mount_offsets": _normalized_camera_offsets(
@@ -1118,11 +1146,9 @@ def _runtime_vehicle_from_config(
         "camera_input_transport": str(
             merged_vehicle.get("camera_input_transport", "compressed")
         ).strip(),
-        "camera_rotate_degrees": float(
-            merged_vehicle.get(
-                "camera_rotate_degrees", 180.0 if mission_target == "payload" else 0.0
-            )
-            or 0.0
+        "camera_rotate_degrees": _float_value(
+            merged_vehicle.get("camera_rotate_degrees"),
+            default=180.0 if mission_target == "payload" else 0.0,
         ),
         "camera_preprocess_hook": str(
             merged_vehicle.get("camera_preprocess_hook", "")
@@ -1136,7 +1162,7 @@ def _runtime_vehicle_from_config(
     if mission_target == "uav":
         px4_airframe_id = merged_vehicle.get("px4_airframe_id")
         runtime_vehicle["px4_airframe_id"] = (
-            int(px4_airframe_id) if px4_airframe_id is not None else None
+            _int_value(px4_airframe_id) if px4_airframe_id is not None else None
         )
         runtime_vehicle["px4_namespace"] = (
             str(merged_vehicle.get("px4_namespace", vehicle_name)).strip()
@@ -1175,7 +1201,9 @@ def _fleet_preview(ctx: AppContext, fleet_file: str) -> dict[str, object]:
             merged = deepcopy(defaults)
             merged.update(vehicle)
             vehicle_name = str(vehicle.get("name", "")).strip()
-            fleet_policy = policy_lookup.get(vehicle_name, {})
+            fleet_policy = policy_lookup.get(
+                vehicle_name
+            ) or _fleet_network_policy_from_merged_vehicle(merged)
             try:
                 runtime_vehicle, local_mission_path, _ = _runtime_vehicle_from_config(
                     ctx,
@@ -1255,7 +1283,7 @@ def _vehicle_from_fleet(fleet: dict, vehicle_name: str) -> dict:
 
 def _mission_source_for(
     ctx: AppContext, vehicle: dict
-) -> tuple[str, Path, MissionSpec]:
+) -> tuple[str, Path, MissionSpecCompat]:
     mission_path = str(vehicle.get("mission_path", "")).strip()
     if mission_path:
         local_path = _resolve_local_path(ctx, mission_path)
@@ -1275,6 +1303,22 @@ def _normalized_camera_offsets(value: object) -> list[float]:
     if isinstance(value, list) and len(value) == 3:
         return [float(component) for component in value]
     return [0.0, 0.0, 0.0]
+
+
+def _int_value(value: object, *, default: int = 0) -> int:
+    if value in (None, ""):
+        return default
+    if isinstance(value, bool) or not isinstance(value, int | float | str):
+        raise ValueError(f"Expected integer value, received {value!r}.")
+    return int(value)
+
+
+def _float_value(value: object, *, default: float = 0.0) -> float:
+    if value in (None, ""):
+        return default
+    if isinstance(value, bool) or not isinstance(value, int | float | str):
+        raise ValueError(f"Expected numeric value, received {value!r}.")
+    return float(value)
 
 
 def _bool_value(value: object, *, default: bool) -> bool:
@@ -2672,10 +2716,11 @@ async def set_global_fleet_file(
             success=True,
             output=f"Fleet selected: {selected}",
         )
-        if response.get("source"):
-            response["source"]["fleet_catalog_source"] = catalog_source
-            response["source"]["available_fleets"] = sorted(catalog_lookup)
-            response["source"]["fleet_options"] = sorted(catalog_lookup)
+        source_payload = response.get("source")
+        if isinstance(source_payload, dict):
+            source_payload["fleet_catalog_source"] = catalog_source
+            source_payload["available_fleets"] = sorted(catalog_lookup)
+            source_payload["fleet_options"] = sorted(catalog_lookup)
         return response
     except Exception as exc:
         return _build_source_response(
@@ -3155,7 +3200,7 @@ async def list_builds(
                 return None
             cached_subject = _commit_subject_cache_get(commit_sha)
             if cached_subject is not ...:
-                return cached_subject
+                return cached_subject if isinstance(cached_subject, str) else None
             if commit_lookup_rate_limited:
                 return None
             try:
@@ -3189,7 +3234,7 @@ async def list_builds(
                 return None
             cached_run = _workflow_run_cache_get(run_id)
             if cached_run is not ...:
-                return cached_run
+                return cached_run if isinstance(cached_run, dict) else None
             if workflow_lookup_rate_limited:
                 return None
             try:
@@ -3262,7 +3307,7 @@ async def list_builds(
                 if commit_sha:
                     artifact_commit_shas.append(commit_sha)
 
-            unique_commit_shas = {
+            unique_commit_shas: dict[str, str | None] = {
                 sha: None for sha in (release_commit_shas + artifact_commit_shas) if sha
             }
             for commit_sha in unique_commit_shas:
@@ -3397,11 +3442,11 @@ async def download_build(
         return {"success": False, "error": "GITHUB_REPO not configured"}
 
     tmp_path = ""
+    extract_dir: Path | None = None
     try:
         httpx = _require_httpx()
         headers = _github_headers(ctx)
         artifact_name = ""
-        extract_dir: Path | None = None
         async with httpx.AsyncClient(timeout=300, follow_redirects=True) as client:
             if source == "actions":
                 if not artifact_id:
@@ -3480,7 +3525,7 @@ async def download_build(
     finally:
         if tmp_path and os.path.exists(tmp_path):
             os.unlink(tmp_path)
-        if "extract_dir" in locals() and extract_dir is not None:
+        if extract_dir is not None:
             shutil.rmtree(extract_dir, ignore_errors=True)
 
 

--- a/controls/sae_2025_ws/src/integration/backend/services/deploy.py
+++ b/controls/sae_2025_ws/src/integration/backend/services/deploy.py
@@ -929,10 +929,10 @@ def _github_error_message(
     during_commit_lookup: bool = False,
 ) -> str | None:
     response = getattr(exc, "response", None)
+    if response is None:
+        return None
     status_code = getattr(response, "status_code", None)
     if status_code != 403:
-        return None
-    if response is None:
         return None
 
     message = ""


### PR DESCRIPTION
Fixes #220.
Fixes #228.
Part of #201.

## Summary
- Type JSON-backed build source and discovery/config response fields.
- Expose lazy integration service exports to type checkers.
- Type fleet network policies, catalog cache payloads, YAML/JSON narrowing, and deploy archive cleanup state.
- Folded #229 into this PR as a separate commit.

## Verification
- Constituent focused Pyright, compile, ruff, and integration pytest checks from #221 and #229 passed when created.
- Integrated workspace Pyright baseline after condensation: 161 files analyzed, 0 errors, 0 warnings.
