### PR TITLE
Type UAV launch helpers

### DIFF
--- a/controls/sae_2025_ws/src/uav/launch/main.launch.py
+++ b/controls/sae_2025_ws/src/uav/launch/main.launch.py
@@ -228,7 +228,7 @@ def _single_vehicle_config(context, params: dict) -> tuple[dict, dict | None]:
     airframe_id = None
     if mission_spec.is_uav:
         airframe_id = _resolve_airframe_id(params.get("airframe", "quadcopter"))
-        vehicle_class, _, airframe_model = get_airframe_details(px4_path, airframe_id)
+        vehicle_class, airframe_model = get_airframe_details(px4_path, airframe_id)
         vehicle_class_name = vehicle_class.name
         if not model:
             model = airframe_model

--- a/controls/sae_2025_ws/src/uav/launch/vehicle_stack.launch.py
+++ b/controls/sae_2025_ws/src/uav/launch/vehicle_stack.launch.py
@@ -19,6 +19,7 @@ from launch_ros.actions import Node
 
 from uav.runtime.mission_spec import MissionSpec, mission_path_for_name
 from uav.runtime.vision_loader import load_vision_class
+from uav.vehicles.AirframeClass import AirframeClass
 from uav.utils import (
     camel_to_snake,
     find_folder_with_heuristic,
@@ -151,9 +152,13 @@ def _resolve_airframe_id(config: dict) -> int:
             raise ValueError(f"Unknown airframe name: {airframe_value}") from exc
 
 
-def _resolve_uav_airframe(config: dict, px4_path: str) -> tuple[object, int, str]:
+def _resolve_uav_airframe(
+    config: dict, px4_path: str
+) -> tuple[AirframeClass, int, str]:
     airframe_id = _resolve_airframe_id(config)
     vehicle_class, model_name = get_airframe_details(px4_path, airframe_id)
+    if not isinstance(vehicle_class, AirframeClass):
+        raise ValueError(f"Unexpected airframe class: {vehicle_class!r}.")
     model = str(config.get("model", "")).strip() or model_name
     return vehicle_class, int(airframe_id), model
 
@@ -267,12 +272,13 @@ def _build_camera_actions(
 ) -> list:
     save_vision = save_vision_milliseconds > 0
     actions = []
+    vehicle_name = str(camera_contract["vehicle_name"])
 
     if sim:
         actions.extend(
             _sim_camera_bridge_actions(
                 world_name=sim_world_name,
-                vehicle_name=str(camera_contract["vehicle_name"]),
+                vehicle_name=vehicle_name,
                 sim_entity_name=sim_entity_name,
                 mission_target=str(camera_contract["mission_target"]),
             )
@@ -350,8 +356,8 @@ def _build_camera_actions(
         Node(
             package="uav",
             executable="camera",
-            namespace=camera_contract["vehicle_name"],
-            name=f"{camera_contract['vehicle_name']}_camera",
+            namespace=vehicle_name,
+            name=f"{vehicle_name}_camera",
             output="screen",
             parameters=[camera_parameters],
         )
@@ -371,8 +377,8 @@ def _build_camera_actions(
             Node(
                 package="uav",
                 executable=executable,
-                namespace=camera_contract["vehicle_name"],
-                name=f"{camera_contract['vehicle_name']}_{executable}",
+                namespace=vehicle_name,
+                name=f"{vehicle_name}_{executable}",
                 output="screen",
                 parameters=[
                     {
@@ -594,8 +600,8 @@ def launch_setup(context, *args, **kwargs):
     ) or _resolve_force_camera(config, logger=logger)
 
     px4_path = ""
-    vehicle_class = None
-    autostart = None
+    vehicle_class: AirframeClass | None = None
+    autostart: int | None = None
     model = str(config.get("model", "")).strip()
     if mission_spec.is_uav:
         px4_path = find_folder_with_heuristic(
@@ -645,8 +651,11 @@ def launch_setup(context, *args, **kwargs):
             "v4l2_camera will fall back to its default camera_info behavior."
         )
 
-    camera_actions = (
-        _build_camera_actions(
+    camera_actions = []
+    if requires_camera:
+        if camera_contract is None:
+            raise ValueError(f"Vehicle '{vehicle_name}' requires a camera contract.")
+        camera_actions = _build_camera_actions(
             mission_spec=mission_spec,
             camera_contract=camera_contract,
             vision_nodes=list(mission_spec.vision_nodes),
@@ -657,9 +666,6 @@ def launch_setup(context, *args, **kwargs):
             debug_vision_node=debug_vision_node,
             save_vision_milliseconds=save_vision_milliseconds,
         )
-        if requires_camera
-        else []
-    )
 
     mission_node = Node(
         package="uav",
@@ -732,6 +738,10 @@ def launch_setup(context, *args, **kwargs):
         actions.append(_middleware_action(sim=sim, config=config))
 
     if mission_spec.is_uav and launch_px4_sitl:
+        if autostart is None:
+            raise ValueError(
+                f"Vehicle '{vehicle_name}' cannot launch PX4 SITL without a valid UAV airframe."
+            )
         actions.append(
             _px4_sitl_action(
                 px4_path=px4_path,

--- a/controls/sae_2025_ws/src/uav/setup.py
+++ b/controls/sae_2025_ws/src/uav/setup.py
@@ -2,6 +2,7 @@ from glob import glob
 import os
 from pathlib import Path
 import sys
+from typing import Protocol, cast
 
 from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py as _build_py
@@ -10,6 +11,10 @@ from setuptools.command.install import install as _install
 
 package_name = "uav"
 _SCHEMA_REGISTRY_REFRESHED = False
+
+
+class _CommandWithRun(Protocol):
+    def run(self) -> None: ...
 
 
 def _missing_pydantic_v2(exc: ImportError) -> bool:
@@ -44,9 +49,9 @@ def _refresh_mode_schema_registry() -> None:
 
 
 class _RefreshSchemaRegistryMixin:
-    def run(self):
+    def run(self) -> None:
         _refresh_mode_schema_registry()
-        super().run()
+        cast(_CommandWithRun, super()).run()
 
 
 class build_py(_RefreshSchemaRegistryMixin, _build_py):


### PR DESCRIPTION
## Summary

- fix `main.launch.py` airframe detail unpacking to match the helper return shape
- narrow launch config values before passing them to ROS launch APIs
- type PX4 autostart and airframe state in `vehicle_stack.launch.py`
- type the setup command mixin's `super().run()` call

Fixes #222
Part of #201

## Verification

- `source /opt/ros/humble/setup.bash && source /home/ubuntu/monorepo/controls/sae_2025_ws/install/setup.bash && export PYTHONPATH="$PWD/controls/sae_2025_ws/src/uav:$PYTHONPATH" && npx --yes pyright controls/sae_2025_ws/src/uav/launch/main.launch.py controls/sae_2025_ws/src/uav/launch/vehicle_stack.launch.py controls/sae_2025_ws/src/uav/setup.py --outputjson`
- `python3 -m compileall controls/sae_2025_ws/src/uav/launch/main.launch.py controls/sae_2025_ws/src/uav/launch/vehicle_stack.launch.py controls/sae_2025_ws/src/uav/setup.py`
- `ruff check --config controls/sae_2025_ws/.ruff.toml controls/sae_2025_ws/src/uav/launch/main.launch.py controls/sae_2025_ws/src/uav/launch/vehicle_stack.launch.py controls/sae_2025_ws/src/uav/setup.py`
- `ruff format --check --config controls/sae_2025_ws/.ruff.toml controls/sae_2025_ws/src/uav/launch/main.launch.py controls/sae_2025_ws/src/uav/launch/vehicle_stack.launch.py controls/sae_2025_ws/src/uav/setup.py`
- `source /opt/ros/humble/setup.bash && source /home/ubuntu/monorepo/controls/sae_2025_ws/install/setup.bash && export PYTHONPATH="$PWD/controls/sae_2025_ws/src/uav:$PYTHONPATH" && python3 -m pytest -q controls/sae_2025_ws/src/uav/test/test_launch_helpers.py controls/sae_2025_ws/src/uav/test/test_fleet_launch.py`
