### PR TITLE
Mark optional debug dependencies

### DIFF
--- a/controls/sae_2025_ws/src/payload/test/sn754410_test.py
+++ b/controls/sae_2025_ws/src/payload/test/sn754410_test.py
@@ -1,4 +1,4 @@
-import pigpio
+import pigpio  # pyright: ignore[reportMissingImports]
 import time
 
 # ----------------------

--- a/controls/sae_2025_ws/src/payload/test/test_motor_low.py
+++ b/controls/sae_2025_ws/src/payload/test/test_motor_low.py
@@ -8,7 +8,7 @@ For SN754410 (PWM + IN1 + IN2), prefer `sn754410_test.py`.
 Requires the pigpiod daemon to be running (`sudo pigpiod`).
 """
 
-import pigpio
+import pigpio  # pyright: ignore[reportMissingImports]
 import time
 
 # --- Pin assignments (BCM numbering) ---

--- a/controls/sae_2025_ws/src/tools/apriltag_debug/apriltag_debug.py
+++ b/controls/sae_2025_ws/src/tools/apriltag_debug/apriltag_debug.py
@@ -3,7 +3,7 @@ import rclpy
 from sensor_msgs.msg import Image, CompressedImage
 import cv2 as cv
 import numpy as np
-import pupil_apriltags
+import pupil_apriltags  # pyright: ignore[reportMissingImports]
 from cv_bridge import CvBridge
 
 
@@ -50,6 +50,9 @@ class AprilTagDebugger(Node):
     def _compressed_cb(self, msg: CompressedImage):
         buf = np.frombuffer(msg.data, dtype=np.uint8)
         frame = cv.imdecode(buf, cv.IMREAD_COLOR)
+        if frame is None:
+            self.get_logger().warn("Failed to decode compressed image.")
+            return
         self._process_and_show(frame)
 
     def _process_and_show(self, frame: np.ndarray):


### PR DESCRIPTION
## Summary

- mark `pigpio` and `pupil_apriltags` imports as optional for Pyright in hardware/debug scripts
- guard failed compressed image decode before AprilTag debug processing

Fixes #224
Part of #201

## Verification

- `source /opt/ros/humble/setup.bash && source /home/ubuntu/monorepo/controls/sae_2025_ws/install/setup.bash && export PYTHONPATH="$PWD/controls/sae_2025_ws/src/payload:$PWD/controls/sae_2025_ws/src/tools:$PYTHONPATH" && npx --yes pyright controls/sae_2025_ws/src/payload/test/sn754410_test.py controls/sae_2025_ws/src/payload/test/test_motor_low.py controls/sae_2025_ws/src/tools/apriltag_debug/apriltag_debug.py --outputjson`
- `python3 -m compileall controls/sae_2025_ws/src/payload/test/sn754410_test.py controls/sae_2025_ws/src/payload/test/test_motor_low.py controls/sae_2025_ws/src/tools/apriltag_debug/apriltag_debug.py`
- `ruff check --config controls/sae_2025_ws/.ruff.toml controls/sae_2025_ws/src/payload/test/sn754410_test.py controls/sae_2025_ws/src/payload/test/test_motor_low.py controls/sae_2025_ws/src/tools/apriltag_debug/apriltag_debug.py`
- `ruff format --check --config controls/sae_2025_ws/.ruff.toml controls/sae_2025_ws/src/payload/test/sn754410_test.py controls/sae_2025_ws/src/payload/test/test_motor_low.py controls/sae_2025_ws/src/tools/apriltag_debug/apriltag_debug.py`

Not run: hardware scripts themselves, because they require pigpiod/camera hardware.
