### PR TITLE
Type UAV CV array helpers

### DIFF
--- a/controls/sae_2025_ws/src/uav/uav/cv/confidence.py
+++ b/controls/sae_2025_ws/src/uav/uav/cv/confidence.py
@@ -2,21 +2,26 @@ import cv2
 import numpy as np
 
 
-def fit_quadrilateral(contour):
-    print(contour)
-    return cv2.boxPoints(cv2.minAreaRect(np.array(list(contour))))
+def _contour_array(contour) -> np.ndarray:
+    return np.asarray(contour, dtype=np.int32)
 
 
-def rect_confidence(contour, height, width):
+def fit_quadrilateral(contour) -> np.ndarray:
+    return cv2.boxPoints(cv2.minAreaRect(_contour_array(contour)))
+
+
+def rect_confidence(contour, height, width) -> float:
+    contour_array = _contour_array(contour)
+
     # Create empty masks
     mask1 = np.zeros((height, width), dtype=np.uint8)
     mask2 = np.zeros((height, width), dtype=np.uint8)
 
     # Convert the box into a contour (it needs to be a list of points)
-    box = np.int0(fit_quadrilateral(contour))  # Convert to integer points
+    box = fit_quadrilateral(contour_array).astype(np.int32)
 
     # Draw the contour of the original contour on mask1
-    cv2.drawContours(mask1, [contour], 0, 255, thickness=cv2.FILLED)
+    cv2.drawContours(mask1, [contour_array], 0, 255, thickness=cv2.FILLED)
 
     # Draw the quadrilateral bounding box on mask2
     cv2.drawContours(mask2, [box], 0, 255, thickness=cv2.FILLED)
@@ -26,21 +31,23 @@ def rect_confidence(contour, height, width):
 
     # Calculate the area of the intersection
     area = cv2.countNonZero(intersection)
-    confidence = 1 - area / (cv2.contourArea(contour) + cv2.contourArea(box))
+    confidence = 1 - area / (cv2.contourArea(contour_array) + cv2.contourArea(box))
     return confidence
 
 
-def confidence(contour, target_area, height, width):
+def confidence(contour, target_area, height, width) -> float:
+    contour_array = _contour_array(contour)
+
     # use target_area negative as a proxy for not suppying a target area
     if target_area < 0:
-        return rect_confidence(contour, height, width)
-    area = cv2.contourArea(contour)
+        return rect_confidence(contour_array, height, width)
+    area = cv2.contourArea(contour_array)
     area_confidence = (1 - area / target_area) ** 2
     if area_confidence > 1:
         area_confidence = 0
     else:
         area_confidence = 1 - area_confidence
 
-    shape_confidence = rect_confidence(contour, height, width)
+    shape_confidence = rect_confidence(contour_array, height, width)
 
     return shape_confidence * area_confidence

--- a/controls/sae_2025_ws/src/uav/uav/cv/dlz_color_regions.py
+++ b/controls/sae_2025_ws/src/uav/uav/cv/dlz_color_regions.py
@@ -106,7 +106,7 @@ def detect_focused_dlz_paper_masks(
 
     proposal_mask = np.zeros_like(candidate_mask)
     num_labels, labels, stats, _ = cv2.connectedComponentsWithStats(
-        (split_mask > 0).astype(np.uint8), 8
+        (split_mask > 0).astype(np.uint8), connectivity=8
     )
 
     for label in range(1, num_labels):
@@ -169,7 +169,7 @@ def detect_focused_dlz_paper_masks(
 
         out = np.zeros_like(mask)
         n, cc_labels, cc_stats, _ = cv2.connectedComponentsWithStats(
-            (cleaned > 0).astype(np.uint8), 8
+            (cleaned > 0).astype(np.uint8), connectivity=8
         )
 
         for cc in range(1, n):

--- a/controls/sae_2025_ws/src/uav/uav/cv/threshold.py
+++ b/controls/sae_2025_ws/src/uav/uav/cv/threshold.py
@@ -1,7 +1,8 @@
 import cv2
+import numpy as np
 
 
-def distance(c1, c2):
+def distance(c1: tuple[int, int], c2: tuple[int, int]) -> int:
     return (c1[0] - c2[0]) ** 2 + (c1[1] - c2[1]) ** 2
 
 
@@ -9,7 +10,9 @@ def detect_contour(threshold, frame):
     hsl = cv2.cvtColor(frame, cv2.COLOR_BGR2HLS)
     hsl = cv2.GaussianBlur(hsl, (5, 5), 0)
 
-    thresh = cv2.inRange(hsl, (0, threshold[0], 0), (180, threshold[1], 255))
+    lower = np.array([0, int(threshold[0]), 0], dtype=np.uint8)
+    upper = np.array([180, int(threshold[1]), 255], dtype=np.uint8)
+    thresh = cv2.inRange(hsl, lower, upper)
     # thresh = cv2.inRange(hsl, (80, 100, 0), (180, 255, 255))
     # thresh = cv2.inRange(hsl, (140, 50, 80), (180, 255, 255))
 
@@ -55,7 +58,7 @@ def threshold(thresh, prev_center, frame):
             center = c2
             closest = center_distance
 
-    if contour is not None:
+    if contour is not None and center is not None:
         cv2.drawContours(frame, [contour], -1, (0, 255, 0), 2)
         cv2.circle(frame, center, 2, (0, 0, 255), -1)
         contour = [x[0] for x in contour]
@@ -69,6 +72,8 @@ if __name__ == "__main__":
     cap = cv2.VideoCapture("DJI_0033.mov")
     thresh = (170, 255)
     ret, prev = cap.read()
+    if not ret or prev is None:
+        raise RuntimeError("Unable to read initial frame.")
     prev = cv2.resize(prev, (2704 // 2, 1520 // 2))
     _, prev_centers = detect_contour(thresh, prev)
     prev_center = None
@@ -77,6 +82,8 @@ if __name__ == "__main__":
 
     while cap.isOpened():
         ret, frame = cap.read()
+        if not ret or frame is None:
+            break
         frame = cv2.resize(frame, (2704 // 2, 1520 // 2))
         if frame is not None:
             # If the payload was in the previous frame

--- a/controls/sae_2025_ws/src/uav/uav/cv/tracking.py
+++ b/controls/sae_2025_ws/src/uav/uav/cv/tracking.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import cv2
 import numpy as np
+from collections.abc import Sequence
 from typing import Optional, Tuple
 import os
 
@@ -20,6 +21,11 @@ _PAPER_MASK_KEYS = {
     "blue": "blue_mask",
     "purple": "purple_mask",
 }
+HsvBound = Sequence[int] | np.ndarray
+
+
+def _hsv_bound_array(bound: HsvBound) -> np.ndarray:
+    return np.asarray(bound, dtype=np.uint8)
 
 
 def _normalize_payload_color(
@@ -60,14 +66,16 @@ def _largest_contour_centroid(
 
 def _legacy_focused_payload_mask(
     focused_bgr: np.ndarray,
-    lower_payload,
-    upper_payload,
+    lower_payload: HsvBound | None,
+    upper_payload: HsvBound | None,
 ) -> np.ndarray:
     if lower_payload is None or upper_payload is None:
         return np.zeros(focused_bgr.shape[:2], dtype=np.uint8)
 
     hsv_image = cv2.cvtColor(focused_bgr, cv2.COLOR_BGR2HSV)
-    payload_mask = cv2.inRange(hsv_image, lower_payload, upper_payload)
+    payload_mask = cv2.inRange(
+        hsv_image, _hsv_bound_array(lower_payload), _hsv_bound_array(upper_payload)
+    )
     kernel = np.ones((5, 5), np.uint8)
     payload_mask = cv2.morphologyEx(payload_mask, cv2.MORPH_OPEN, kernel)
     payload_mask = cv2.morphologyEx(payload_mask, cv2.MORPH_CLOSE, kernel)
@@ -93,10 +101,10 @@ def _resolved_payload_mask(
 
 def find_payload(
     image: np.ndarray,
-    lower_zone: np.ndarray,
-    upper_zone: np.ndarray,
-    lower_payload: np.ndarray | None,
-    upper_payload: np.ndarray | None,
+    lower_zone: HsvBound,
+    upper_zone: HsvBound,
+    lower_payload: HsvBound | None,
+    upper_payload: HsvBound | None,
     uuid: str,
     debug: bool = False,
     save_vision: bool = False,
@@ -124,7 +132,9 @@ def find_payload(
         payload_color, lower_payload, upper_payload
     )
 
-    zone_mask = cv2.inRange(hsv_image, lower_zone, upper_zone)
+    zone_mask = cv2.inRange(
+        hsv_image, _hsv_bound_array(lower_zone), _hsv_bound_array(upper_zone)
+    )
     kernel = np.ones((5, 5), np.uint8)
     dilated = cv2.dilate(zone_mask, kernel, iterations=3)
     zone_mask = cv2.morphologyEx(dilated, cv2.MORPH_CLOSE, kernel)
@@ -134,12 +144,13 @@ def find_payload(
         zone_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
     )
     if not contours:
+        vis_image = image.copy() if debug or save_vision else None
         if debug or save_vision:
-            vis_image = image.copy()
-        if debug:
+            assert vis_image is not None
+        if debug and vis_image is not None:
             cv2.imshow("Payload Tracking", vis_image)
             cv2.waitKey(1)
-        if save_vision:
+        if save_vision and vis_image is not None:
             import time
 
             time = int(time.time())
@@ -183,6 +194,7 @@ def find_payload(
         else:
             dlz_empty = False
 
+    vis_image: np.ndarray | None = None
     if debug or save_vision:
         vis_image = image.copy()
 
@@ -190,7 +202,7 @@ def find_payload(
         if largest_payload_contour is not None:
             cv2.drawContours(vis_image, [largest_payload_contour], -1, (0, 255, 0), 2)
         cv2.circle(vis_image, (cx, cy), 5, (0, 0, 255), -1)
-    if debug:
+    if debug and vis_image is not None:
         cv2.namedWindow("Payload Tracking", cv2.WINDOW_AUTOSIZE)
         cv2.imshow("Payload Tracking", vis_image)
         cv2.imshow(f"DLZ Mask {lower_zone}, {upper_zone}", zone_mask)
@@ -200,7 +212,7 @@ def find_payload(
             cv2.imshow("Proposal Mask", paper_masks["proposal_mask"])
             cv2.imshow("Unknown Mask", paper_masks["unknown_mask"])
         cv2.waitKey(1)
-    if save_vision:
+    if save_vision and vis_image is not None:
         import time
 
         time = int(time.time())
@@ -278,7 +290,7 @@ def find_dlz(
     lower_green: np.ndarray,
     upper_green: np.ndarray,
     debug: bool = False,
-) -> Optional[Tuple[int, int, np.ndarray]]:
+) -> Optional[Tuple[int, int, np.ndarray | None]]:
     """
     Detect payload in image using color thresholding.
 
@@ -290,8 +302,8 @@ def find_dlz(
         upper_green (np.ndarray): Upper HSV threshold for green payload.
 
     Returns:
-        Optional[Tuple[int, int, np.ndarray]]: A tuple (cx, cy, visualization_image)
-        if detection is successful; otherwise, None.
+        Optional[Tuple[int, int, np.ndarray | None]]: A tuple
+        (cx, cy, visualization_image) if detection is successful; otherwise, None.
     """
     hsv_image = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
 
@@ -355,6 +367,8 @@ if __name__ == "__main__":
     image = cv2.imread(
         "/Users/ethanyu/VSCodeProjects/monorepo/good_images/image_20250322_191023.png"
     )
+    if image is None:
+        raise RuntimeError("Unable to read debug image.")
     print(
         find_payload(
             image,


### PR DESCRIPTION
## Summary

- normalize contour and HSV bound inputs before OpenCV calls
- use named OpenCV connectivity arguments where overloads distinguish labels from connectivity
- guard nullable debug image/frame reads before processing
- type debug visualization paths to match existing return behavior

Fixes #226
Part of #201

## Verification

- `source /opt/ros/humble/setup.bash && source /home/ubuntu/monorepo/controls/sae_2025_ws/install/setup.bash && export PYTHONPATH="$PWD/controls/sae_2025_ws/src/uav:$PYTHONPATH" && npx --yes pyright controls/sae_2025_ws/src/uav/uav/cv/tracking.py controls/sae_2025_ws/src/uav/uav/cv/threshold.py controls/sae_2025_ws/src/uav/uav/cv/confidence.py controls/sae_2025_ws/src/uav/uav/cv/dlz_color_regions.py --outputjson`
- `python3 -m compileall controls/sae_2025_ws/src/uav/uav/cv/tracking.py controls/sae_2025_ws/src/uav/uav/cv/threshold.py controls/sae_2025_ws/src/uav/uav/cv/confidence.py controls/sae_2025_ws/src/uav/uav/cv/dlz_color_regions.py`
- `ruff check --config controls/sae_2025_ws/.ruff.toml controls/sae_2025_ws/src/uav/uav/cv/tracking.py controls/sae_2025_ws/src/uav/uav/cv/threshold.py controls/sae_2025_ws/src/uav/uav/cv/confidence.py controls/sae_2025_ws/src/uav/uav/cv/dlz_color_regions.py`
- `ruff format --check --config controls/sae_2025_ws/.ruff.toml controls/sae_2025_ws/src/uav/uav/cv/tracking.py controls/sae_2025_ws/src/uav/uav/cv/threshold.py controls/sae_2025_ws/src/uav/uav/cv/confidence.py controls/sae_2025_ws/src/uav/uav/cv/dlz_color_regions.py`
- `source /opt/ros/humble/setup.bash && source /home/ubuntu/monorepo/controls/sae_2025_ws/install/setup.bash && export PYTHONPATH="$PWD/controls/sae_2025_ws/src/uav:$PYTHONPATH" && python3 -m pytest -q controls/sae_2025_ws/src/uav/test/test_payload_dlz_convex_hull_masking.py`
