### PR TITLE
Type UAV runtime comms and annotations

### DIFF
--- a/controls/sae_2025_ws/src/uav/uav/runtime/ModeManager.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/ModeManager.py
@@ -5,7 +5,7 @@ import inspect
 import os
 from pathlib import Path
 from time import time
-from typing import Any, Callable, Iterator, get_type_hints
+from typing import Any, Callable, Iterator, cast, get_type_hints
 
 from rclpy.node import Node
 from std_srvs.srv import Trigger
@@ -30,15 +30,15 @@ from .vision_loader import canonical_vision_node_path, load_vision_class
 
 @dataclass(frozen=True)
 class _RawNodeApi:
-    create_publisher: Callable[..., object]
-    create_subscription: Callable[..., object]
-    create_client: Callable[..., object]
-    create_service: Callable[..., object]
-    create_timer: Callable[..., object]
-    destroy_publisher: Callable[[object], bool | None]
-    destroy_subscription: Callable[[object], bool | None]
-    destroy_client: Callable[[object], bool | None]
-    destroy_timer: Callable[[object], bool | None] | None
+    create_publisher: Callable[..., Any]
+    create_subscription: Callable[..., Any]
+    create_client: Callable[..., Any]
+    create_service: Callable[..., Any]
+    create_timer: Callable[..., Any]
+    destroy_publisher: Callable[..., bool | None]
+    destroy_subscription: Callable[..., bool | None]
+    destroy_client: Callable[..., bool | None]
+    destroy_timer: Callable[..., bool | None] | None
 
 
 MISSION_STARTED_MARKER_ENV = "PENNAIR_MISSION_STARTED_MARKER_PATH"
@@ -57,15 +57,15 @@ class ModeManager(Node):
         peer_stale_timeout_s: float = 0.5,
     ) -> None:
         super().__init__(node_name)
-        self.vehicle = None
-        self.modes = {}
-        self.transitions = {}
-        self.active_mode = None
+        self.vehicle: Vehicle | None = None
+        self.modes: dict[str, Mode] = {}
+        self.transitions: dict[str, dict[str, str]] = {}
+        self.active_mode: str | None = None
         self.last_update_time = time()
-        self._vision_clients = {}
-        self.timer = None
+        self._vision_clients: dict[str, Any] = {}
+        self.timer: Any | None = None
         self.auto_launch = bool(auto_launch)
-        self._auto_launch_timer = None
+        self._auto_launch_timer: Any | None = None
         self._runtime_vehicle_name = normalize_vehicle_name(vehicle_name)
         self.peer_heartbeat_hz = float(peer_heartbeat_hz)
         self.peer_stale_timeout_s = float(peer_stale_timeout_s)
@@ -78,8 +78,8 @@ class ModeManager(Node):
                 "peer_stale_timeout_s must be positive, "
                 f"got {self.peer_stale_timeout_s!r}."
             )
-        self._shared_mode_state = {}
-        self._current_comm_builder = None
+        self._shared_mode_state: dict[str, dict[str, Any]] = {}
+        self._current_comm_builder: ModeCommBuilder | None = None
         self._runtime_closed = False
         self._initialize_comms_runtime(vehicle_name=vehicle_name)
         self.start_mission_service = self.create_service(
@@ -90,7 +90,10 @@ class ModeManager(Node):
             self._auto_launch_timer = self.create_timer(0.1, self._maybe_auto_launch)
 
     def get_active_mode(self) -> Mode:
-        return self.modes[self.active_mode]
+        active_mode = self.active_mode
+        if active_mode is None:
+            raise RuntimeError("No active mode is set.")
+        return self.modes[active_mode]
 
     def _now_seconds(self) -> float:
         return self.get_clock().now().nanoseconds * 1e-9
@@ -204,11 +207,14 @@ class ModeManager(Node):
             )
 
     @property
-    def vision_clients(self) -> dict:
+    def vision_clients(self) -> dict[str, Any]:
         return self._vision_clients
 
-    def _connect_vision_client(self, vision_class):
-        service_name = self.vehicle.vision_service_name(vision_class)
+    def _connect_vision_client(self, vision_class: type[Any]) -> tuple[Any, str]:
+        vehicle = self.vehicle
+        if vehicle is None:
+            raise ValueError("Vision nodes require an active vehicle camera contract.")
+        service_name = vehicle.vision_service_name(vision_class)
         while True:
             client = super().create_client(vision_class.srv, service_name)
             if client.wait_for_service(timeout_sec=1.0):
@@ -258,14 +264,14 @@ class ModeManager(Node):
         finally:
             self._current_comm_builder = previous_builder
 
-    def _raw_method(self, name: str):
+    def _raw_method(self, name: str) -> Callable[..., Any]:
         raw_node_api = getattr(self, "_raw_node_api", None)
         if raw_node_api is not None:
             return getattr(raw_node_api, name)
         raw_method = getattr(super(ModeManager, self), name, None)
         if raw_method is not None:
             return raw_method
-        return getattr(Node, name)
+        return cast(Callable[..., Any], getattr(Node, name))
 
     def _instantiate_mode(
         self,
@@ -304,7 +310,7 @@ class ModeManager(Node):
         name: str,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
-    ):
+    ) -> Any:
         if not hasattr(self, "_runtime_vehicle_name"):
             return self._raw_method(f"create_{kind}")(
                 interface_type,
@@ -335,7 +341,7 @@ class ModeManager(Node):
             kwargs=kwargs,
         )
 
-    def _destroy_entity(self, *, kind: str, entity) -> bool:
+    def _destroy_entity(self, *, kind: str, entity: object) -> bool:
         registry = getattr(self, "_managed_registry", None)
         if registry is None:
             return bool(self._raw_method(f"destroy_{kind}")(entity))
@@ -409,7 +415,10 @@ class ModeManager(Node):
         self.get_logger().info(
             f"Transitioning from {self.active_mode} based on state {state}."
         )
-        return self.transitions[self.active_mode][state]
+        active_mode = self.active_mode
+        if active_mode is None:
+            raise RuntimeError("No active mode is set.")
+        return self.transitions[active_mode][state]
 
     def switch_mode(self, mode_name: str) -> None:
         if self.active_mode:
@@ -502,6 +511,9 @@ class ModeManager(Node):
         self._write_mission_started_marker()
         return True
 
+    def spin_once(self) -> None:
+        raise NotImplementedError("ModeManager subclasses must implement spin_once().")
+
     def _cancel_auto_launch_timer(self) -> None:
         if self._auto_launch_timer is None:
             return
@@ -544,7 +556,9 @@ class ModeManager(Node):
             else:
                 self.switch_mode(next_mode)
 
-    def create_publisher(self, msg_type, topic: str, *args, **kwargs):
+    def create_publisher(
+        self, msg_type: object, topic: str, *args: Any, **kwargs: Any
+    ) -> Any:
         return self._create_entity(
             kind="publisher",
             interface_type=msg_type,
@@ -553,7 +567,9 @@ class ModeManager(Node):
             kwargs=kwargs,
         )
 
-    def create_subscription(self, msg_type, topic: str, *args, **kwargs):
+    def create_subscription(
+        self, msg_type: object, topic: str, *args: Any, **kwargs: Any
+    ) -> Any:
         return self._create_entity(
             kind="subscription",
             interface_type=msg_type,
@@ -562,7 +578,9 @@ class ModeManager(Node):
             kwargs=kwargs,
         )
 
-    def create_client(self, srv_type, srv_name: str, *args, **kwargs):
+    def create_client(
+        self, srv_type: object, srv_name: str, *args: Any, **kwargs: Any
+    ) -> Any:
         return self._create_entity(
             kind="client",
             interface_type=srv_type,
@@ -571,7 +589,9 @@ class ModeManager(Node):
             kwargs=kwargs,
         )
 
-    def create_service(self, srv_type, srv_name: str, *args, **kwargs):
+    def create_service(
+        self, srv_type: object, srv_name: str, *args: Any, **kwargs: Any
+    ) -> Any:
         return self._create_entity(
             kind="service",
             interface_type=srv_type,
@@ -580,13 +600,13 @@ class ModeManager(Node):
             kwargs=kwargs,
         )
 
-    def destroy_publisher(self, publisher) -> bool:
+    def destroy_publisher(self, publisher: object) -> bool:
         return self._destroy_entity(kind="publisher", entity=publisher)
 
-    def destroy_subscription(self, subscription) -> bool:
+    def destroy_subscription(self, subscription: object) -> bool:
         return self._destroy_entity(kind="subscription", entity=subscription)
 
-    def destroy_client(self, client) -> bool:
+    def destroy_client(self, client: object) -> bool:
         return self._destroy_entity(kind="client", entity=client)
 
     def _close_runtime_helpers(self) -> None:
@@ -600,7 +620,7 @@ class ModeManager(Node):
         if peer_connections is not None:
             peer_connections.close()
 
-    def destroy_node(self) -> bool:
+    def destroy_node(self) -> Any:
         self._clear_mission_started_marker()
         if getattr(self, "active_mode", None):
             self._deactivate_active_mode()

--- a/controls/sae_2025_ws/src/uav/uav/runtime/UAVModeManager.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/UAVModeManager.py
@@ -1,10 +1,12 @@
 from time import time
+from typing import cast
 
 from px4_msgs.msg import VehicleStatus
 from std_srvs.srv import Trigger
 
 from uav.vehicles.AirframeClass import AirframeClass
 from uav.vehicles.Multicopter import Multicopter
+from uav.vehicles.UAV import UAV
 from uav.vehicles.VTOL import VTOL
 from uav.modes.uav.LandingMode import LandingMode
 from .ModeManager import ModeManager
@@ -71,47 +73,54 @@ class UAVModeManager(ModeManager):
         )
         self.setup_modes(mission_spec)
 
+    def _uav_vehicle(self) -> UAV | None:
+        vehicle = self.vehicle
+        if vehicle is None:
+            return None
+        return cast(UAV, vehicle)
+
     def _auto_launch_ready(self) -> bool:
-        if self.vehicle is None:
+        vehicle = self._uav_vehicle()
+        if vehicle is None:
             return False
         return (
-            self.vehicle.vehicle_status is not None
-            and self.vehicle.vehicle_attitude is not None
-            and self.vehicle.yaw is not None
-            and self.vehicle.local_position is not None
-            and self.vehicle.global_position is not None
-            and bool(self.vehicle.flight_check)
+            vehicle.vehicle_status is not None
+            and vehicle.vehicle_attitude is not None
+            and vehicle.yaw is not None
+            and vehicle.local_position is not None
+            and vehicle.global_position is not None
+            and bool(vehicle.flight_check)
         )
 
     def trigger_failsafe(self, request, response):
         self.get_logger().info("Failsafe triggered via service call")
-        if self.vehicle is not None and hasattr(self.vehicle, "failsafe_trigger"):
-            self.vehicle.failsafe_trigger = True
-            self.vehicle.failsafe = (
-                self.vehicle.failsafe_px4 or self.vehicle.failsafe_trigger
-            )
+        vehicle = self._uav_vehicle()
+        if vehicle is not None:
+            vehicle.failsafe_trigger = True
+            vehicle.failsafe = vehicle.failsafe_px4 or vehicle.failsafe_trigger
         response.success = True
         response.message = "Failsafe triggered."
         return response
 
     def spin_once(self) -> None:
         current_time = time()
-        if self.vehicle is None:
+        vehicle = self._uav_vehicle()
+        if vehicle is None:
             return
 
         if self.active_mode is None:
             self.switch_mode("start")
 
-        if self.vehicle.failsafe:
-            if not self.vehicle.emergency_landing:
-                self.vehicle.hover()
+        if vehicle.failsafe:
+            if not vehicle.emergency_landing:
+                vehicle.hover()
                 self.get_logger().warn("Failsafe: Switching to AUTO_LOITER mode.")
-                self.vehicle.emergency_landing = True
+                vehicle.emergency_landing = True
             if (
-                self.vehicle.nav_state == VehicleStatus.NAVIGATION_STATE_AUTO_LOITER
-                or self.vehicle.arm_state != VehicleStatus.ARMING_STATE_ARMED
+                vehicle.nav_state == VehicleStatus.NAVIGATION_STATE_AUTO_LOITER
+                or vehicle.arm_state != VehicleStatus.ARMING_STATE_ARMED
             ):
-                self.vehicle.land()
+                vehicle.land()
                 self.get_logger().warn("Failsafe: Initiating landing.")
             return
 
@@ -119,24 +128,24 @@ class UAVModeManager(ModeManager):
             self._run_active_mode(current_time)
             return
 
-        if not self.vehicle.origin_set:
-            self.vehicle.set_origin()
+        if not vehicle.origin_set:
+            vehicle.set_origin()
 
-        if self.vehicle.arm_state != VehicleStatus.ARMING_STATE_ARMED:
+        if vehicle.arm_state != VehicleStatus.ARMING_STATE_ARMED:
             self.get_logger().info(
-                f"UAV is not armed. Current arm state: {self.vehicle.arm_state}"
+                f"UAV is not armed. Current arm state: {vehicle.arm_state}"
             )
             if (
                 self.active_mode is not None
                 and isinstance(self.get_active_mode(), LandingMode)
-                and self.vehicle.nav_state != VehicleStatus.NAVIGATION_STATE_AUTO_LAND
+                and vehicle.nav_state != VehicleStatus.NAVIGATION_STATE_AUTO_LAND
             ):
                 self.get_logger().info("Successfully Landed UAV")
                 self.get_logger().info("Finishing Mission")
                 self.destroy_node()
                 return
 
-            if self.vehicle.attempted_takeoff and self.active_mode is not None:
+            if vehicle.attempted_takeoff and self.active_mode is not None:
                 self.get_logger().error(
                     "UAV disarmed unexpectedly after takeoff attempt. Terminating to prevent infinite cycle."
                 )
@@ -146,18 +155,18 @@ class UAVModeManager(ModeManager):
                 self.destroy_node()
                 return
 
-            self.vehicle.arm()
+            vehicle.arm()
             self.get_logger().info("Arming UAV")
             self.start_time = current_time
             return
 
-        if self.vehicle.local_position is None or self.vehicle.global_position is None:
+        if vehicle.local_position is None or vehicle.global_position is None:
             return
 
-        self.vehicle.publish_offboard_control_heartbeat_signal()
+        vehicle.publish_offboard_control_heartbeat_signal()
         self._run_active_mode(current_time)
 
-        if self.vehicle.nav_state == VehicleStatus.NAVIGATION_STATE_AUTO_LAND:
+        if vehicle.nav_state == VehicleStatus.NAVIGATION_STATE_AUTO_LAND:
             self.get_logger().info("Landing")
 
     def handle_mode_state(self, state: str) -> None:
@@ -165,8 +174,9 @@ class UAVModeManager(ModeManager):
             self.get_logger().error(
                 f"Error in mode {self.active_mode}. Switching to failsafe."
             )
-            if self.vehicle is not None:
-                self.vehicle.failsafe = True
+            vehicle = self._uav_vehicle()
+            if vehicle is not None:
+                vehicle.failsafe = True
             return
         if state == "terminate":
             self.get_logger().info("Mission has completed.")

--- a/controls/sae_2025_ws/src/uav/uav/runtime/managed_entities.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/managed_entities.py
@@ -1,15 +1,5 @@
 from __future__ import annotations
 
-from typing import Any, Protocol, cast
-
-
-class _Publisher(Protocol):
-    def publish(self, message: Any) -> Any: ...
-
-
-class _Client(Protocol):
-    def call_async(self, request: Any) -> Any: ...
-
 
 class ManagedEntity:
     def __init__(self, spec):
@@ -44,11 +34,14 @@ class ManagedEntity:
 
 
 class ManagedPublisher(ManagedEntity):
-    def publish(self, message) -> None:
+    def publish(self, message: object) -> None:
         entity = self.get_underlying()
         if entity is None or self.destroyed:
             return None
-        cast(_Publisher, entity).publish(message)
+        publish = getattr(entity, "publish", None)
+        if not callable(publish):
+            return None
+        publish(message)
         return None
 
 
@@ -62,10 +55,13 @@ class ManagedClient(ManagedEntity):
             return False
         return bool(wait_for_service(timeout_sec=timeout_sec))
 
-    def call_async(self, request):
+    def call_async(self, request: object):
         entity = self.get_underlying()
         if entity is None or self.destroyed:
             return None
         if not self.wait_for_service(timeout_sec=0.0):
             return None
-        return cast(_Client, entity).call_async(request)
+        call_async = getattr(entity, "call_async", None)
+        if not callable(call_async):
+            return None
+        return call_async(request)

--- a/controls/sae_2025_ws/src/uav/uav/runtime/managed_entities.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/managed_entities.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
+from typing import Any, Protocol, cast
+
+
+class _Publisher(Protocol):
+    def publish(self, message: Any) -> Any: ...
+
+
+class _Client(Protocol):
+    def call_async(self, request: Any) -> Any: ...
+
 
 class ManagedEntity:
     def __init__(self, spec):
@@ -38,7 +48,8 @@ class ManagedPublisher(ManagedEntity):
         entity = self.get_underlying()
         if entity is None or self.destroyed:
             return None
-        return entity.publish(message)
+        cast(_Publisher, entity).publish(message)
+        return None
 
 
 class ManagedClient(ManagedEntity):
@@ -57,4 +68,4 @@ class ManagedClient(ManagedEntity):
             return None
         if not self.wait_for_service(timeout_sec=0.0):
             return None
-        return entity.call_async(request)
+        return cast(_Client, entity).call_async(request)

--- a/controls/sae_2025_ws/src/uav/uav/runtime/managed_registry.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/managed_registry.py
@@ -53,12 +53,12 @@ class ManagedCommRegistry:
         self,
         *,
         connection_status: Callable[[], Mapping[str, bool]],
-        raw_create_publisher: Callable[..., object],
-        raw_create_subscription: Callable[..., object],
-        raw_create_client: Callable[..., object],
-        raw_destroy_publisher: Callable[[object], bool | None],
-        raw_destroy_subscription: Callable[[object], bool | None],
-        raw_destroy_client: Callable[[object], bool | None],
+        raw_create_publisher: Callable[..., Any],
+        raw_create_subscription: Callable[..., Any],
+        raw_create_client: Callable[..., Any],
+        raw_destroy_publisher: Callable[..., bool | None],
+        raw_destroy_subscription: Callable[..., bool | None],
+        raw_destroy_client: Callable[..., bool | None],
     ) -> None:
         self._connection_status = connection_status
         self._raw_create_publisher = raw_create_publisher

--- a/controls/sae_2025_ws/src/uav/uav/runtime/peer_connections.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/peer_connections.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Callable, Mapping
+from typing import Any, Callable, Mapping, Protocol
 
 from std_msgs.msg import Empty
 
 HEARTBEAT_TOPIC_SUFFIX = "mode_manager/heartbeat"
+
+
+class _ConnectionChangeCallback(Protocol):
+    def __call__(self, peer_name: str, *, connected: bool) -> None: ...
+
+
+class _HeartbeatPublisher(Protocol):
+    def publish(self, message: Empty) -> Any: ...
 
 
 def normalize_vehicle_name(vehicle_name: str | None) -> str:
@@ -64,13 +72,13 @@ class PeerConnectionTracker:
         peer_heartbeat_hz: float = 10.0,
         peer_stale_timeout_s: float = 0.5,
         now_seconds: Callable[[], float],
-        on_connection_change: Callable[[str], None] | Callable[..., None],
-        raw_create_publisher: Callable[..., object],
-        raw_create_subscription: Callable[..., object],
-        raw_destroy_publisher: Callable[[object], bool | None],
-        raw_destroy_subscription: Callable[[object], bool | None],
-        raw_create_timer: Callable[..., object],
-        raw_destroy_timer: Callable[[object], bool | None] | None = None,
+        on_connection_change: _ConnectionChangeCallback,
+        raw_create_publisher: Callable[..., Any],
+        raw_create_subscription: Callable[..., Any],
+        raw_destroy_publisher: Callable[..., bool | None],
+        raw_destroy_subscription: Callable[..., bool | None],
+        raw_create_timer: Callable[..., Any],
+        raw_destroy_timer: Callable[..., bool | None] | None = None,
     ) -> None:
         self._runtime_vehicle_name = normalize_vehicle_name(runtime_vehicle_name)
         self.peer_heartbeat_hz = float(peer_heartbeat_hz)
@@ -84,8 +92,8 @@ class PeerConnectionTracker:
         self._raw_create_timer = raw_create_timer
         self._raw_destroy_timer = raw_destroy_timer
 
-        self._heartbeat_publisher = None
-        self._heartbeat_timer = None
+        self._heartbeat_publisher: _HeartbeatPublisher | None = None
+        self._heartbeat_timer: Any | None = None
         self._heartbeat_subscriptions: dict[str, object] = {}
         self._connected: dict[str, bool] = {}
         self._last_seen: dict[str, float | None] = {}

--- a/controls/sae_2025_ws/src/uav/uav/runtime/uav_mission.py
+++ b/controls/sae_2025_ws/src/uav/uav/runtime/uav_mission.py
@@ -45,6 +45,21 @@ class UAVMissionBootstrap(Node):
             )
         return float(value)
 
+    def _float_list_parameter(self, name: str) -> list[float]:
+        value = self.get_parameter(name).value
+        if not isinstance(value, (list, tuple)):
+            raise ValueError(
+                f"uav_mission requires numeric list parameter '{name}', received {value!r}."
+            )
+        offsets: list[float] = []
+        for item in value:
+            if not isinstance(item, (int, float)) or isinstance(item, bool):
+                raise ValueError(
+                    f"uav_mission requires numeric list parameter '{name}', received {value!r}."
+                )
+            offsets.append(float(item))
+        return offsets
+
     def manager_kwargs(self) -> dict:
         mission_path = str(self.get_parameter("mode_map").value)
         if not mission_path:
@@ -66,7 +81,7 @@ class UAVMissionBootstrap(Node):
             "vehicle_class": AirframeClass.parse(
                 self.get_parameter("vehicle_class").value
             ),
-            "camera_offsets": list(self.get_parameter("camera_mount_offsets").value),
+            "camera_offsets": self._float_list_parameter("camera_mount_offsets"),
             "peer_heartbeat_hz": self._float_parameter("peer_heartbeat_hz"),
             "peer_stale_timeout_s": self._float_parameter("peer_stale_timeout_s"),
             "node_name": "mission",


### PR DESCRIPTION
Fixes #232.
Fixes #248.
Part of #201.

## Summary
- Type raw ROS create/destroy callables and managed comm registry boundaries.
- Add structural typing for peer connection callbacks, heartbeat publishers, publisher/client delegation, and active-mode access.
- Validate UAV camera offset parameters before converting them to floats.
- Folded #249 into this PR as a separate commit.

## Verification
- Constituent focused Pyright, compile, ruff, and runtime/peer pytest checks from #233 and #249 passed when created.
- Dynamic peer reconnect check after condensation: `1 passed in 17.75s`.
