### PR TITLE
Type integration tests

### DIFF
--- a/controls/sae_2025_ws/src/integration/test/test_api_contract.py
+++ b/controls/sae_2025_ws/src/integration/test/test_api_contract.py
@@ -6,7 +6,7 @@ import sys
 import types
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -682,7 +682,7 @@ def test_fleet_action_accepts_query_scoped_single_device(client, monkeypatch):
 def test_build_deploy_route_accepts_network_policy_fields(client, monkeypatch):
     from backend.services import deploy as deploy_service
 
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
 
     async def fake_deploy_selected_source(
         ctx,

--- a/controls/sae_2025_ws/src/integration/test/test_api_contract.py
+++ b/controls/sae_2025_ws/src/integration/test/test_api_contract.py
@@ -6,6 +6,7 @@ import sys
 import types
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import httpx
 import pytest
@@ -32,6 +33,14 @@ from backend.config import (  # noqa: E402
     TargetRecord,
     build_source_store_paths,
 )
+from backend.context import AppContext  # noqa: E402
+
+
+_TargetStoreDict = dict[str, str | bool | None]
+
+
+def _target_store_dict(target: TargetRecord) -> _TargetStoreDict:
+    return cast(_TargetStoreDict, target.to_store_dict())
 
 
 def _assert_api_device_card(
@@ -107,27 +116,17 @@ def _make_target() -> TargetRecord:
     )
 
 
-def _make_context(tmp_path: Path) -> SimpleNamespace:
+def _make_context(tmp_path: Path) -> AppContext:
     base_dir = tmp_path / "src" / "integration"
     base_dir.mkdir(parents=True, exist_ok=True)
     operator = _make_operator(tmp_path)
     target = _make_target()
-    inventory_kwargs = {
-        "operator_config": operator,
-        "default_deploy_root": operator.default_deploy_root,
-    }
-    if "seed_target" in inspect.signature(InventoryStore).parameters:
-        inventory = InventoryStore(
-            operator.inventory_path,
-            seed_target=target,
-            **inventory_kwargs,
-        )
-    else:
-        inventory = InventoryStore(
-            operator.inventory_path,
-            **inventory_kwargs,
-        )
-        inventory.upsert_target(target.to_store_dict())
+    inventory = InventoryStore(
+        operator.inventory_path,
+        operator_config=operator,
+        default_deploy_root=operator.default_deploy_root,
+    )
+    inventory.upsert_target(_target_store_dict(target))
     build_source_path, cache_dir = build_source_store_paths(operator.inventory_path)
     build_source_store = BuildSourceStore(
         build_source_path,
@@ -232,15 +231,18 @@ def _make_context(tmp_path: Path) -> SimpleNamespace:
             ),
         )
 
-    return SimpleNamespace(
-        base_dir=base_dir,
-        operator_config=operator,
-        inventory=inventory,
-        build_source_store=build_source_store,
-        require_deploy_context=lambda require_build_source=True: None,
-        resolve_target=resolve_target,
-        resolve_live_target=resolve_live_target,
-        list_targets=inventory.list_targets,
+    return cast(
+        AppContext,
+        SimpleNamespace(
+            base_dir=base_dir,
+            operator_config=operator,
+            inventory=inventory,
+            build_source_store=build_source_store,
+            require_deploy_context=lambda require_build_source=True: None,
+            resolve_target=resolve_target,
+            resolve_live_target=resolve_live_target,
+            list_targets=inventory.list_targets,
+        ),
     )
 
 

--- a/controls/sae_2025_ws/src/integration/test/test_config.py
+++ b/controls/sae_2025_ws/src/integration/test/test_config.py
@@ -4,6 +4,7 @@ import json
 import sys
 import types
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -23,6 +24,13 @@ from backend.config import (  # noqa: E402
     TargetRecord,
     build_source_store_paths,
 )
+
+
+_TargetStoreDict = dict[str, str | bool | None]
+
+
+def _target_store_dict(data: dict[str, object]) -> _TargetStoreDict:
+    return cast(_TargetStoreDict, data)
 
 
 def _make_operator(tmp_path: Path) -> OperatorConfig:
@@ -173,7 +181,7 @@ def test_inventory_store_round_trips_through_disk(tmp_path):
         operator_config=operator,
         default_deploy_root=operator.default_deploy_root,
     )
-    created, was_created = store.upsert_target(_make_target())
+    created, was_created = store.upsert_target(_target_store_dict(_make_target()))
     assert was_created is True
     assert created.target_id == "pi-1"
 
@@ -236,7 +244,7 @@ def test_inventory_store_round_trips_through_disk(tmp_path):
         operator_config=_make_operator(tmp_path),
         default_deploy_root="/home/penn/pennair-deploy",
     )
-    created, _ = lone_store.upsert_target(_make_target())
+    created, _ = lone_store.upsert_target(_target_store_dict(_make_target()))
     lone_store.delete_target(created.target_id)
     assert lone_store.list_targets() == []
     assert lone_store.active_target_id() == ""
@@ -251,7 +259,7 @@ def test_inventory_store_revalidates_existing_target_updates(tmp_path):
         operator_config=operator,
         default_deploy_root=operator.default_deploy_root,
     )
-    store.upsert_target(_make_target())
+    store.upsert_target(_target_store_dict(_make_target()))
 
     with pytest.raises(ValueError, match="invalid pi_host"):
         store.upsert_target(
@@ -269,7 +277,7 @@ def test_inventory_store_exports_and_imports(tmp_path):
         operator_config=operator,
         default_deploy_root=operator.default_deploy_root,
     )
-    store.upsert_target(_make_target())
+    store.upsert_target(_target_store_dict(_make_target()))
 
     created, was_created = store.upsert_target(
         {
@@ -286,7 +294,7 @@ def test_inventory_store_exports_and_imports(tmp_path):
 
     payload = store.export_payload()
     assert payload["active_target_id"] == "pi-1"
-    assert len(payload["targets"]) == 2
+    assert len(cast(list[object], payload["targets"])) == 2
 
     summary = store.import_payload(
         {
@@ -344,7 +352,7 @@ def test_build_source_store_persists_separately_from_inventory(tmp_path):
         operator_config=operator,
         default_deploy_root=operator.default_deploy_root,
     )
-    inventory.upsert_target(_make_target())
+    inventory.upsert_target(_target_store_dict(_make_target()))
     source_path, cache_dir = build_source_store_paths(operator.inventory_path)
     store = BuildSourceStore(source_path, cache_dir=cache_dir)
 

--- a/controls/sae_2025_ws/src/integration/test/test_deploy.py
+++ b/controls/sae_2025_ws/src/integration/test/test_deploy.py
@@ -66,6 +66,10 @@ def _target_context(target_ctx: object) -> TargetContext:
     return cast(TargetContext, target_ctx)
 
 
+def _response_dict(value: object) -> dict[str, Any]:
+    return cast(dict[str, Any], value)
+
+
 class _FakeSSHResult:
     def __init__(self, *, returncode: int = 0, stdout: str = "", stderr: str = ""):
         self.returncode = returncode
@@ -132,9 +136,9 @@ class _FakeAsyncClient:
     def __init__(
         self,
         *,
-        releases_payload: dict,
-        artifacts_payload: dict,
-        commit_payloads: dict[str, dict] | None = None,
+        releases_payload: object,
+        artifacts_payload: object,
+        commit_payloads: dict[str, object] | None = None,
         response_overrides: dict[str, _FakeResponse] | None = None,
     ):
         self.releases_payload = releases_payload
@@ -1530,7 +1534,7 @@ def test_get_fleet_catalog_reuses_stale_exact_build_cache_after_rate_limit(
         )
     )
 
-    first = asyncio.run(deploy_service.get_fleet_catalog(ctx))
+    first = _response_dict(asyncio.run(deploy_service.get_fleet_catalog(ctx)))
     assert first["success"] is True
     assert sorted(first["available_fleets"]) == ["alpha.yaml", "beta.yaml"]
     first_catalog_dir = deploy_service._fleet_catalog_dir(ctx)
@@ -1581,7 +1585,7 @@ def test_get_fleet_catalog_reuses_stale_exact_build_cache_after_rate_limit(
         ),
     )
 
-    second = asyncio.run(deploy_service.get_fleet_catalog(ctx))
+    second = _response_dict(asyncio.run(deploy_service.get_fleet_catalog(ctx)))
 
     assert second["success"] is True
     assert sorted(second["available_fleets"]) == ["alpha.yaml", "beta.yaml"]
@@ -1678,24 +1682,28 @@ def test_build_source_round_trip_and_local_artifact_cache(tmp_path):
     )
     ctx = _make_context(tmp_path, target, fleet_file=tmp_path / "fleet.yaml")
 
-    result = asyncio.run(
-        deploy_service.set_github_build_source(
-            ctx,
-            source="release",
-            tag="build-deadbeef",
-            sha="deadbee",
-            name="build-deadbeef",
+    result = _response_dict(
+        asyncio.run(
+            deploy_service.set_github_build_source(
+                ctx,
+                source="release",
+                tag="build-deadbeef",
+                sha="deadbee",
+                name="build-deadbeef",
+            )
         )
     )
     assert result["success"] is True
     assert result["source"]["kind"] == "github"
     assert result["source"]["tag"] == "build-deadbeef"
 
-    result = asyncio.run(
-        deploy_service.set_local_artifact_build_source(
-            ctx,
-            filename="hardware-build.tar.gz",
-            file_bytes=b"deploy-bundle",
+    result = _response_dict(
+        asyncio.run(
+            deploy_service.set_local_artifact_build_source(
+                ctx,
+                filename="hardware-build.tar.gz",
+                file_bytes=b"deploy-bundle",
+            )
         )
     )
     assert result["success"] is True
@@ -1726,7 +1734,7 @@ def test_deploy_selected_source_dispatches_to_persisted_selection(
         ap_selection="strongest",
     )
 
-    calls: list[tuple[str, dict[str, object]]] = []
+    calls: list[tuple[str, dict[str, Any]]] = []
 
     async def fake_download_build(inner_ctx, **kwargs):
         calls.append(("github", kwargs))
@@ -1853,13 +1861,15 @@ def test_fleet_catalog_exposes_local_artifact_fleets_and_validates_selection(
     )
     assert result["success"] is True
 
-    catalog = asyncio.run(deploy_service.get_fleet_catalog(ctx))
+    catalog = _response_dict(asyncio.run(deploy_service.get_fleet_catalog(ctx)))
     assert catalog["success"] is True
     assert len(catalog["available_fleets"]) == 2
 
     selected_fleet = catalog["available_fleets"][0]
-    result = asyncio.run(
-        deploy_service.set_global_fleet_file(ctx, fleet_file=selected_fleet)
+    result = _response_dict(
+        asyncio.run(
+            deploy_service.set_global_fleet_file(ctx, fleet_file=selected_fleet)
+        )
     )
     assert result["success"] is True
     assert selected_fleet in result["source"]["available_fleets"]
@@ -1869,8 +1879,10 @@ def test_fleet_catalog_exposes_local_artifact_fleets_and_validates_selection(
         "vehicles:\n  - name: uav_9\n    mission: hover\n",
         encoding="utf-8",
     )
-    result = asyncio.run(
-        deploy_service.set_global_fleet_file(ctx, fleet_file=str(rogue_fleet))
+    result = _response_dict(
+        asyncio.run(
+            deploy_service.set_global_fleet_file(ctx, fleet_file=str(rogue_fleet))
+        )
     )
     assert result["success"] is False
     assert "selected build source" in result["error"].lower()
@@ -1886,19 +1898,21 @@ def test_local_artifact_catalog_dedupes_mirrored_fleet_filenames(tmp_path):
 
     bundle_path = _write_mirrored_fleet_bundle(tmp_path, fleet_name="shared.yaml")
 
-    result = asyncio.run(
-        deploy_service.set_local_artifact_build_source(
-            ctx,
-            filename="mirrored-fleet-bundle.tar.gz",
-            file_bytes=bundle_path.read_bytes(),
+    result = _response_dict(
+        asyncio.run(
+            deploy_service.set_local_artifact_build_source(
+                ctx,
+                filename="mirrored-fleet-bundle.tar.gz",
+                file_bytes=bundle_path.read_bytes(),
+            )
         )
     )
     assert result["success"] is True
     assert result["source"]["fleet_catalog_error"] is None
     assert result["source"]["available_fleets"] == ["shared.yaml"]
 
-    result = asyncio.run(
-        deploy_service.set_global_fleet_file(ctx, fleet_file="shared.yaml")
+    result = _response_dict(
+        asyncio.run(deploy_service.set_global_fleet_file(ctx, fleet_file="shared.yaml"))
     )
     assert result["success"] is True
     assert result["source"]["fleet_file"] == "shared.yaml"
@@ -2225,7 +2239,7 @@ def test_perform_action_threads_operator_ap_vehicles_to_deploy(tmp_path, monkeyp
             "ap_selection": "strongest",
         }
     )
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
 
     async def fake_deploy_selected_source(
         inner_ctx,
@@ -2447,11 +2461,15 @@ def test_build_source_change_preserves_matching_fleet_filename(tmp_path):
         name="shared.yaml",
     )
 
-    result = asyncio.run(deploy_service.set_local_codebase_build_source(ctx))
+    result = _response_dict(
+        asyncio.run(deploy_service.set_local_codebase_build_source(ctx))
+    )
     assert result["success"] is True
 
-    result = asyncio.run(
-        deploy_service.set_global_fleet_file(ctx, fleet_file=str(shared_fleet))
+    result = _response_dict(
+        asyncio.run(
+            deploy_service.set_global_fleet_file(ctx, fleet_file=str(shared_fleet))
+        )
     )
     assert result["success"] is True
     assert result["source"]["fleet_file"] == "shared.yaml"
@@ -2460,11 +2478,13 @@ def test_build_source_change_preserves_matching_fleet_filename(tmp_path):
         tmp_path,
         fleet_names=("shared.yaml", "backup.yaml"),
     )
-    result = asyncio.run(
-        deploy_service.set_local_artifact_build_source(
-            ctx,
-            filename="fleet-bundle.tar.gz",
-            file_bytes=bundle_path.read_bytes(),
+    result = _response_dict(
+        asyncio.run(
+            deploy_service.set_local_artifact_build_source(
+                ctx,
+                filename="fleet-bundle.tar.gz",
+                file_bytes=bundle_path.read_bytes(),
+            )
         )
     )
 
@@ -2487,11 +2507,15 @@ def test_build_source_change_clears_missing_fleet_filename(tmp_path):
         name="primary.yaml",
     )
 
-    result = asyncio.run(deploy_service.set_local_codebase_build_source(ctx))
+    result = _response_dict(
+        asyncio.run(deploy_service.set_local_codebase_build_source(ctx))
+    )
     assert result["success"] is True
 
-    result = asyncio.run(
-        deploy_service.set_global_fleet_file(ctx, fleet_file=str(primary_fleet))
+    result = _response_dict(
+        asyncio.run(
+            deploy_service.set_global_fleet_file(ctx, fleet_file=str(primary_fleet))
+        )
     )
     assert result["success"] is True
     assert result["source"]["fleet_file"] == "primary.yaml"
@@ -2500,11 +2524,13 @@ def test_build_source_change_clears_missing_fleet_filename(tmp_path):
         tmp_path,
         fleet_names=("backup.yaml",),
     )
-    result = asyncio.run(
-        deploy_service.set_local_artifact_build_source(
-            ctx,
-            filename="fleet-bundle.tar.gz",
-            file_bytes=bundle_path.read_bytes(),
+    result = _response_dict(
+        asyncio.run(
+            deploy_service.set_local_artifact_build_source(
+                ctx,
+                filename="fleet-bundle.tar.gz",
+                file_bytes=bundle_path.read_bytes(),
+            )
         )
     )
 
@@ -2547,7 +2573,7 @@ def test_fleet_catalog_discovers_nested_actions_artifact_tarball(tmp_path, monke
         )
     )
 
-    catalog = asyncio.run(deploy_service.get_fleet_catalog(ctx))
+    catalog = _response_dict(asyncio.run(deploy_service.get_fleet_catalog(ctx)))
 
     assert catalog["success"] is True
     assert catalog["fleet_catalog_error"] is None

--- a/controls/sae_2025_ws/src/integration/test/test_deploy.py
+++ b/controls/sae_2025_ws/src/integration/test/test_deploy.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import io
-import inspect
 import sys
 import tarfile
 import types
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 import zipfile
 
 import pytest
@@ -26,8 +26,8 @@ backend_pkg.__path__ = [str(PACKAGE_ROOT / "backend")]
 sys.modules.setdefault("backend", backend_pkg)
 
 context_pkg = types.ModuleType("backend.context")
-context_pkg.AppContext = type("AppContext", (), {})
-context_pkg.TargetContext = type("TargetContext", (), {})
+setattr(context_pkg, "AppContext", type("AppContext", (), {}))
+setattr(context_pkg, "TargetContext", type("TargetContext", (), {}))
 sys.modules.setdefault("backend.context", context_pkg)
 
 services_pkg = types.ModuleType("backend.services")
@@ -41,7 +41,29 @@ from backend.config import (  # noqa: E402
     TargetRecord,
     build_source_store_paths,
 )
+from backend.context import AppContext, TargetContext  # noqa: E402
 from backend.services import deploy as deploy_service  # noqa: E402
+
+
+_TargetStoreDict = dict[str, str | bool | None]
+
+
+def _target_store_dict(target: TargetRecord) -> _TargetStoreDict:
+    return cast(_TargetStoreDict, target.to_store_dict())
+
+
+def _minimal_context(tmp_path: Path) -> AppContext:
+    return cast(
+        AppContext,
+        SimpleNamespace(
+            base_dir=tmp_path / "src" / "integration",
+            operator_config=_make_operator(tmp_path),
+        ),
+    )
+
+
+def _target_context(target_ctx: object) -> TargetContext:
+    return cast(TargetContext, target_ctx)
 
 
 class _FakeSSHResult:
@@ -243,28 +265,18 @@ def _make_context(
     *,
     fleet_file: Path | None = None,
     extra_targets: list[TargetRecord] | None = None,
-) -> SimpleNamespace:
+) -> AppContext:
     base_dir = tmp_path / "src" / "integration"
     base_dir.mkdir(parents=True, exist_ok=True)
     operator = _make_operator(tmp_path)
-    inventory_kwargs = {
-        "operator_config": operator,
-        "default_deploy_root": operator.default_deploy_root,
-    }
-    if "seed_target" in inspect.signature(InventoryStore).parameters:
-        inventory = InventoryStore(
-            operator.inventory_path,
-            seed_target=target,
-            **inventory_kwargs,
-        )
-    else:
-        inventory = InventoryStore(
-            operator.inventory_path,
-            **inventory_kwargs,
-        )
-        inventory.upsert_target(target.to_store_dict())
+    inventory = InventoryStore(
+        operator.inventory_path,
+        operator_config=operator,
+        default_deploy_root=operator.default_deploy_root,
+    )
+    inventory.upsert_target(_target_store_dict(target))
     for extra_target in extra_targets or []:
-        inventory.upsert_target(extra_target.to_store_dict())
+        inventory.upsert_target(_target_store_dict(extra_target))
     build_source_path, cache_dir = build_source_store_paths(operator.inventory_path)
     build_source_store = BuildSourceStore(
         build_source_path,
@@ -317,18 +329,21 @@ def _make_context(
             ssh=_FakeSSH(result=_FakeSSHResult()),
         )
 
-    return SimpleNamespace(
-        base_dir=base_dir,
-        operator_config=operator,
-        inventory=inventory,
-        build_source_store=build_source_store,
-        require_deploy_context=require_deploy_context,
-        resolve_target=lambda target_id=None: SimpleNamespace(
-            target=inventory.get_target(target_id),
-            ssh=_FakeSSH(result=_FakeSSHResult()),
+    return cast(
+        AppContext,
+        SimpleNamespace(
+            base_dir=base_dir,
+            operator_config=operator,
+            inventory=inventory,
+            build_source_store=build_source_store,
+            require_deploy_context=require_deploy_context,
+            resolve_target=lambda target_id=None: SimpleNamespace(
+                target=inventory.get_target(target_id),
+                ssh=_FakeSSH(result=_FakeSSHResult()),
+            ),
+            resolve_live_target=resolve_live_target,
+            list_targets=inventory.list_targets,
         ),
-        resolve_live_target=resolve_live_target,
-        list_targets=inventory.list_targets,
     )
 
 
@@ -990,7 +1005,7 @@ def test_release_metadata_payload_and_summary(tmp_path):
     target_ctx = SimpleNamespace(target=target)
 
     metadata = deploy_service._release_metadata_payload(
-        target_ctx,
+        _target_context(target_ctx),
         release_id="20260411-build-hover",
         source_type="source-build",
         source_label="local-uav.tar.gz",
@@ -1112,10 +1127,7 @@ def test_build_local_source_bundle_scopes_packages_for_target(tmp_path, monkeypa
 
 
 def test_list_builds_combines_releases_and_artifacts(tmp_path, monkeypatch):
-    ctx = SimpleNamespace(
-        base_dir=tmp_path / "src" / "integration",
-        operator_config=_make_operator(tmp_path),
-    )
+    ctx = _minimal_context(tmp_path)
 
     fake_httpx = SimpleNamespace(
         AsyncClient=lambda timeout=20: _FakeAsyncClient(
@@ -1252,10 +1264,7 @@ def test_list_builds_combines_releases_and_artifacts(tmp_path, monkeypatch):
 def test_list_builds_enriches_actions_artifacts_from_workflow_run_lookup(
     tmp_path, monkeypatch
 ):
-    ctx = SimpleNamespace(
-        base_dir=tmp_path / "src" / "integration",
-        operator_config=_make_operator(tmp_path),
-    )
+    ctx = _minimal_context(tmp_path)
 
     run_id = "42"
     artifact_id = "99"
@@ -1334,10 +1343,7 @@ def test_list_builds_enriches_actions_artifacts_from_workflow_run_lookup(
 
 
 def test_list_builds_uses_cached_response_for_repeat_requests(tmp_path, monkeypatch):
-    ctx = SimpleNamespace(
-        base_dir=tmp_path / "src" / "integration",
-        operator_config=_make_operator(tmp_path),
-    )
+    ctx = _minimal_context(tmp_path)
 
     client_creations = 0
 
@@ -1379,10 +1385,7 @@ def test_list_builds_uses_cached_response_for_repeat_requests(tmp_path, monkeypa
 def test_list_builds_returns_stale_cache_when_github_rate_limited(
     tmp_path, monkeypatch
 ):
-    ctx = SimpleNamespace(
-        base_dir=tmp_path / "src" / "integration",
-        operator_config=_make_operator(tmp_path),
-    )
+    ctx = _minimal_context(tmp_path)
     ctx.operator_config.github_token = ""
 
     base_httpx = SimpleNamespace(
@@ -1910,7 +1913,7 @@ def test_ensure_runtime_prereqs_uses_shared_deploy_lib(tmp_path):
     ctx = _make_context(tmp_path, target)
     helper_path = _write_deploy_lib(tmp_path)
 
-    target_ctx = ctx.resolve_target("pi-runtime-prereqs")
+    target_ctx = cast(Any, ctx.resolve_target("pi-runtime-prereqs"))
     asyncio.run(deploy_service._ensure_runtime_prereqs(ctx, target_ctx))
 
     paths = target_ctx.target.deploy_paths()
@@ -1933,7 +1936,7 @@ def test_ensure_source_build_prereqs_uses_shared_deploy_lib(tmp_path):
     ctx = _make_context(tmp_path, target)
     helper_path = _write_deploy_lib(tmp_path)
 
-    target_ctx = ctx.resolve_target("pi-source-prereqs")
+    target_ctx = cast(Any, ctx.resolve_target("pi-source-prereqs"))
     asyncio.run(deploy_service._ensure_source_build_prereqs(ctx, target_ctx))
 
     paths = target_ctx.target.deploy_paths()
@@ -1958,7 +1961,7 @@ def test_runner_script_disables_nounset_only_around_ros_setup(tmp_path):
         ssh=_FakeSSH(result=_FakeSSHResult()),
     )
 
-    script = deploy_service._runner_script(target_ctx)
+    script = deploy_service._runner_script(_target_context(target_ctx))
 
     assert "set -euo pipefail" in script
     assert "set +u" in script
@@ -2087,7 +2090,7 @@ def test_activate_release_polls_stability_and_rolls_back_on_instability(tmp_path
     with pytest.raises(RuntimeError, match="Reverted to the previous release"):
         asyncio.run(
             deploy_service._activate_release(
-                target_ctx,
+                _target_context(target_ctx),
                 release_dir="/home/penn/pennair-deploy/releases/release-new",
                 previous_target="/home/penn/pennair-deploy/releases/release-old",
             )
@@ -2419,7 +2422,7 @@ def test_batch_action_marks_top_level_failure_when_any_row_fails(tmp_path, monke
 
     result = asyncio.run(
         fleet_service.batch_action(
-            SimpleNamespace(),
+            cast(AppContext, SimpleNamespace()),
             action="deploy",
         )
     )

--- a/controls/sae_2025_ws/src/integration/test/test_deploy.py
+++ b/controls/sae_2025_ws/src/integration/test/test_deploy.py
@@ -67,7 +67,8 @@ def _target_context(target_ctx: object) -> TargetContext:
 
 
 def _response_dict(value: object) -> dict[str, Any]:
-    return cast(dict[str, Any], value)
+    assert isinstance(value, dict)
+    return value
 
 
 class _FakeSSHResult:

--- a/controls/sae_2025_ws/src/integration/test/test_discovery.py
+++ b/controls/sae_2025_ws/src/integration/test/test_discovery.py
@@ -5,6 +5,7 @@ import sys
 import types
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 import subprocess
 
 
@@ -18,6 +19,7 @@ sys.modules.setdefault("backend", backend_pkg)
 
 from backend import discovery  # noqa: E402
 from backend.config import InventoryStore, OperatorConfig  # noqa: E402
+from backend.context import AppContext  # noqa: E402
 
 
 def _reset_discovery_snapshot() -> None:
@@ -53,7 +55,7 @@ def _make_operator(tmp_path: Path) -> OperatorConfig:
     )
 
 
-def _make_context(tmp_path: Path) -> SimpleNamespace:
+def _make_context(tmp_path: Path) -> AppContext:
     operator = _make_operator(tmp_path)
     inventory = InventoryStore(
         operator.inventory_path,
@@ -74,7 +76,7 @@ def _make_context(tmp_path: Path) -> SimpleNamespace:
             "service_unit": "pennair-autonomy.service",
         }
     )
-    return SimpleNamespace(list_targets=inventory.list_targets)
+    return cast(AppContext, SimpleNamespace(list_targets=inventory.list_targets))
 
 
 def test_live_hardware_cards_return_hostname_scoped_devices(tmp_path, monkeypatch):
@@ -146,7 +148,7 @@ def test_live_hardware_cards_ignore_inventory_matches(tmp_path, monkeypatch):
             "service_unit": "pennair-autonomy.service",
         }
     )
-    ctx = SimpleNamespace(list_targets=inventory.list_targets)
+    ctx = cast(AppContext, SimpleNamespace(list_targets=inventory.list_targets))
 
     monkeypatch.setattr(
         discovery,


### PR DESCRIPTION
Fixes #238.
Fixes #240.
Part of #201.

## Summary
- Type dynamic app and target contexts in integration backend tests.
- Type deploy/API response payload helpers and captured fake HTTP payloads.
- Remove obsolete InventoryStore compatibility paths from the tests.

## Verification
- `npx --yes pyright controls/sae_2025_ws/src/integration/integration_tests/test_deploy.py controls/sae_2025_ws/src/integration/integration_tests/test_api_contract.py controls/sae_2025_ws/src/integration/integration_tests/test_config.py controls/sae_2025_ws/src/integration/integration_tests/test_discovery.py --outputjson` => 0 errors
- `ruff format` / `ruff check` on touched integration test files
- `python3 -m pytest -q controls/sae_2025_ws/src/integration/integration_tests/test_deploy.py controls/sae_2025_ws/src/integration/integration_tests/test_api_contract.py controls/sae_2025_ws/src/integration/integration_tests/test_config.py controls/sae_2025_ws/src/integration/integration_tests/test_discovery.py` => 96 passed
