### PR TITLE
Type UAV peer contract tests

### DIFF
--- a/controls/sae_2025_ws/src/uav/test/test_peer_runtime_contract.py
+++ b/controls/sae_2025_ws/src/uav/test/test_peer_runtime_contract.py
@@ -5,7 +5,7 @@ import sys
 import textwrap
 from types import SimpleNamespace
 import types
-from typing import Any
+from typing import Any, Mapping, cast
 
 import pytest
 
@@ -236,8 +236,8 @@ class _RecordingNode:
         return SimpleNamespace(kind="service", name=service_name)
 
 
-def _make_mode_manager() -> ModeManager:
-    manager = object.__new__(ModeManager)
+def _make_mode_manager() -> Any:
+    manager = cast(Any, object.__new__(ModeManager))
     manager.vehicle = _FakeVehicle()
     manager.modes = {}
     manager.transitions = {}
@@ -409,7 +409,9 @@ def test_build_mode_registry_entry_includes_peer_vehicle_names():
         def __init__(self, node, vehicle) -> None:
             super().__init__(node, vehicle)
 
-        def on_disconnect(self, time_delta: float, peers: dict[str, bool]) -> None:
+        def on_disconnect(
+            self, time_delta: float, connection_status: Mapping[str, bool]
+        ) -> None:
             pass
 
         def on_update(self, time_delta: float) -> None:
@@ -530,7 +532,9 @@ def test_mode_manager_validates_peer_and_shared_entity_namespaces(monkeypatch):
             )
             self.shared_pub = self.node.create_publisher(object, "/shared/debug", 1)
 
-        def on_disconnect(self, time_delta: float, peers: dict[str, bool]) -> None:
+        def on_disconnect(
+            self, time_delta: float, connection_status: Mapping[str, bool]
+        ) -> None:
             pass
 
         def on_update(self, time_delta: float) -> None:
@@ -575,7 +579,9 @@ def test_mode_manager_validates_peer_and_shared_entity_namespaces(monkeypatch):
     )
 
     manager = _make_mode_manager()
-    mode = ModeManager.initialize_mode(manager, "fake.module.PeerAwareMode", {})
+    mode = cast(
+        Any, ModeManager.initialize_mode(manager, "fake.module.PeerAwareMode", {})
+    )
     _configure_manager_for_mode(manager, mode)
 
     with manager._use_comm_builder(
@@ -634,7 +640,7 @@ def test_run_active_mode_uses_connection_ready_for_gating():
             self.connection_checks: list[dict[str, bool]] = []
             self.status_checks = 0
 
-        def connection_ready(self, connection_status: dict[str, bool]) -> bool:
+        def connection_ready(self, connection_status: Mapping[str, bool]) -> bool:
             self.connection_checks.append(dict(connection_status))
             return True
 
@@ -642,7 +648,7 @@ def test_run_active_mode_uses_connection_ready_for_gating():
             self.update_calls.append(time_delta)
 
         def on_disconnect(
-            self, time_delta: float, connection_status: dict[str, bool]
+            self, time_delta: float, connection_status: Mapping[str, bool]
         ) -> None:
             self.disconnect_calls.append((time_delta, dict(connection_status)))
 
@@ -688,12 +694,12 @@ def test_run_active_mode_passes_full_connection_status_to_disconnect():
             self.connection_checks: list[dict[str, bool]] = []
             self.status_checks = 0
 
-        def connection_ready(self, connection_status: dict[str, bool]) -> bool:
+        def connection_ready(self, connection_status: Mapping[str, bool]) -> bool:
             self.connection_checks.append(dict(connection_status))
             return False
 
         def on_disconnect(
-            self, time_delta: float, connection_status: dict[str, bool]
+            self, time_delta: float, connection_status: Mapping[str, bool]
         ) -> None:
             self.disconnect_calls.append((time_delta, dict(connection_status)))
 
@@ -732,7 +738,9 @@ def test_mode_connection_ready_defaults_to_all_declared_peers_connected():
         def __init__(self, node, vehicle) -> None:
             super().__init__(node, vehicle)
 
-        def on_disconnect(self, time_delta: float, peers: dict[str, bool]) -> None:
+        def on_disconnect(
+            self, time_delta: float, connection_status: Mapping[str, bool]
+        ) -> None:
             pass
 
         def on_update(self, time_delta: float) -> None:
@@ -741,7 +749,7 @@ def test_mode_connection_ready_defaults_to_all_declared_peers_connected():
         def check_status(self) -> str:
             return "continue"
 
-    mode = PeerAwareMode(_RecordingNode(), _FakeVehicle())
+    mode = PeerAwareMode(cast(Any, _RecordingNode()), cast(Any, _FakeVehicle()))
 
     assert mode.connection_ready({"uav_1": True, "uav_2": True}) is True
     assert mode.connection_ready({"uav_1": True, "uav_2": False}) is False
@@ -761,7 +769,9 @@ def test_peer_client_wrapper_rebinds_on_connection_changes(monkeypatch):
         def __init__(self, node, vehicle) -> None:
             super().__init__(node, vehicle)
 
-        def on_disconnect(self, time_delta: float, peers: dict[str, bool]) -> None:
+        def on_disconnect(
+            self, time_delta: float, connection_status: Mapping[str, bool]
+        ) -> None:
             pass
 
         def on_update(self, time_delta: float) -> None:
@@ -870,7 +880,9 @@ def test_managed_entity_descriptors_use_persistent_and_active_phases(monkeypatch
             super().__init__(node, vehicle)
             self.node.create_publisher(object, "/shared/debug", 1)
 
-        def on_disconnect(self, time_delta: float, peers: dict[str, bool]) -> None:
+        def on_disconnect(
+            self, time_delta: float, connection_status: Mapping[str, bool]
+        ) -> None:
             pass
 
         def on_enter(self) -> None:
@@ -930,7 +942,9 @@ def test_shared_state_for_is_keyed_by_canonical_mode_path():
         def __init__(self, node, vehicle) -> None:
             super().__init__(node, vehicle)
 
-        def on_disconnect(self, time_delta: float, peers: dict[str, bool]) -> None:
+        def on_disconnect(
+            self, time_delta: float, connection_status: Mapping[str, bool]
+        ) -> None:
             pass
 
         def on_update(self, time_delta: float) -> None:
@@ -966,7 +980,9 @@ def test_peer_entity_usage_instrumentation_matches_declared_peers():
             super().__init__(node, vehicle)
             self.node.create_subscription(object, "/uav_2/status", lambda _msg: None, 1)
 
-        def on_disconnect(self, time_delta: float, peers: dict[str, bool]) -> None:
+        def on_disconnect(
+            self, time_delta: float, connection_status: Mapping[str, bool]
+        ) -> None:
             pass
 
         def on_enter(self) -> None:
@@ -980,7 +996,7 @@ def test_peer_entity_usage_instrumentation_matches_declared_peers():
             return "continue"
 
     node = _RecordingNode()
-    mode = InstrumentedPeerMode(node, _FakeVehicle())
+    mode = InstrumentedPeerMode(cast(Any, node), cast(Any, _FakeVehicle()))
     mode.activate()
 
     assert _observed_peer_vehicle_names(node.calls, mode.peer_vehicle_names) == {

--- a/controls/sae_2025_ws/src/uav/test/test_peer_stack_reconnect.py
+++ b/controls/sae_2025_ws/src/uav/test/test_peer_stack_reconnect.py
@@ -9,6 +9,7 @@ import shutil
 import signal
 import subprocess
 import time
+from typing import cast
 
 import pytest
 
@@ -104,7 +105,7 @@ class _PeerStackObserver(Node):
                 String,
                 f"/{vehicle_name}/peer_test/state",
                 lambda message, vehicle_name=vehicle_name: self._on_status(
-                    vehicle_name, message
+                    vehicle_name, cast(String, message)
                 ),
                 10,
             )
@@ -388,6 +389,12 @@ def _launch_vehicle_stack(
     )
 
 
+def _status_int(status: dict[str, object], key: str) -> int:
+    value = status[key]
+    assert isinstance(value, int)
+    return value
+
+
 @pytest.fixture
 def live_ros_environment(monkeypatch):
     _require_uav_package()
@@ -483,9 +490,9 @@ def test_vehicle_stack_peer_reconnect_recovers_state_and_traffic(
         assert observer.shared_counts_by_sender.get("payload_0", 0) > 0
         assert observer.shared_counts_by_sender.get("payload_1", 0) > 0
 
-        payload_0_peer_before_disconnect = int(status_0["peer_received_total"])
-        payload_0_shared_before_disconnect = int(
-            status_0["shared_remote_received_total"]
+        payload_0_peer_before_disconnect = _status_int(status_0, "peer_received_total")
+        payload_0_shared_before_disconnect = _status_int(
+            status_0, "shared_remote_received_total"
         )
         payload_1_shared_events_before_disconnect = (
             observer.shared_counts_by_sender.get("payload_1", 0)
@@ -502,9 +509,12 @@ def test_vehicle_stack_peer_reconnect_recovers_state_and_traffic(
             state="waiting",
             disconnected_peers=["payload_1"],
         )
-        assert int(waiting_0["peer_received_total"]) >= payload_0_peer_before_disconnect
         assert (
-            int(waiting_0["shared_remote_received_total"])
+            _status_int(waiting_0, "peer_received_total")
+            >= payload_0_peer_before_disconnect
+        )
+        assert (
+            _status_int(waiting_0, "shared_remote_received_total")
             >= payload_0_shared_before_disconnect
         )
 
@@ -563,15 +573,15 @@ def test_vehicle_stack_peer_reconnect_recovers_state_and_traffic(
             shared_remote_received_total=1,
         )
         assert (
-            int(reconnect_status_0["peer_received_total"])
+            _status_int(reconnect_status_0, "peer_received_total")
             > payload_0_peer_before_disconnect
         )
         assert (
-            int(reconnect_status_0["shared_remote_received_total"])
+            _status_int(reconnect_status_0, "shared_remote_received_total")
             > payload_0_shared_before_disconnect
         )
-        assert int(reconnect_status_1["peer_received_total"]) > 0
-        assert int(reconnect_status_1["shared_remote_received_total"]) > 0
+        assert _status_int(reconnect_status_1, "peer_received_total") > 0
+        assert _status_int(reconnect_status_1, "shared_remote_received_total") > 0
         assert (
             observer.shared_counts_by_sender.get("payload_1", 0)
             > payload_1_shared_events_before_disconnect


### PR DESCRIPTION
Fixes #246.
Part of #201.
Stacked on #243.

## Summary
- Cast isolated ModeManager and node fakes used by peer contract tests.
- Align peer mode override signatures with the Mode peer contract.
- Narrow live reconnect status payload fields before integer comparisons.

## Verification
- `python3 -m py_compile controls/sae_2025_ws/src/uav/test/test_peer_runtime_contract.py controls/sae_2025_ws/src/uav/test/test_peer_stack_reconnect.py`
- `npx --yes pyright controls/sae_2025_ws/src/uav/test/test_peer_runtime_contract.py controls/sae_2025_ws/src/uav/test/test_peer_stack_reconnect.py --outputjson` => 0 errors
- `ruff format controls/sae_2025_ws/src/uav/test/test_peer_runtime_contract.py controls/sae_2025_ws/src/uav/test/test_peer_stack_reconnect.py`
- `ruff check controls/sae_2025_ws/src/uav/test/test_peer_runtime_contract.py controls/sae_2025_ws/src/uav/test/test_peer_stack_reconnect.py`
- `python3 -m pytest -q controls/sae_2025_ws/src/uav/test/test_peer_runtime_contract.py` => 12 passed
- `python3 -m pytest -q controls/sae_2025_ws/src/uav/test/test_peer_stack_reconnect.py` => 1 passed
