### PR TITLE
prebuild px4_msgs into the CI image to speed up ros-validate

### DIFF
--- a/controls/sae_2025_ws/scripts/ci/common.sh
+++ b/controls/sae_2025_ws/scripts/ci/common.sh
@@ -126,3 +126,34 @@ ci_install_pigpio() {
 ci_py_files() {
     find src/uav src/payload src/vehicle_common src/sim src/tools -name '*.py' | sort
 }
+
+# Install prefix for the px4_msgs that is prebuilt into the CI image so per-PR
+# validation does not have to recompile it (~6 minutes). Single source of truth
+# shared by the image build and the validation script.
+ci_px4_msgs_prefix() {
+    echo "/opt/px4_msgs"
+}
+
+# Build px4_msgs at $1 (a commit SHA) into the prefix above, and record the
+# exact commit baked so validation can detect submodule drift.
+ci_build_px4_msgs() {
+    local commit="$1"
+    local prefix
+    prefix=$(ci_px4_msgs_prefix)
+    local ws="/tmp/px4_msgs_ws"
+
+    ci_log "Building px4_msgs ($commit) into $prefix"
+    rm -rf "$ws"
+    mkdir -p "$ws/src"
+    git clone https://github.com/PX4/px4_msgs.git "$ws/src/px4_msgs"
+    git -C "$ws/src/px4_msgs" checkout "$commit"
+
+    (
+        cd "$ws"
+        ci_source_ros
+        colcon build --merge-install --install-base "$prefix"
+    )
+
+    echo "$commit" > "$prefix/PINNED_COMMIT"
+    rm -rf "$ws"
+}

--- a/controls/sae_2025_ws/scripts/ci/install_ros_ci_deps.sh
+++ b/controls/sae_2025_ws/scripts/ci/install_ros_ci_deps.sh
@@ -35,3 +35,9 @@ python3 -m pip install --no-cache-dir \
     "fastapi[standard]" \
     httpx \
     python-multipart
+
+# Prebuild px4_msgs so per-PR validation does not recompile it (~6 min). Keep
+# this commit in sync with the px4_msgs submodule gitlink; validate_ros_workspace.sh
+# fails the build if they drift.
+PX4_MSGS_COMMIT="86d8239e962f6939e05c3737784f60c02fa884db"
+ci_build_px4_msgs "$PX4_MSGS_COMMIT"

--- a/controls/sae_2025_ws/scripts/ci/validate_ros_workspace.sh
+++ b/controls/sae_2025_ws/scripts/ci/validate_ros_workspace.sh
@@ -29,9 +29,32 @@ rosdep install -r -i -y --rosdistro "$ROS_DISTRO" \
     src/payload src/payload_interfaces src/tools src/vehicle_common \
     src/payload_controller src/sim src/udp_bridge
 
+ci_log "Resolving prebuilt px4_msgs"
+PX4_MSGS_PREFIX="$(ci_px4_msgs_prefix)"
+BUILD_PX4_MSGS=1
+if [[ -f "$PX4_MSGS_PREFIX/PINNED_COMMIT" ]]; then
+    baked_commit="$(cat "$PX4_MSGS_PREFIX/PINNED_COMMIT")"
+    # The checked-out submodule commit (in CI this equals the pinned gitlink).
+    pinned_commit="$(git -C src/px4_msgs rev-parse HEAD 2>/dev/null || true)"
+    if [[ -n "$pinned_commit" && "$baked_commit" != "$pinned_commit" ]]; then
+        ci_log "ERROR: prebuilt px4_msgs ($baked_commit) does not match the checked-out submodule ($pinned_commit)."
+        ci_log "Update PX4_MSGS_COMMIT in scripts/ci/install_ros_ci_deps.sh and rebuild the CI image,"
+        ci_log "or run 'git submodule update --init src/px4_msgs' to match the pin."
+        exit 1
+    fi
+    ci_log "Using prebuilt px4_msgs ($baked_commit)"
+    ci_source_setup "$PX4_MSGS_PREFIX/setup.sh"
+    BUILD_PX4_MSGS=0
+else
+    ci_log "No prebuilt px4_msgs found; building it from source"
+fi
+
 ci_log "Building shared hardware dependencies"
-colcon build \
-    --packages-select payload_interfaces px4_msgs uav_interfaces actuator_msgs udp_bridge vehicle_common
+shared_packages=(payload_interfaces uav_interfaces actuator_msgs udp_bridge vehicle_common)
+if [[ "$BUILD_PX4_MSGS" == "1" ]]; then
+    shared_packages+=(px4_msgs)
+fi
+colcon build --packages-select "${shared_packages[@]}"
 
 ci_log "Building hardware payload package"
 ci_source_workspace "$WORKSPACE_ROOT"


### PR DESCRIPTION
ROS Validate takes 2min instead of 7min

builds on #256 for testing the workflow

need to investigate why px4msgs is rebuilding inside ros ci image and taking so long