### PR TITLE
uses astral-sh's ruff action install of manual install. 

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -2,17 +2,8 @@ name: Static Checks
 
 on:
   push:
-    branches: [main, master, integration]
-    paths:
-      - ".github/workflows/**"
-      - ".github/ci/**"
-      - "controls/sae_2025_ws/**"
+    branches: [main]
   pull_request:
-    branches: [main, master]
-    paths:
-      - ".github/workflows/**"
-      - ".github/ci/**"
-      - "controls/sae_2025_ws/**"
   workflow_dispatch:
 
 permissions:
@@ -31,20 +22,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
       - name: Install Ruff
-        run: python -m pip install ruff==0.15.10
+        uses: astral-sh/ruff-action@v4.0.0
+        with:
+          version: "0.15.10"
+          args: "--version"
 
-      - name: Check Ruff formatting
-        working-directory: controls/sae_2025_ws
+      - name: Check Ruff Formatting
         run: ruff format --check --diff .
 
       - name: Check Ruff lint
-        working-directory: controls/sae_2025_ws
         run: ruff check .
 
       - name: Run actionlint

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           version: "0.15.10"
           args: "--version"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Ruff Formatting
         run: ruff format --check --diff .
@@ -34,5 +35,8 @@ jobs:
       - name: Check Ruff lint
         run: ruff check .
 
-      - name: Run actionlint
-        uses: rhysd/actionlint@v1.7.8
+      - name: actionlint Check workflow files
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color
+        shell: bash


### PR DESCRIPTION
uses astral-sh's ruff action install of manual install. 

Also changed it so that static checks run on every pull request to any branch.
Since I moved pyproject.toml to project root, ruff now checks and format checks from project root

Removed runs specific to paths, static checks run on every change now (this change could be debated, bc small changes like adding readme  checks for no particular reasons