### PR TITLE
start new sim launch

### DIFF
--- a/controls/sae_2025_ws/src/sim/launch/sim2.launch.py
+++ b/controls/sae_2025_ws/src/sim/launch/sim2.launch.py
@@ -1,0 +1,120 @@
+import os
+from enum import StrEnum
+from pathlib import Path
+
+from launch import LaunchDescription, Action
+from launch.actions import (
+    DeclareLaunchArgument,
+    OpaqueFunction,
+    ExecuteProcess,
+)
+
+from vehicle_common.launch_utils import (
+    get_logger,
+    LaunchError,
+    is_truthy,
+    format_bullet_list,
+    prepend_env_path
+)
+
+from sim.utils import get_available_worlds
+
+logger = get_logger("sim.launch")
+
+# TODO: Make these get envs during launch a helper
+PENNAIR_GZ_MODELS_PATH = os.environ.get("PENNAIR_GZ_MODELS_PATH", "")
+if not PENNAIR_GZ_MODELS_PATH:
+    raise LaunchError(
+        "PENNAIR_GZ_MODELS_PATH is not set. Please source dev_env.sh or manually set it"
+    )
+
+PENNAIR_PX4_PATH = os.environ.get("PENNAIR_PX4_PATH", "")
+if not PENNAIR_PX4_PATH:
+    raise LaunchError(
+        "PENNAIR_PX4_PATH is not set. Please source dev_env.sh or manually set it"
+    )
+
+GZ_SIM_RESOURCE_PATH = Path(PENNAIR_GZ_MODELS_PATH) / "models"
+# Prepends value to existing value, bc we don't want to overwrite any user-set paths
+GZ_SIM_RESOURCE_PATH = prepend_env_path("GZ_SIM_RESOURCE_PATH", str(GZ_SIM_RESOURCE_PATH))
+
+GZ_SIM_SERVER_CONFIG_PATH = Path(PENNAIR_GZ_MODELS_PATH) / "server.config" # no need to prepend because points to file
+
+# .so plugins include: libOpticalFlowSystem.so, libGstCameraSystem.so, etc.
+GZ_SIM_SYSTEM_PLUGIN_PATH = Path(PENNAIR_PX4_PATH) / "build" / "px4_sitl_default" / "src" / "modules" / "simulation" / "gz_plugins" # noqa: F401
+GZ_SIM_SYSTEM_PLUGIN_PATH = prepend_env_path("GZ_SIM_SYSTEM_PLUGIN_PATH", str(GZ_SIM_SYSTEM_PLUGIN_PATH)) # noqa: F401
+
+GZ_WORLDS_PATH = Path(PENNAIR_GZ_MODELS_PATH) / "worlds" # not a default GZ_SIM* env var, so no need to prepend
+
+logger.debug(f"ENV VAR DETECTED: PENNAIR_GZ_MODELS_PATH={PENNAIR_GZ_MODELS_PATH}")
+logger.debug(f"ENV VAR DETECTED: PENNAIR_PX4_PATH={PENNAIR_PX4_PATH}")
+logger.debug(f"GZ_SIM_RESOURCE_PATH={GZ_SIM_RESOURCE_PATH}")
+logger.debug(f"GZ_SIM_SERVER_CONFIG_PATH={GZ_SIM_SERVER_CONFIG_PATH}")
+logger.debug(f"GZ_SIM_SYSTEM_PLUGIN_PATH={GZ_SIM_SYSTEM_PLUGIN_PATH}")
+
+
+class Args(StrEnum):
+    """Maps constants to launch argument keyords"""
+
+    WORLD = "world"
+    HEADLESS = "headless"
+
+
+def gz_sim_command(world: str, headless: bool) -> list[str]:
+    world_path = GZ_WORLDS_PATH / f"{world}.sdf"
+    cmd = ["gz", "sim", "--render-engine", "ogre", "-r", str(world_path)]
+    if headless:
+        cmd.extend(["-s", "--headless-rendering"])  # add flags for gz headless mode
+    return cmd
+
+
+def launch_setup(context) -> list[Action]:
+    config = context.launch_configurations  # dict containing declared launch arguments
+
+    headless: bool = is_truthy(config[Args.HEADLESS])
+    world: str = config[Args.WORLD]
+
+    gz_env = {
+        "GZ_SIM_RESOURCE_PATH":  GZ_SIM_RESOURCE_PATH,
+        "GZ_SIM_SERVER_CONFIG_PATH": GZ_SIM_SERVER_CONFIG_PATH,
+        "GZ_SIM_SYSTEM_PLUGIN_PATH": GZ_SIM_SYSTEM_PLUGIN_PATH,
+    }
+    # TODO: These need to be documented
+    if headless:  # what do these env vars do?
+        gz_env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        gz_env["QT_QPA_PLATFORM"] = "offscreen"
+    else:
+        gz_env["QT_QPA_PLATFORM_PLUGIN_PATH"] = ""
+        gz_env["QT_QPA_FONTDIR"] = ""
+
+    gz = ExecuteProcess(
+        cmd=gz_sim_command(world, headless),
+        output="log",
+        name=f"gz_{world}",
+        additional_env=gz_env,  # type: ignore (dict[str, str] works instead of SomeSubstitutionsType)
+    )
+
+    logger.info(f"Creating world: {world}")
+    return [gz]
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                Args.WORLD,
+                default_value="default",
+                description=format_bullet_list(
+                    "simulation world for gz to load. Looks under {PENNAIR_GZ_MODELS_PATH}/worlds/{world}.sdf\n\tAvailable Worlds:",
+                    options=get_available_worlds(GZ_WORLDS_PATH),
+                ),
+            ),
+            DeclareLaunchArgument(
+                Args.HEADLESS,
+                default_value="false",
+                description="If true, runs gz server in headless mode (no GUI)",
+                choices=["true", "false", "t", "f", "0", "1"]
+            ),
+            OpaqueFunction(function=launch_setup),
+        ]
+    )

--- a/controls/sae_2025_ws/src/sim/launch/sim2.launch.py
+++ b/controls/sae_2025_ws/src/sim/launch/sim2.launch.py
@@ -14,7 +14,7 @@ from vehicle_common.launch_utils import (
     LaunchError,
     is_truthy,
     format_bullet_list,
-    prepend_env_path
+    prepend_env_path,
 )
 
 from sim.utils import get_available_worlds
@@ -36,15 +36,31 @@ if not PENNAIR_PX4_PATH:
 
 GZ_SIM_RESOURCE_PATH = Path(PENNAIR_GZ_MODELS_PATH) / "models"
 # Prepends value to existing value, bc we don't want to overwrite any user-set paths
-GZ_SIM_RESOURCE_PATH = prepend_env_path("GZ_SIM_RESOURCE_PATH", str(GZ_SIM_RESOURCE_PATH))
+GZ_SIM_RESOURCE_PATH = prepend_env_path(
+    "GZ_SIM_RESOURCE_PATH", str(GZ_SIM_RESOURCE_PATH)
+)
 
-GZ_SIM_SERVER_CONFIG_PATH = Path(PENNAIR_GZ_MODELS_PATH) / "server.config" # no need to prepend because points to file
+GZ_SIM_SERVER_CONFIG_PATH = (
+    Path(PENNAIR_GZ_MODELS_PATH) / "server.config"
+)  # no need to prepend because points to file
 
 # .so plugins include: libOpticalFlowSystem.so, libGstCameraSystem.so, etc.
-GZ_SIM_SYSTEM_PLUGIN_PATH = Path(PENNAIR_PX4_PATH) / "build" / "px4_sitl_default" / "src" / "modules" / "simulation" / "gz_plugins" # noqa: F401
-GZ_SIM_SYSTEM_PLUGIN_PATH = prepend_env_path("GZ_SIM_SYSTEM_PLUGIN_PATH", str(GZ_SIM_SYSTEM_PLUGIN_PATH)) # noqa: F401
+GZ_SIM_SYSTEM_PLUGIN_PATH = (
+    Path(PENNAIR_PX4_PATH)
+    / "build"
+    / "px4_sitl_default"
+    / "src"
+    / "modules"
+    / "simulation"
+    / "gz_plugins"
+)  # noqa: F401
+GZ_SIM_SYSTEM_PLUGIN_PATH = prepend_env_path(
+    "GZ_SIM_SYSTEM_PLUGIN_PATH", str(GZ_SIM_SYSTEM_PLUGIN_PATH)
+)  # noqa: F401
 
-GZ_WORLDS_PATH = Path(PENNAIR_GZ_MODELS_PATH) / "worlds" # not a default GZ_SIM* env var, so no need to prepend
+GZ_WORLDS_PATH = (
+    Path(PENNAIR_GZ_MODELS_PATH) / "worlds"
+)  # not a default GZ_SIM* env var, so no need to prepend
 
 logger.debug(f"ENV VAR DETECTED: PENNAIR_GZ_MODELS_PATH={PENNAIR_GZ_MODELS_PATH}")
 logger.debug(f"ENV VAR DETECTED: PENNAIR_PX4_PATH={PENNAIR_PX4_PATH}")
@@ -75,7 +91,7 @@ def launch_setup(context) -> list[Action]:
     world: str = config[Args.WORLD]
 
     gz_env = {
-        "GZ_SIM_RESOURCE_PATH":  GZ_SIM_RESOURCE_PATH,
+        "GZ_SIM_RESOURCE_PATH": GZ_SIM_RESOURCE_PATH,
         "GZ_SIM_SERVER_CONFIG_PATH": GZ_SIM_SERVER_CONFIG_PATH,
         "GZ_SIM_SYSTEM_PLUGIN_PATH": GZ_SIM_SYSTEM_PLUGIN_PATH,
     }
@@ -113,7 +129,7 @@ def generate_launch_description():
                 Args.HEADLESS,
                 default_value="false",
                 description="If true, runs gz server in headless mode (no GUI)",
-                choices=["true", "false", "t", "f", "0", "1"]
+                choices=["true", "false", "t", "f", "0", "1"],
             ),
             OpaqueFunction(function=launch_setup),
         ]

--- a/controls/sae_2025_ws/src/sim/sim/utils.py
+++ b/controls/sae_2025_ws/src/sim/sim/utils.py
@@ -182,7 +182,7 @@ def build_node_arguments(node_class: type, params: Dict[str, Any]) -> Dict[str, 
 
     return args
 
-
+# why does this exist when we have symlink-install?
 def find_package_resource(
     relative_path: Union[str, Path],
     package_name: str = "sim",
@@ -336,3 +336,15 @@ def camel_to_snake(name: str) -> str:
     s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
     s2 = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1)
     return s2.lower()
+
+def get_available_worlds(path: str | Path) -> list[str]:
+    """Returns a list of the basenames of all of the sdf files in the given path
+
+    Args:
+        path: Path to search
+
+    Returns:
+        List of available world names
+    """
+    path = Path(path)
+    return sorted([f.stem for f in path.iterdir() if f.is_file() and f.suffix == ".sdf"])

--- a/controls/sae_2025_ws/src/sim/sim/utils.py
+++ b/controls/sae_2025_ws/src/sim/sim/utils.py
@@ -182,6 +182,7 @@ def build_node_arguments(node_class: type, params: Dict[str, Any]) -> Dict[str, 
 
     return args
 
+
 # why does this exist when we have symlink-install?
 def find_package_resource(
     relative_path: Union[str, Path],
@@ -337,6 +338,7 @@ def camel_to_snake(name: str) -> str:
     s2 = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1)
     return s2.lower()
 
+
 def get_available_worlds(path: str | Path) -> list[str]:
     """Returns a list of the basenames of all of the sdf files in the given path
 
@@ -347,4 +349,6 @@ def get_available_worlds(path: str | Path) -> list[str]:
         List of available world names
     """
     path = Path(path)
-    return sorted([f.stem for f in path.iterdir() if f.is_file() and f.suffix == ".sdf"])
+    return sorted(
+        [f.stem for f in path.iterdir() if f.is_file() and f.suffix == ".sdf"]
+    )

--- a/controls/sae_2025_ws/src/uav/launch/uav_sitl.launch.py
+++ b/controls/sae_2025_ws/src/uav/launch/uav_sitl.launch.py
@@ -59,12 +59,12 @@ def px4_sitl_action(
         cwd=px4_path,
         output="screen",
         name=f"{vehicle_ns}_px4_sitl",
-        additional_env=env_export,
+        additional_env=env_export, # type: ignore (dict[str, str] works instead of SomeSubstitutionsType)
         log_cmd=True,
     )
 
 
-def launch_setup(context):
+def launch_setup(context) -> list[Action]:
     config = context.launch_configurations  # dict containing declared launch arguments
     check_unknown_launch_args(Args, config, logger)  # warn for unknown args
 

--- a/controls/sae_2025_ws/src/uav/launch/uav_sitl.launch.py
+++ b/controls/sae_2025_ws/src/uav/launch/uav_sitl.launch.py
@@ -59,7 +59,7 @@ def px4_sitl_action(
         cwd=px4_path,
         output="screen",
         name=f"{vehicle_ns}_px4_sitl",
-        additional_env=env_export, # type: ignore (dict[str, str] works instead of SomeSubstitutionsType)
+        additional_env=env_export,  # type: ignore (dict[str, str] works instead of SomeSubstitutionsType)
         log_cmd=True,
     )
 

--- a/controls/sae_2025_ws/src/vehicle_common/vehicle_common/launch_utils/__init__.py
+++ b/controls/sae_2025_ws/src/vehicle_common/vehicle_common/launch_utils/__init__.py
@@ -14,5 +14,5 @@ __all__ = [
     "check_unknown_launch_args",
     "format_bullet_list",
     "is_truthy",
-    "prepend_env_path"
+    "prepend_env_path",
 ]

--- a/controls/sae_2025_ws/src/vehicle_common/vehicle_common/launch_utils/__init__.py
+++ b/controls/sae_2025_ws/src/vehicle_common/vehicle_common/launch_utils/__init__.py
@@ -3,6 +3,8 @@ from .launch_utils import LaunchError
 from .launch_utils import include_launch
 from .launch_utils import check_unknown_launch_args
 from .launch_utils import format_bullet_list
+from .launch_utils import is_truthy
+from .launch_utils import prepend_env_path
 
 
 __all__ = [
@@ -11,4 +13,6 @@ __all__ = [
     "include_launch",
     "check_unknown_launch_args",
     "format_bullet_list",
+    "is_truthy",
+    "prepend_env_path"
 ]

--- a/controls/sae_2025_ws/src/vehicle_common/vehicle_common/launch_utils/launch_utils.py
+++ b/controls/sae_2025_ws/src/vehicle_common/vehicle_common/launch_utils/launch_utils.py
@@ -77,9 +77,11 @@ def format_bullet_list(title: str, options: list[str]) -> str:
 
     return f"{title}\n" + "\n".join(f"\t  • {option}" for option in options)
 
+
 # data
 def is_truthy(s: str) -> bool:
     return s.strip().lower() in {"1", "true", "t"}
+
 
 def prepend_env_path(var_name: str, new_path: str) -> str:
     """Safely prepends a path to an existing PATH environment variable"""
@@ -89,4 +91,3 @@ def prepend_env_path(var_name: str, new_path: str) -> str:
         return new_path
     else:
         return f"{new_path}:{existing}"
-

--- a/controls/sae_2025_ws/src/vehicle_common/vehicle_common/launch_utils/launch_utils.py
+++ b/controls/sae_2025_ws/src/vehicle_common/vehicle_common/launch_utils/launch_utils.py
@@ -7,7 +7,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import IncludeLaunchDescription
 
-PA_LAUNCH_DEBUG = os.getenv("PA_LAUNCH_DEBUG", "0").lower() == "1"
+PENNAIR_LAUNCH_DEBUG = os.getenv("PENNAIR_LAUNCH_DEBUG", "0").lower() == "1"
 
 RED = "\033[31m"
 CYAN = "\033[36m"
@@ -35,7 +35,7 @@ def get_logger(name: str) -> logging.Logger:
         )
         logger.addHandler(handler)
         logger.propagate = False
-    logger.setLevel(logging.DEBUG if PA_LAUNCH_DEBUG else logging.INFO)
+    logger.setLevel(logging.DEBUG if PENNAIR_LAUNCH_DEBUG else logging.INFO)
 
     return logger
 
@@ -76,3 +76,17 @@ def format_bullet_list(title: str, options: list[str]) -> str:
     """
 
     return f"{title}\n" + "\n".join(f"\t  • {option}" for option in options)
+
+# data
+def is_truthy(s: str) -> bool:
+    return s.strip().lower() in {"1", "true", "t"}
+
+def prepend_env_path(var_name: str, new_path: str) -> str:
+    """Safely prepends a path to an existing PATH environment variable"""
+
+    existing = os.environ.get(var_name, "")
+    if not existing:
+        return new_path
+    else:
+        return f"{new_path}:{existing}"
+

--- a/dev_env.sh
+++ b/dev_env.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export MONOREPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+export PENNAIR_GZ_MODELS_PATH="${MONOREPO_ROOT}/gz-models"
+export PENNAIR_PX4_PATH="${MONOREPO_ROOT}/PX4-Autopilot"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,6 @@ exclude = [
     "controls/sae_2025_ws/src/ros_gz",
     "controls/sae_2025_ws/src/actuator_msgs",
     "controls/sae_2025_ws/src/px4_msgs",
-    "PX4-Autopilot"
+    "PX4-Autopilot",
+    "gz-models",
 ]


### PR DESCRIPTION
## Issue(s) addressed: #171 Remaking sim launch to just be better



## Description:
made sim launch be cli-first supported tool, with current args being only world and headless mode
currently just launched plain gz world with given sdf, and sets up correct gz env, using sourced dev_env.sh vars.

Instead of running a download gz models step, it just links directly to our forked gz-models submodule. This way downloads can't get stale and we can version track the latest model changes. Then we can get rid of copying random models and accidentally overwriting and whatnot. And gets rid of a lot of unnecessary setup logic within sim. 

It supports launching any world in the gz-models/worlds folder, so its not restricted to whatever "competitions" we have. It also removes the "competitions" notation in favor of more general "world," bc thats better.

Next steps: Add in loading world node logic

Also need to add arg validation for worlds prob

## Testing Done:

Builds and runs when launching just sim2.launch.py

--show-args correctly displays all available worlds. 

