### PR TITLE
Rewrite integration dashboard in TypeScript (orchestrator + pi-agent + web/mobile)

### DIFF
--- a/.github/workflows/arm-artifact.yml
+++ b/.github/workflows/arm-artifact.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".github/workflows/arm-artifact.yml"
       - "controls/sae_2025_ws/**"
+      - "!controls/sae_2025_ws/integration/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/integration-ts.yml
+++ b/.github/workflows/integration-ts.yml
@@ -1,0 +1,55 @@
+name: Integration TypeScript
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - ".github/workflows/integration-ts.yml"
+      - "controls/sae_2025_ws/integration/**"
+  pull_request:
+    branches: [main, master]
+    paths:
+      - ".github/workflows/integration-ts.yml"
+      - "controls/sae_2025_ws/integration/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: integration-ts-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_lint_test:
+    name: Build, Lint, Typecheck, Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: controls/sae_2025_ws/integration
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: controls/sae_2025_ws/integration/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/ros-validate.yml
+++ b/.github/workflows/ros-validate.yml
@@ -10,6 +10,7 @@ on:
       - ".gitmodules"
       - "PX4-Autopilot"
       - "controls/sae_2025_ws/**"
+      - "!controls/sae_2025_ws/integration/**"
   pull_request:
     branches: [main, master]
     paths:
@@ -19,6 +20,7 @@ on:
       - ".gitmodules"
       - "PX4-Autopilot"
       - "controls/sae_2025_ws/**"
+      - "!controls/sae_2025_ws/integration/**"
   workflow_dispatch:
 
 permissions:

--- a/controls/sae_2025_ws/integration/.gitignore
+++ b/controls/sae_2025_ws/integration/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.expo/
+*.tsbuildinfo

--- a/controls/sae_2025_ws/integration/eslint.config.js
+++ b/controls/sae_2025_ws/integration/eslint.config.js
@@ -1,0 +1,17 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    ignores: ["**/dist/**", "**/node_modules/**", "**/.expo/**"],
+  },
+  {
+    // TypeScript's own compiler already catches undefined identifiers;
+    // no-undef otherwise false-positives on ambient/DOM/Node globals.
+    rules: {
+      "no-undef": "off",
+    },
+  },
+);

--- a/controls/sae_2025_ws/integration/launch/orchestrator.launch.py
+++ b/controls/sae_2025_ws/integration/launch/orchestrator.launch.py
@@ -1,0 +1,52 @@
+"""Launches the orchestrator (the "computer") that phone/web clients talk to.
+
+The orchestrator lives outside the colcon `src/` tree (it's a Node/TS
+process, not a ROS package), but it's a real ROS2 participant (see the
+integration rewrite plan's `rclnodejs` decision for mission RPC), so it's
+started the same way as everything else in this fleet: `ros2 launch`.
+
+Usage:
+    ros2 launch orchestrator.launch.py
+    ros2 launch orchestrator.launch.py serve_frontend:=true
+"""
+
+from __future__ import annotations
+
+import os
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
+
+_INTEGRATION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def generate_launch_description() -> LaunchDescription:
+    serve_frontend_arg = DeclareLaunchArgument(
+        "serve_frontend",
+        default_value="false",
+        description="Also start the web frontend's dev server alongside the orchestrator.",
+    )
+    serve_frontend = LaunchConfiguration("serve_frontend")
+
+    orchestrator_process = ExecuteProcess(
+        cmd=["node", "packages/orchestrator/dist/index.js"],
+        cwd=_INTEGRATION_ROOT,
+        output="screen",
+    )
+
+    frontend_process = ExecuteProcess(
+        cmd=["npm", "run", "dev", "--workspace", "@pennair/web"],
+        cwd=_INTEGRATION_ROOT,
+        output="screen",
+        condition=IfCondition(serve_frontend),
+    )
+
+    return LaunchDescription(
+        [
+            serve_frontend_arg,
+            orchestrator_process,
+            frontend_process,
+        ]
+    )

--- a/controls/sae_2025_ws/integration/package-lock.json
+++ b/controls/sae_2025_ws/integration/package-lock.json
@@ -14666,6 +14666,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
@@ -14739,7 +14754,10 @@
     },
     "packages/core": {
       "name": "@pennair/integration-core",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "yaml": "^2.6.1"
+      }
     },
     "packages/mobile": {
       "name": "@pennair/mobile",

--- a/controls/sae_2025_ws/integration/package-lock.json
+++ b/controls/sae_2025_ws/integration/package-lock.json
@@ -1,0 +1,14206 @@
+{
+  "name": "pennair-integration",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pennair-integration",
+      "workspaces": [
+        "packages/*"
+      ],
+      "devDependencies": {
+        "@eslint/js": "^9.15.0",
+        "@types/node": "^22.9.0",
+        "eslint": "^9.15.0",
+        "prettier": "^3.3.3",
+        "typescript": "^5.7.2",
+        "typescript-eslint": "^8.15.0",
+        "vitest": "^2.1.5"
+      }
+    },
+    "node_modules/@0no-co/graphql.web": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.3.3.tgz",
+      "integrity": "sha512-4gFGBdyaFmQ6n9euhp5JtIGS4ZeivwDr1tCPENUxTvy5wyv532yOtFCr9zzYAJh1s6uibgC+TRXUcay+mxzCoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "regexpu-core": "^6.3.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "debug": "^4.4.3",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.22.11"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz",
+      "integrity": "sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-wrap-function": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-wrap-function": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz",
+      "integrity": "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.9.tgz",
+      "integrity": "sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz",
+      "integrity": "sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
+      "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
+      "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz",
+      "integrity": "sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-transform-optional-chaining": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz",
+      "integrity": "sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-class-properties": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
+      "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-decorators": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-export-default-from": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.29.7.tgz",
+      "integrity": "sha512-p+G5BNXDcy3bOXplhY4HybQ1GxH3i2Tppmdm/3epyRu2VgJJZuUlZ61MqRTg582Q7ZLBdP7fePYvsumSEkMxcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz",
+      "integrity": "sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-optional-chaining": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.21.0.tgz",
+      "integrity": "sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
+      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-export-default-from": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.29.7.tgz",
+      "integrity": "sha512-foag0BB37ROhdeIX9O8G0jX7hw0UekJc04cHMrYLOnrErsnBKqJGHJ8eDRpoCFZBvEPPygmmtw4qyU97qa4oOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-flow": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.29.7.tgz",
+      "integrity": "sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
+      "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
+      "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-generator-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz",
+      "integrity": "sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-remap-async-to-generator": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz",
+      "integrity": "sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-remap-async-to-generator": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
+      "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz",
+      "integrity": "sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
+      "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz",
+      "integrity": "sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-classes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz",
+      "integrity": "sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz",
+      "integrity": "sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/template": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
+      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dotall-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz",
+      "integrity": "sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
+      "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz",
+      "integrity": "sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dynamic-import": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
+      "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
+      "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz",
+      "integrity": "sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-export-namespace-from": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
+      "integrity": "sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-flow-strip-types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.29.7.tgz",
+      "integrity": "sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-flow": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz",
+      "integrity": "sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz",
+      "integrity": "sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-json-strings": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz",
+      "integrity": "sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-literals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
+      "integrity": "sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-logical-assignment-operators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz",
+      "integrity": "sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
+      "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
+      "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-systemjs": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-umd": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
+      "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz",
+      "integrity": "sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-new-target": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
+      "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
+      "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-numeric-separator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz",
+      "integrity": "sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-rest-spread": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz",
+      "integrity": "sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7",
+        "@babel/plugin-transform-parameters": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
+      "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz",
+      "integrity": "sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz",
+      "integrity": "sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
+      "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-property-in-object": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz",
+      "integrity": "sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
+      "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
+      "integrity": "sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
+      "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-jsx": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
+      "integrity": "sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
+      "integrity": "sha512-H5E+HBgDpr6Q5t+Aj11tL7XkIui1jhbIoArVQnqjgXo5/3YxkN7ZEBcWF4RQlB0T4rrxJQbXS6kiFV6B7XTqUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regenerator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
+      "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regexp-modifiers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz",
+      "integrity": "sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
+      "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.7.tgz",
+      "integrity": "sha512-xmAscdE/AsqRW7vutbPNoUmu/nF5SrLKPs7aoJgEjo35lLKA/Bc0i2rMv/hr1+Y0o1bQCiVtith3u2vdgRL39Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "babel-plugin-polyfill-corejs2": "^0.4.14",
+        "babel-plugin-polyfill-corejs3": "^0.13.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.5",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz",
+      "integrity": "sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-spread": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
+      "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-sticky-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz",
+      "integrity": "sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
+      "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
+      "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-escapes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
+      "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-property-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz",
+      "integrity": "sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz",
+      "integrity": "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz",
+      "integrity": "sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/preset-env": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.7.tgz",
+      "integrity": "sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.29.7",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.29.7",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.29.7",
+        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.7",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.29.7",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.29.7",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-syntax-import-assertions": "^7.29.7",
+        "@babel/plugin-syntax-import-attributes": "^7.29.7",
+        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.29.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.29.7",
+        "@babel/plugin-transform-async-to-generator": "^7.29.7",
+        "@babel/plugin-transform-block-scoped-functions": "^7.29.7",
+        "@babel/plugin-transform-block-scoping": "^7.29.7",
+        "@babel/plugin-transform-class-properties": "^7.29.7",
+        "@babel/plugin-transform-class-static-block": "^7.29.7",
+        "@babel/plugin-transform-classes": "^7.29.7",
+        "@babel/plugin-transform-computed-properties": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7",
+        "@babel/plugin-transform-dotall-regex": "^7.29.7",
+        "@babel/plugin-transform-duplicate-keys": "^7.29.7",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.7",
+        "@babel/plugin-transform-dynamic-import": "^7.29.7",
+        "@babel/plugin-transform-explicit-resource-management": "^7.29.7",
+        "@babel/plugin-transform-exponentiation-operator": "^7.29.7",
+        "@babel/plugin-transform-export-namespace-from": "^7.29.7",
+        "@babel/plugin-transform-for-of": "^7.29.7",
+        "@babel/plugin-transform-function-name": "^7.29.7",
+        "@babel/plugin-transform-json-strings": "^7.29.7",
+        "@babel/plugin-transform-literals": "^7.29.7",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.29.7",
+        "@babel/plugin-transform-member-expression-literals": "^7.29.7",
+        "@babel/plugin-transform-modules-amd": "^7.29.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+        "@babel/plugin-transform-modules-systemjs": "^7.29.7",
+        "@babel/plugin-transform-modules-umd": "^7.29.7",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.7",
+        "@babel/plugin-transform-new-target": "^7.29.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.29.7",
+        "@babel/plugin-transform-numeric-separator": "^7.29.7",
+        "@babel/plugin-transform-object-rest-spread": "^7.29.7",
+        "@babel/plugin-transform-object-super": "^7.29.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.29.7",
+        "@babel/plugin-transform-optional-chaining": "^7.29.7",
+        "@babel/plugin-transform-parameters": "^7.29.7",
+        "@babel/plugin-transform-private-methods": "^7.29.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.29.7",
+        "@babel/plugin-transform-property-literals": "^7.29.7",
+        "@babel/plugin-transform-regenerator": "^7.29.7",
+        "@babel/plugin-transform-regexp-modifiers": "^7.29.7",
+        "@babel/plugin-transform-reserved-words": "^7.29.7",
+        "@babel/plugin-transform-shorthand-properties": "^7.29.7",
+        "@babel/plugin-transform-spread": "^7.29.7",
+        "@babel/plugin-transform-sticky-regex": "^7.29.7",
+        "@babel/plugin-transform-template-literals": "^7.29.7",
+        "@babel/plugin-transform-typeof-symbol": "^7.29.7",
+        "@babel/plugin-transform-unicode-escapes": "^7.29.7",
+        "@babel/plugin-transform-unicode-property-regex": "^7.29.7",
+        "@babel/plugin-transform-unicode-regex": "^7.29.7",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.29.7",
+        "@babel/preset-modules": "0.1.6-no-external-plugins",
+        "babel-plugin-polyfill-corejs2": "^0.4.15",
+        "babel-plugin-polyfill-corejs3": "^0.14.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.6",
+        "core-js-compat": "^3.48.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+      "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
+        "core-js-compat": "^3.48.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/preset-flow": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.29.7.tgz",
+      "integrity": "sha512-KYIRV0BuaN68CDdsqFkAD7MU7yipUqQNuNElwATdxaIdpTjhvtY82QvkBJs7zV3Evxj2jFAAZ1iO8nyy0nhjqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-transform-flow-strip-types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-modules": {
+      "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-react": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.29.7.tgz",
+      "integrity": "sha512-C+PV1TFUPTmBQGoPBL8j2QmLpZ117YTCwxIZeJOM96GbYMFSc7/pOXU5lVykwnZxyTqQxRsvoRk6f2FktZgGHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-transform-react-display-name": "^7.29.7",
+        "@babel/plugin-transform-react-jsx": "^7.29.7",
+        "@babel/plugin-transform-react-jsx-development": "^7.29.7",
+        "@babel/plugin-transform-react-pure-annotations": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
+      "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-syntax-jsx": "^7.29.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+        "@babel/plugin-transform-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/register": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.29.7.tgz",
+      "integrity": "sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "find-cache-dir": "^2.0.0",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.6",
+        "source-map-support": "^0.5.16"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse--for-generate-function-map": {
+      "name": "@babel/traverse",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@expo/bunyan": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/bunyan/-/bunyan-4.0.1.tgz",
+      "integrity": "sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@expo/cli": {
+      "version": "0.22.28",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.22.28.tgz",
+      "integrity": "sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@0no-co/graphql.web": "^1.0.8",
+        "@babel/runtime": "^7.20.0",
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/config": "~10.0.11",
+        "@expo/config-plugins": "~9.0.17",
+        "@expo/devcert": "^1.1.2",
+        "@expo/env": "~0.4.2",
+        "@expo/image-utils": "^0.6.5",
+        "@expo/json-file": "^9.0.2",
+        "@expo/metro-config": "~0.19.12",
+        "@expo/osascript": "^2.1.6",
+        "@expo/package-manager": "^1.7.2",
+        "@expo/plist": "^0.2.2",
+        "@expo/prebuild-config": "~8.2.0",
+        "@expo/rudder-sdk-node": "^1.1.1",
+        "@expo/spawn-async": "^1.7.2",
+        "@expo/ws-tunnel": "^1.0.1",
+        "@expo/xcpretty": "^4.3.0",
+        "@react-native/dev-middleware": "0.76.9",
+        "@urql/core": "^5.0.6",
+        "@urql/exchange-retry": "^1.3.0",
+        "accepts": "^1.3.8",
+        "arg": "^5.0.2",
+        "better-opn": "~3.0.2",
+        "bplist-creator": "0.0.7",
+        "bplist-parser": "^0.3.1",
+        "cacache": "^18.0.2",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.3.0",
+        "compression": "^1.7.4",
+        "connect": "^3.7.0",
+        "debug": "^4.3.4",
+        "env-editor": "^0.4.1",
+        "fast-glob": "^3.3.2",
+        "form-data": "^3.0.1",
+        "freeport-async": "^2.0.0",
+        "fs-extra": "~8.1.0",
+        "getenv": "^1.0.0",
+        "glob": "^10.4.2",
+        "internal-ip": "^4.3.0",
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1",
+        "lodash.debounce": "^4.0.8",
+        "minimatch": "^3.0.4",
+        "node-forge": "^1.3.3",
+        "npm-package-arg": "^11.0.0",
+        "ora": "^3.4.0",
+        "picomatch": "^3.0.1",
+        "pretty-bytes": "^5.6.0",
+        "pretty-format": "^29.7.0",
+        "progress": "^2.0.3",
+        "prompts": "^2.3.2",
+        "qrcode-terminal": "0.11.0",
+        "require-from-string": "^2.0.2",
+        "requireg": "^0.2.2",
+        "resolve": "^1.22.2",
+        "resolve-from": "^5.0.0",
+        "resolve.exports": "^2.0.3",
+        "semver": "^7.6.0",
+        "send": "^0.19.0",
+        "slugify": "^1.3.4",
+        "source-map-support": "~0.5.21",
+        "stacktrace-parser": "^0.1.10",
+        "structured-headers": "^0.4.1",
+        "tar": "^6.2.1",
+        "temp-dir": "^2.0.0",
+        "tempy": "^0.7.1",
+        "terminal-link": "^2.1.1",
+        "undici": "^6.18.2",
+        "unique-string": "~2.0.0",
+        "wrap-ansi": "^7.0.0",
+        "ws": "^8.12.1"
+      },
+      "bin": {
+        "expo-internal": "build/bin/cli"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/picomatch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
+      "integrity": "sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/code-signing-certificates": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.6.tgz",
+      "integrity": "sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==",
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "^1.3.3"
+      }
+    },
+    "node_modules/@expo/config": {
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-10.0.11.tgz",
+      "integrity": "sha512-nociJ4zr/NmbVfMNe9j/+zRlt7wz/siISu7PjdWE4WE+elEGxWWxsGzltdJG0llzrM+khx8qUiFK5aiVcdMBww==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~9.0.17",
+        "@expo/config-types": "^52.0.5",
+        "@expo/json-file": "^9.0.2",
+        "deepmerge": "^4.3.1",
+        "getenv": "^1.0.0",
+        "glob": "^10.4.2",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "resolve-workspace-root": "^2.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4",
+        "sucrase": "3.35.0"
+      }
+    },
+    "node_modules/@expo/config-plugins": {
+      "version": "9.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-9.0.17.tgz",
+      "integrity": "sha512-m24F1COquwOm7PBl5wRbkT9P9DviCXe0D7S7nQsolfbhdCWuvMkfXeoWmgjtdhy7sDlOyIgBrAdnB6MfsWKqIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^52.0.5",
+        "@expo/json-file": "~9.0.2",
+        "@expo/plist": "^0.2.2",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^1.0.0",
+        "glob": "^10.4.2",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slash": "^3.0.0",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/@expo/json-file": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-9.0.2.tgz",
+      "integrity": "sha512-yAznIUrybOIWp3Uax7yRflB0xsEpvIwIEqIjao9SGi2Gaa+N0OamWfe0fnXBSWF+2zzF4VvqwT4W5zwelchfgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/config-types": {
+      "version": "52.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-52.0.5.tgz",
+      "integrity": "sha512-AMDeuDLHXXqd8W+0zSjIt7f37vUd/BP8p43k68NHpyAvQO+z8mbQZm3cNQVAMySeayK2XoPigAFB1JF2NFajaA==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/config/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/devcert": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@expo/devcert/-/devcert-1.2.1.tgz",
+      "integrity": "sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/sudo-prompt": "^9.3.1",
+        "debug": "^3.1.0"
+      }
+    },
+    "node_modules/@expo/devcert/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@expo/env": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-0.4.2.tgz",
+      "integrity": "sha512-TgbCgvSk0Kq0e2fLoqHwEBL4M0ztFjnBEz0YCDm5boc1nvkV1VMuIMteVdeBwnTh8Z0oPJTwHCD49vhMEt1I6A==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "debug": "^4.3.4",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "getenv": "^1.0.0"
+      }
+    },
+    "node_modules/@expo/fingerprint": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.11.11.tgz",
+      "integrity": "sha512-gNyn1KnAOpEa8gSNsYqXMTcq0fSwqU/vit6fP5863vLSKxHm/dNt/gm/uZJxrRZxKq71KUJWF6I7d3z8qIfq5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "^5.0.2",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "find-up": "^5.0.0",
+        "getenv": "^1.0.0",
+        "minimatch": "^3.0.4",
+        "p-limit": "^3.1.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
+      },
+      "bin": {
+        "fingerprint": "bin/cli.js"
+      }
+    },
+    "node_modules/@expo/fingerprint/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/image-utils": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.6.5.tgz",
+      "integrity": "sha512-RsS/1CwJYzccvlprYktD42KjyfWZECH6PPIEowvoSmXfGLfdViwcUEI4RvBfKX5Jli6P67H+6YmHvPTbGOboew==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/spawn-async": "^1.7.2",
+        "chalk": "^4.0.0",
+        "fs-extra": "9.0.0",
+        "getenv": "^1.0.0",
+        "jimp-compact": "0.16.1",
+        "parse-png": "^2.1.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "temp-dir": "~2.0.0",
+        "unique-string": "~2.0.0"
+      }
+    },
+    "node_modules/@expo/image-utils/node_modules/fs-extra": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@expo/image-utils/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@expo/image-utils/node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@expo/image-utils/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/image-utils/node_modules/universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@expo/json-file": {
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-9.1.5.tgz",
+      "integrity": "sha512-prWBhLUlmcQtvN6Y7BpW2k9zXGd3ySa3R6rAguMJkp1z22nunLN64KYTUWfijFlprFoxm9r2VNnGkcbndAlgKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/json-file/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/metro-config": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.19.12.tgz",
+      "integrity": "sha512-fhT3x1ikQWHpZgw7VrEghBdscFPz1laRYa8WcVRB18nTTqorF6S8qPYslkJu1faEziHZS7c2uyDzTYnrg/CKbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.5",
+        "@babel/parser": "^7.20.0",
+        "@babel/types": "^7.20.0",
+        "@expo/config": "~10.0.11",
+        "@expo/env": "~0.4.2",
+        "@expo/json-file": "~9.0.2",
+        "@expo/spawn-async": "^1.7.2",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.2",
+        "fs-extra": "^9.1.0",
+        "getenv": "^1.0.0",
+        "glob": "^10.4.2",
+        "jsc-safe-url": "^0.2.4",
+        "lightningcss": "~1.27.0",
+        "minimatch": "^3.0.4",
+        "postcss": "~8.4.32",
+        "resolve-from": "^5.0.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/json-file": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-9.0.2.tgz",
+      "integrity": "sha512-yAznIUrybOIWp3Uax7yRflB0xsEpvIwIEqIjao9SGi2Gaa+N0OamWfe0fnXBSWF+2zzF4VvqwT4W5zwelchfgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@expo/osascript": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.7.1.tgz",
+      "integrity": "sha512-Zn03EX6In7ts2lPUW2ESUSkEhEWQN1qqsiXjadtZMJOuZRkMiAg1ZQHuvz9DjByDWNJ2pBwAGyrts9lj9k389g==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/spawn-async": "^1.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@expo/package-manager": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.13.1.tgz",
+      "integrity": "sha512-y/K+CaYYpZpNGZhSX4HyLT/vyIunFjNfyoxNysPBCefeLKI/VCx6f9LNPzrxayr3rCYO5bl9O8H+HRQK265Nkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/json-file": "^11.0.1",
+        "@expo/spawn-async": "^1.8.0",
+        "chalk": "^4.0.0",
+        "npm-package-arg": "^11.0.0",
+        "ora": "^3.4.0",
+        "resolve-workspace-root": "^2.0.0"
+      }
+    },
+    "node_modules/@expo/package-manager/node_modules/@expo/json-file": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.1.tgz",
+      "integrity": "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/plist": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.2.2.tgz",
+      "integrity": "sha512-ZZGvTO6vEWq02UAPs3LIdja+HRO18+LRI5QuDl6Hs3Ps7KX7xU6Y6kjahWKY37Rx2YjNpX07dGpBFzzC+vKa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "~0.7.7",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^14.0.0"
+      }
+    },
+    "node_modules/@expo/prebuild-config": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-8.2.0.tgz",
+      "integrity": "sha512-CxiPpd980s0jyxi7eyN3i/7YKu3XL+8qPjBZUCYtc0+axpGweqIkq2CslyLSKHyqVyH/zlPkbVgWdyiYavFS5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~10.0.11",
+        "@expo/config-plugins": "~9.0.17",
+        "@expo/config-types": "^52.0.5",
+        "@expo/image-utils": "^0.6.5",
+        "@expo/json-file": "^9.0.2",
+        "@react-native/normalize-colors": "0.76.9",
+        "debug": "^4.3.1",
+        "fs-extra": "^9.0.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@expo/rudder-sdk-node": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/rudder-sdk-node/-/rudder-sdk-node-1.1.1.tgz",
+      "integrity": "sha512-uy/hS/awclDJ1S88w9UGpc6Nm9XnNUjzOAAib1A3PVAnGQIwebg8DpFqOthFBTlZxeuV/BKbZ5jmTbtNZkp1WQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/bunyan": "^4.0.0",
+        "@segment/loosely-validate-event": "^2.0.0",
+        "fetch-retry": "^4.1.1",
+        "md5": "^2.2.1",
+        "node-fetch": "^2.6.1",
+        "remove-trailing-slash": "^0.1.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@expo/sdk-runtime-versions": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz",
+      "integrity": "sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/spawn-async": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.8.0.tgz",
+      "integrity": "sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@expo/sudo-prompt": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
+      "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/vector-icons": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-14.0.4.tgz",
+      "integrity": "sha512-+yKshcbpDfbV4zoXOgHxCwh7lkE9VVTT5T03OUlBsqfze1PLy6Hi4jp1vSb1GVbY6eskvMIivGVc9SKzIv0oEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      }
+    },
+    "node_modules/@expo/ws-tunnel": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.6.tgz",
+      "integrity": "sha512-nDRbLmSrJar7abvUjp3smDwH8HcbZcoOEa5jVPUv9/9CajgmWw20JNRwTuBRzWIWIkEJDkz20GoNA+tSwUqk0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/xcpretty": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.4.tgz",
+      "integrity": "sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "chalk": "^4.1.0",
+        "js-yaml": "^4.1.0"
+      },
+      "bin": {
+        "excpretty": "build/cli.js"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+      "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.1.0.tgz",
+      "integrity": "sha512-PxcYtKLbQ8Z+yApiqjK8FwxIwvEj38k2OiLc17u8dkJSlmfi2wHHPaSnaoqBPQqtvF8YVsDgDpP2snDCfFrpfw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^7.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+      "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/create-cache-key-function": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
+      "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@jest/transform/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+      "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@pennair/integration-core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@pennair/mobile": {
+      "resolved": "packages/mobile",
+      "link": true
+    },
+    "node_modules/@pennair/orchestrator": {
+      "resolved": "packages/orchestrator",
+      "link": true
+    },
+    "node_modules/@pennair/pi-agent": {
+      "resolved": "packages/pi-agent",
+      "link": true
+    },
+    "node_modules/@pennair/web": {
+      "resolved": "packages/web",
+      "link": true
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@react-native/assets-registry": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.76.3.tgz",
+      "integrity": "sha512-7Fnc3lzCFFpnoyL1egua6d/qUp0KiIpeSLbfOMln4nI2g2BMzyFHdPjJnpLV2NehmS0omOOkrfRqK5u1F/MXzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/babel-plugin-codegen": {
+      "version": "0.76.9",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.9.tgz",
+      "integrity": "sha512-vxL/vtDEIYHfWKm5oTaEmwcnNGsua/i9OjIxBDBFiJDu5i5RU3bpmDiXQm/bJxrJNPRp5lW0I0kpGihVhnMAIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/codegen": "0.76.9"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/babel-preset": {
+      "version": "0.76.9",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.76.9.tgz",
+      "integrity": "sha512-TbSeCplCM6WhL3hR2MjC/E1a9cRnMLz7i767T7mP90oWkklEjyPxWl+0GGoVGnJ8FC/jLUupg/HvREKjjif6lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-proposal-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-transform-arrow-functions": "^7.24.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
+        "@babel/plugin-transform-async-to-generator": "^7.24.7",
+        "@babel/plugin-transform-block-scoping": "^7.25.0",
+        "@babel/plugin-transform-class-properties": "^7.25.4",
+        "@babel/plugin-transform-classes": "^7.25.4",
+        "@babel/plugin-transform-computed-properties": "^7.24.7",
+        "@babel/plugin-transform-destructuring": "^7.24.8",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-for-of": "^7.24.7",
+        "@babel/plugin-transform-function-name": "^7.25.1",
+        "@babel/plugin-transform-literals": "^7.25.2",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-numeric-separator": "^7.24.7",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.8",
+        "@babel/plugin-transform-parameters": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+        "@babel/plugin-transform-react-display-name": "^7.24.7",
+        "@babel/plugin-transform-react-jsx": "^7.25.2",
+        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
+        "@babel/plugin-transform-regenerator": "^7.24.7",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/plugin-transform-shorthand-properties": "^7.24.7",
+        "@babel/plugin-transform-spread": "^7.24.7",
+        "@babel/plugin-transform-sticky-regex": "^7.24.7",
+        "@babel/plugin-transform-typescript": "^7.25.2",
+        "@babel/plugin-transform-unicode-regex": "^7.24.7",
+        "@babel/template": "^7.25.0",
+        "@react-native/babel-plugin-codegen": "0.76.9",
+        "babel-plugin-syntax-hermes-parser": "^0.25.1",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "react-refresh": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/babel-preset/node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@react-native/codegen": {
+      "version": "0.76.9",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.76.9.tgz",
+      "integrity": "sha512-AzlCHMTKrAVC2709V4ZGtBXmGVtWTpWm3Ruv5vXcd3/anH4mGucfJ4rjbWKdaYQJMpXa3ytGomQrsIsT/s8kgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.3",
+        "glob": "^7.1.1",
+        "hermes-parser": "0.23.1",
+        "invariant": "^2.2.4",
+        "jscodeshift": "^0.14.0",
+        "mkdirp": "^0.5.1",
+        "nullthrows": "^1.1.1",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      }
+    },
+    "node_modules/@react-native/codegen/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.76.3.tgz",
+      "integrity": "sha512-vgsLixHS24jR0d0QqPykBWFaC+V8x9cM3cs4oYXw3W199jgBNGP9MWcUJLazD2vzrT/lUTVBVg0rBeB+4XR6fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/dev-middleware": "0.76.3",
+        "@react-native/metro-babel-transformer": "0.76.3",
+        "chalk": "^4.0.0",
+        "execa": "^5.1.1",
+        "invariant": "^2.2.4",
+        "metro": "^0.81.0",
+        "metro-config": "^0.81.0",
+        "metro-core": "^0.81.0",
+        "node-fetch": "^2.2.0",
+        "readline": "^1.3.0",
+        "semver": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-native-community/cli-server-api": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-community/cli-server-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-frontend": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.76.3.tgz",
+      "integrity": "sha512-pMHQ3NpPB28RxXciSvm2yD+uDx3pkhzfuWkc7VFgOduyzPSIr0zotUiOJzsAtrj8++bPbOsAraCeQhCqoOTWQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/dev-middleware": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.76.3.tgz",
+      "integrity": "sha512-b+2IpW40z1/S5Jo5JKrWPmucYU/PzeGyGBZZ/SJvmRnBDaP3txb9yIqNZAII1EWsKNhedh8vyRO5PSuJ9Juqzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.76.3",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.2.0",
+        "connect": "^3.6.5",
+        "debug": "^2.2.0",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "selfsigned": "^2.4.1",
+        "serve-static": "^1.13.1",
+        "ws": "^6.2.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/ws": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.6.tgz",
+      "integrity": "sha512-XTrf1gv7kXoVf1hbC3PAyAiPgR8Wz1blcrYIjEsUmr08BLksT41R8KbjmS9408C2ERx7v1JDLD/BkpLEttjfKA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/@react-native/debugger-frontend": {
+      "version": "0.76.9",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.76.9.tgz",
+      "integrity": "sha512-0Ru72Bm066xmxFuOXhhvrryxvb57uI79yDSFf+hxRpktkC98NMuRenlJhslMrbJ6WjCu1vOe/9UjWNYyxXTRTA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/dev-middleware": {
+      "version": "0.76.9",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.76.9.tgz",
+      "integrity": "sha512-xkd3C3dRcmZLjFTEAOvC14q3apMLouIvJViCZY/p1EfCMrNND31dgE1dYrLTiI045WAWMt5bD15i6f7dE2/QWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.76.9",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.2.0",
+        "connect": "^3.6.5",
+        "debug": "^2.2.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "selfsigned": "^2.4.1",
+        "serve-static": "^1.13.1",
+        "ws": "^6.2.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/ws": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.6.tgz",
+      "integrity": "sha512-XTrf1gv7kXoVf1hbC3PAyAiPgR8Wz1blcrYIjEsUmr08BLksT41R8KbjmS9408C2ERx7v1JDLD/BkpLEttjfKA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/@react-native/gradle-plugin": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.76.3.tgz",
+      "integrity": "sha512-t0aYZ8ND7+yc+yIm6Yp52bInneYpki6RSIFZ9/LMUzgMKvEB62ptt/7sfho9QkKHCNxE1DJSWIqLIGi/iHHkyg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/js-polyfills": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.76.3.tgz",
+      "integrity": "sha512-pubJFArMMrdZiytH+W95KngcSQs+LsxOBsVHkwgMnpBfRUxXPMK4fudtBwWvhnwN76Oe+WhxSq7vOS5XgoPhmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.76.3.tgz",
+      "integrity": "sha512-b2zQPXmW7avw/7zewc9nzMULPIAjsTwN03hskhxHUJH5pzUf7pIklB3FrgYPZrRhJgzHiNl3tOPu7vqiKzBYPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@react-native/babel-preset": "0.76.3",
+        "hermes-parser": "0.23.1",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/babel-plugin-codegen": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.3.tgz",
+      "integrity": "sha512-mZ7jmIIg4bUnxCqY3yTOkoHvvzsDyrZgfnIKiTGm5QACrsIGa5eT3pMFpMm2OpxGXRDrTMsYdPXE2rCyDX52VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/codegen": "0.76.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/babel-preset": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.76.3.tgz",
+      "integrity": "sha512-zi2nPlQf9q2fmfPyzwWEj6DU96v8ziWtEfG7CTAX2PG/Vjfsr94vn/wWrCdhBVvLRQ6Kvd/MFAuDYpxmQwIiVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-proposal-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-transform-arrow-functions": "^7.24.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
+        "@babel/plugin-transform-async-to-generator": "^7.24.7",
+        "@babel/plugin-transform-block-scoping": "^7.25.0",
+        "@babel/plugin-transform-class-properties": "^7.25.4",
+        "@babel/plugin-transform-classes": "^7.25.4",
+        "@babel/plugin-transform-computed-properties": "^7.24.7",
+        "@babel/plugin-transform-destructuring": "^7.24.8",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-for-of": "^7.24.7",
+        "@babel/plugin-transform-function-name": "^7.25.1",
+        "@babel/plugin-transform-literals": "^7.25.2",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-numeric-separator": "^7.24.7",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.8",
+        "@babel/plugin-transform-parameters": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+        "@babel/plugin-transform-react-display-name": "^7.24.7",
+        "@babel/plugin-transform-react-jsx": "^7.25.2",
+        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
+        "@babel/plugin-transform-regenerator": "^7.24.7",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/plugin-transform-shorthand-properties": "^7.24.7",
+        "@babel/plugin-transform-spread": "^7.24.7",
+        "@babel/plugin-transform-sticky-regex": "^7.24.7",
+        "@babel/plugin-transform-typescript": "^7.25.2",
+        "@babel/plugin-transform-unicode-regex": "^7.24.7",
+        "@babel/template": "^7.25.0",
+        "@react-native/babel-plugin-codegen": "0.76.3",
+        "babel-plugin-syntax-hermes-parser": "^0.25.1",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "react-refresh": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/codegen": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.76.3.tgz",
+      "integrity": "sha512-oJCH/jbYeGmFJql8/y76gqWCCd74pyug41yzYAjREso1Z7xL88JhDyKMvxEnfhSdMOZYVl479N80xFiXPy3ZYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.3",
+        "glob": "^7.1.1",
+        "hermes-parser": "0.23.1",
+        "invariant": "^2.2.4",
+        "jscodeshift": "^0.14.0",
+        "mkdirp": "^0.5.1",
+        "nullthrows": "^1.1.1",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@react-native/normalize-colors": {
+      "version": "0.76.9",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.76.9.tgz",
+      "integrity": "sha512-TUdMG2JGk72M9d8DYbubdOlrzTYjw+YMe/xOnLU4viDgWRHsCbtRS9x0IAxRjs3amj/7zmK3Atm8jUPvdAc8qw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-native/virtualized-lists": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.76.3.tgz",
+      "integrity": "sha512-wTGv9pVh3vAOWb29xFm+J9VRe9dUcUcb9FyaMLT/Hxa88W4wqa5ZMe1V9UvrrBiA1G5DKjv8/1ZcDsJhyugVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.6",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@segment/loosely-validate-event": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
+      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+      "dependencies": {
+        "component-type": "^1.2.1",
+        "join-component": "^1.1.0"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@urql/core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@0no-co/graphql.web": "^1.0.13",
+        "wonka": "^6.3.2"
+      }
+    },
+    "node_modules/@urql/exchange-retry": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.3.2.tgz",
+      "integrity": "sha512-TQMCz2pFJMfpNxmSfX1VSfTjwUIFx/mL+p1bnfM1xjjdla7Z+KnGMW/EhFbpckp3LyWAH4PgOsMwOMnIN+MBFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@urql/core": "^5.1.2",
+        "wonka": "^6.3.2"
+      },
+      "peerDependencies": {
+        "@urql/core": "^5.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "deprecated": "this version has critical issues, please update to the latest version",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/anser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
+      "integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
+      "integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.3.0.tgz",
+      "integrity": "sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/babel-core": {
+      "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
+        "semver": "^6.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
+      "integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
+        "core-js-compat": "^3.43.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.8"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-react-native-web": {
+      "version": "0.19.13",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.19.13.tgz",
+      "integrity": "sha512-4hHoto6xaN23LCyZgL9LJZc3olmAxd7b6jDzlZnKXAh4rRAbZRKNBJoOOdp46OBqgy+K0t0guTj5/mhA8inymQ==",
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-parser": "0.25.1"
+      }
+    },
+    "node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/babel-plugin-transform-flow-enums": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-enums/-/babel-plugin-transform-flow-enums-0.0.2.tgz",
+      "integrity": "sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-flow": "^7.12.1"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-expo": {
+      "version": "12.0.12",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-12.0.12.tgz",
+      "integrity": "sha512-qAuaGGZIN//DyQVackP7Czr1SMq5dYb5tpu/uQqL/f1bRARb74r+kBWQRLJGxQ3QujsEw13SyAodCZIOUoD6KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-proposal-decorators": "^7.12.9",
+        "@babel/plugin-transform-export-namespace-from": "^7.22.11",
+        "@babel/plugin-transform-object-rest-spread": "^7.12.13",
+        "@babel/plugin-transform-parameters": "^7.22.15",
+        "@babel/preset-react": "^7.22.15",
+        "@babel/preset-typescript": "^7.23.0",
+        "@react-native/babel-preset": "0.76.9",
+        "babel-plugin-react-native-web": "~0.19.13",
+        "react-refresh": "^0.14.2"
+      },
+      "peerDependencies": {
+        "babel-plugin-react-compiler": "^19.0.0-beta-9ee70a1-20241017",
+        "react-compiler-runtime": "^19.0.0-beta-8a03594-20241020"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "react-compiler-runtime": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/babel-preset-expo/node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.6.tgz",
+      "integrity": "sha512-69D/imtToCsIcAl8WBS2YaRwA4jO/j0HhU+hELqMEu9f54MoUtI6+XH5mrKU8rEFNEk/Ui1I2MK4/JkWacclGw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-opn": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-3.0.2.tgz",
+      "integrity": "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "open": "^8.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/better-opn/node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/bplist-creator": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
+      "integrity": "sha512-xp/tcaV3T5PCiaY04mXga7o/TE+t95gqeLmADeBI1CvZtdWTbgBt3uLpvh4UWtenKeBhCV6oVxGk38yZr2uYEA==",
+      "license": "MIT",
+      "dependencies": {
+        "stream-buffers": "~2.2.0"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
+      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "1.6.x"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
+      "integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^3.1.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^4.0.0",
+        "ssri": "^10.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^3.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/caller-callsite/node_modules/callsites": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/caller-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==",
+      "license": "MIT",
+      "dependencies": {
+        "caller-callsite": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chrome-launcher": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
+      "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chromium-edge-launcher": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz",
+      "integrity": "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "node_modules/chromium-edge-launcher/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "license": "MIT"
+    },
+    "node_modules/component-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.2.tgz",
+      "integrity": "sha512-99VUHREHiN5cLeHm3YLq312p6v+HUEcwtLCAtelvUDI6+SH5g5Cr85oNR2S1o6ywzL0ykMbuwLzM2ANocjEOIA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/connect": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.2",
+        "parseurl": "~1.3.3",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/connect/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/connect/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/core-js-compat": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
+      "license": "MIT",
+      "dependencies": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-gateway": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
+      "integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/del": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
+      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
+      "license": "MIT",
+      "dependencies": {
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.397",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.397.tgz",
+      "integrity": "sha512-khGTy9U9x02KEtsKM8vx5A62BsRmcOsIgDpWr1ImE32Ax8GxHGPHZf+Eu9H8zOOyHJnB0jTbseyTHbq2XCT8yw==",
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-editor": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/env-editor/-/env-editor-0.4.2.tgz",
+      "integrity": "sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/execa/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/expo": {
+      "version": "52.0.49",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-52.0.49.tgz",
+      "integrity": "sha512-ge3gUnuyGEePWWKzPY7TQ7FsvtFTdmsdYDHeBVUjMr9KIoQig/gf8A03oH26p3UtTL6sUJcyOIg9vwIHGNPSUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.20.0",
+        "@expo/cli": "0.22.28",
+        "@expo/config": "~10.0.11",
+        "@expo/config-plugins": "~9.0.17",
+        "@expo/fingerprint": "0.11.11",
+        "@expo/metro-config": "0.19.12",
+        "@expo/vector-icons": "~14.0.4",
+        "babel-preset-expo": "~12.0.12",
+        "expo-asset": "~11.0.5",
+        "expo-constants": "~17.0.8",
+        "expo-file-system": "~18.0.12",
+        "expo-font": "~13.0.4",
+        "expo-keep-awake": "~14.0.3",
+        "expo-modules-autolinking": "2.0.8",
+        "expo-modules-core": "2.2.3",
+        "fbemitter": "^3.0.0",
+        "web-streams-polyfill": "^3.3.2",
+        "whatwg-url-without-unicode": "8.0.0-3"
+      },
+      "bin": {
+        "expo": "bin/cli",
+        "expo-modules-autolinking": "bin/autolinking",
+        "fingerprint": "bin/fingerprint"
+      },
+      "peerDependencies": {
+        "@expo/dom-webview": "*",
+        "@expo/metro-runtime": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-webview": "*"
+      },
+      "peerDependenciesMeta": {
+        "@expo/dom-webview": {
+          "optional": true
+        },
+        "@expo/metro-runtime": {
+          "optional": true
+        },
+        "react-native-webview": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-asset": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.0.5.tgz",
+      "integrity": "sha512-TL60LmMBGVzs3NQcO8ylWqBumMh4sx0lmeJsn7+9C88fylGDhyyVnKZ1PyTXo9CVDBkndutZx2JUEQWM9BaiXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.6.5",
+        "expo-constants": "~17.0.8",
+        "invariant": "^2.2.4",
+        "md5-file": "^3.2.3"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-constants": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.0.8.tgz",
+      "integrity": "sha512-XfWRyQAf1yUNgWZ1TnE8pFBMqGmFP5Gb+SFSgszxDdOoheB/NI5D4p7q86kI2fvGyfTrxAe+D+74nZkfsGvUlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~10.0.11",
+        "@expo/env": "~0.4.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-file-system": {
+      "version": "18.0.12",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.0.12.tgz",
+      "integrity": "sha512-HAkrd/mb8r+G3lJ9MzmGeuW2B+BxQR1joKfeCyY4deLl1zoZ48FrAWjgZjHK9aHUVhJ0ehzInu/NQtikKytaeg==",
+      "license": "MIT",
+      "dependencies": {
+        "web-streams-polyfill": "^3.3.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-font": {
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.0.4.tgz",
+      "integrity": "sha512-eAP5hyBgC8gafFtprsz0HMaB795qZfgJWqTmU0NfbSin1wUuVySFMEPMOrTkTgmazU73v4Cb4x7p86jY1XXYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "fontfaceobserver": "^2.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
+    "node_modules/expo-keep-awake": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.0.3.tgz",
+      "integrity": "sha512-6Jh94G6NvTZfuLnm2vwIpKe3GdOiVBuISl7FI8GqN0/9UOg9E0WXXp5cDcfAG8bn80RfgLJS8P7EPUGTZyOvhg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
+    "node_modules/expo-modules-autolinking": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.0.8.tgz",
+      "integrity": "sha512-DezgnEYFQYic8hKGhkbztBA3QUmSftjaNDIKNAtS2iGJmzCcNIkatjN2slFDSWjSTNo8gOvPQyMKfyHWFvLpOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/spawn-async": "^1.7.2",
+        "chalk": "^4.1.0",
+        "commander": "^7.2.0",
+        "fast-glob": "^3.2.5",
+        "find-up": "^5.0.0",
+        "fs-extra": "^9.1.0",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-modules-autolinking": "bin/expo-modules-autolinking.js"
+      }
+    },
+    "node_modules/expo-modules-autolinking/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-modules-autolinking/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/expo-modules-autolinking/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/expo-modules-autolinking/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/expo-modules-core": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-2.2.3.tgz",
+      "integrity": "sha512-01QqZzpP/wWlxnNly4G06MsOBUTbMDj02DQigZoXfDh80vd/rk3/uVXqnZgOdLSggTs6DnvOgAUy0H2q30XdUg==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-json-stringify/node_modules/fast-uri": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.10.0.tgz",
+      "integrity": "sha512-A9L0ziuWGQHgEEVgF3davQ9vbD93IuX+lo2IsxapQmu5b/Y/ynn9m9K5JHt9dvyJXOFc5iN0Zk5GHEOqnzhWjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fbemitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-3.0.0.tgz",
+      "integrity": "sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fbjs": "^3.0.0"
+      }
+    },
+    "node_modules/fbjs": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "^3.1.5",
+        "fbjs-css-vars": "^1.0.0",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^1.0.35"
+      }
+    },
+    "node_modules/fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-retry": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-4.1.1.tgz",
+      "integrity": "sha512-e6eB7zN6UBSwGVwrbWVH+gdLnkW9WwHhmq2YDK1Sh30pzx1onRVGBvogTlUeWxwTa+L86NYdo4hFkh7O8ZjSnA==",
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/flow-enums-runtime": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
+      "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
+      "license": "MIT"
+    },
+    "node_modules/flow-estree": {
+      "version": "0.324.0",
+      "resolved": "https://registry.npmjs.org/flow-estree/-/flow-estree-0.324.0.tgz",
+      "integrity": "sha512-As9kMmy7BhCHr3LZ48Y2eJXL8aceNCFN8kJFZxnr862e/P0q9zBO6b5rFJEfKdry3ZjPtaXcgG7ug8yeWQX6qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/flow-parser": {
+      "version": "0.324.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.324.0.tgz",
+      "integrity": "sha512-0+8EOQ3qagZGO+0Hw6L4PN23vzL6OSrRODp7BZJwirkJxOZCAgJYUdRIQO/VSklUpOPaR7Zf+SAnlnYD9FI+Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-estree": "0.324.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/fontfaceobserver": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
+      "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
+      "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/freeport-async": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/freeport-async/-/freeport-async-2.0.0.tgz",
+      "integrity": "sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/getenv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-1.0.0.tgz",
+      "integrity": "sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.1.tgz",
+      "integrity": "sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==",
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.1.tgz",
+      "integrity": "sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.23.1"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/internal-ip": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
+      "integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
+      "license": "MIT",
+      "dependencies": {
+        "default-gateway": "^4.2.0",
+        "ipaddr.js": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/internal-ip/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jimp-compact": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/jimp-compact/-/jimp-compact-0.16.1.tgz",
+      "integrity": "sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==",
+      "license": "MIT"
+    },
+    "node_modules/join-component": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
+      "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsc-android": {
+      "version": "250231.0.0",
+      "resolved": "https://registry.npmjs.org/jsc-android/-/jsc-android-250231.0.0.tgz",
+      "integrity": "sha512-rS46PvsjYmdmuz1OAWXY/1kCYG7pnf1TBqeTiOJr1iDz7s5DLxxC9n/ZMknLDxzYzNVfI7R95MH10emSSG1Wuw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jsc-safe-url": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
+      "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
+      "license": "0BSD"
+    },
+    "node_modules/jscodeshift": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.14.0.tgz",
+      "integrity": "sha512-7eCC1knD7bLUPuSCwXsMZUH51O8jIcoVyKtI6P0XM0IVzlGjckPy3FIwQlorzbN0Sg79oK+RlohN32Mqf/lrYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.13.16",
+        "@babel/parser": "^7.13.16",
+        "@babel/plugin-proposal-class-properties": "^7.13.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.12",
+        "@babel/plugin-transform-modules-commonjs": "^7.13.8",
+        "@babel/preset-flow": "^7.13.13",
+        "@babel/preset-typescript": "^7.13.0",
+        "@babel/register": "^7.13.16",
+        "babel-core": "^7.0.0-bridge.0",
+        "chalk": "^4.1.2",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.4",
+        "neo-async": "^2.5.0",
+        "node-dir": "^0.1.17",
+        "recast": "^0.21.0",
+        "temp": "^0.8.4",
+        "write-file-atomic": "^2.3.0"
+      },
+      "bin": {
+        "jscodeshift": "bin/jscodeshift.js"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
+      "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^2.6.9",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.27.0.tgz",
+      "integrity": "sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "1.27.0",
+        "lightningcss-darwin-x64": "1.27.0",
+        "lightningcss-freebsd-x64": "1.27.0",
+        "lightningcss-linux-arm-gnueabihf": "1.27.0",
+        "lightningcss-linux-arm64-gnu": "1.27.0",
+        "lightningcss-linux-arm64-musl": "1.27.0",
+        "lightningcss-linux-x64-gnu": "1.27.0",
+        "lightningcss-linux-x64-musl": "1.27.0",
+        "lightningcss-win32-arm64-msvc": "1.27.0",
+        "lightningcss-win32-x64-msvc": "1.27.0"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz",
+      "integrity": "sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.27.0.tgz",
+      "integrity": "sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.27.0.tgz",
+      "integrity": "sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.27.0.tgz",
+      "integrity": "sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.27.0.tgz",
+      "integrity": "sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.27.0.tgz",
+      "integrity": "sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.27.0.tgz",
+      "integrity": "sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.27.0.tgz",
+      "integrity": "sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.27.0.tgz",
+      "integrity": "sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.27.0.tgz",
+      "integrity": "sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/log-symbols/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/md5-file": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-3.2.3.tgz",
+      "integrity": "sha512-3Tkp1piAHaworfcCgH0jKbTvj1jWWFgbvh2cXaNCgHwyTCBxxvD1Y04rmfpvdPm1P4oXMOpm6+2H7sr7v9v8Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc": "^1.1.0"
+      },
+      "bin": {
+        "md5-file": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/metro": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.81.5.tgz",
+      "integrity": "sha512-YpFF0DDDpDVygeca2mAn7K0+us+XKmiGk4rIYMz/CRdjFoCGqAei/IQSpV0UrGfQbToSugpMQeQJveaWSH88Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.24.7",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.25.0",
+        "@babel/parser": "^7.25.3",
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.3",
+        "@babel/types": "^7.25.2",
+        "accepts": "^1.3.7",
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "connect": "^3.6.5",
+        "debug": "^2.2.0",
+        "error-stack-parser": "^2.0.6",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "hermes-parser": "0.25.1",
+        "image-size": "^1.0.2",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "jsc-safe-url": "^0.2.2",
+        "lodash.throttle": "^4.1.1",
+        "metro-babel-transformer": "0.81.5",
+        "metro-cache": "0.81.5",
+        "metro-cache-key": "0.81.5",
+        "metro-config": "0.81.5",
+        "metro-core": "0.81.5",
+        "metro-file-map": "0.81.5",
+        "metro-resolver": "0.81.5",
+        "metro-runtime": "0.81.5",
+        "metro-source-map": "0.81.5",
+        "metro-symbolicate": "0.81.5",
+        "metro-transform-plugins": "0.81.5",
+        "metro-transform-worker": "0.81.5",
+        "mime-types": "^2.1.27",
+        "nullthrows": "^1.1.1",
+        "serialize-error": "^2.1.0",
+        "source-map": "^0.5.6",
+        "throat": "^5.0.0",
+        "ws": "^7.5.10",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "metro": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-babel-transformer": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.81.5.tgz",
+      "integrity": "sha512-oKCQuajU5srm+ZdDcFg86pG/U8hkSjBlkyFjz380SZ4TTIiI5F+OQB830i53D8hmqmcosa4wR/pnKv8y4Q3dLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-parser": "0.25.1",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "license": "MIT"
+    },
+    "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/metro-cache": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.81.5.tgz",
+      "integrity": "sha512-wOsXuEgmZMZ5DMPoz1pEDerjJ11AuMy9JifH4yNW7NmWS0ghCRqvDxk13LsElzLshey8C+my/tmXauXZ3OqZgg==",
+      "license": "MIT",
+      "dependencies": {
+        "exponential-backoff": "^3.1.1",
+        "flow-enums-runtime": "^0.0.6",
+        "metro-core": "0.81.5"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-cache-key": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.81.5.tgz",
+      "integrity": "sha512-lGWnGVm1UwO8faRZ+LXQUesZSmP1LOg14OVR+KNPBip8kbMECbQJ8c10nGesw28uQT7AE0lwQThZPXlxDyCLKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-config": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.81.5.tgz",
+      "integrity": "sha512-oDRAzUvj6RNRxratFdcVAqtAsg+T3qcKrGdqGZFUdwzlFJdHGR9Z413sW583uD2ynsuOjA2QB6US8FdwiBdNKg==",
+      "license": "MIT",
+      "dependencies": {
+        "connect": "^3.6.5",
+        "cosmiconfig": "^5.0.5",
+        "flow-enums-runtime": "^0.0.6",
+        "jest-validate": "^29.7.0",
+        "metro": "0.81.5",
+        "metro-cache": "0.81.5",
+        "metro-core": "0.81.5",
+        "metro-runtime": "0.81.5"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-core": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.81.5.tgz",
+      "integrity": "sha512-+2R0c8ByfV2N7CH5wpdIajCWa8escUFd8TukfoXyBq/vb6yTCsznoA25FhNXJ+MC/cz1L447Zj3vdUfCXIZBwg==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "lodash.throttle": "^4.1.1",
+        "metro-resolver": "0.81.5"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-file-map": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.81.5.tgz",
+      "integrity": "sha512-mW1PKyiO3qZvjeeVjj1brhkmIotObA3/9jdbY1fQQYvEWM6Ml7bN/oJCRDGn2+bJRlG+J8pwyJ+DgdrM4BsKyg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "fb-watchman": "^2.0.0",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "nullthrows": "^1.1.1",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-file-map/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/metro-file-map/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/metro-minify-terser": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.81.5.tgz",
+      "integrity": "sha512-/mn4AxjANnsSS3/Bb+zA1G5yIS5xygbbz/OuPaJYs0CPcZCaWt66D+65j4Ft/nJkffUxcwE9mk4ubpkl3rjgtw==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "terser": "^5.15.0"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-resolver": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.81.5.tgz",
+      "integrity": "sha512-6BX8Nq3g3go3FxcyXkVbWe7IgctjDTk6D9flq+P201DfHHQ28J+DWFpVelFcrNTn4tIfbP/Bw7u/0g2BGmeXfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-runtime": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.81.5.tgz",
+      "integrity": "sha512-M/Gf71ictUKP9+77dV/y8XlAWg7xl76uhU7ggYFUwEdOHHWPG6gLBr1iiK0BmTjPFH8yRo/xyqMli4s3oGorPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-source-map": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.81.5.tgz",
+      "integrity": "sha512-Jz+CjvCKLNbJZYJTBeN3Kq9kIJf6b61MoLBdaOQZJ5Ajhw6Pf95Nn21XwA8BwfUYgajsi6IXsp/dTZsYJbN00Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.25.3",
+        "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3",
+        "@babel/types": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-symbolicate": "0.81.5",
+        "nullthrows": "^1.1.1",
+        "ob1": "0.81.5",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-symbolicate": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.81.5.tgz",
+      "integrity": "sha512-X3HV3n3D6FuTE11UWFICqHbFMdTavfO48nXsSpnNGFkUZBexffu0Xd+fYKp+DJLNaQr3S+lAs8q9CgtDTlRRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-source-map": "0.81.5",
+        "nullthrows": "^1.1.1",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "bin": {
+        "metro-symbolicate": "src/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-transform-plugins": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.81.5.tgz",
+      "integrity": "sha512-MmHhVx/1dJC94FN7m3oHgv5uOjKH8EX8pBeu1pnPMxbJrx6ZuIejO0k84zTSaQTZ8RxX1wqwzWBpXAWPjEX8mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.25.0",
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.3",
+        "flow-enums-runtime": "^0.0.6",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro-transform-worker": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.81.5.tgz",
+      "integrity": "sha512-lUFyWVHa7lZFRSLJEv+m4jH8WrR5gU7VIjUlg4XmxQfV8ngY4V10ARKynLhMYPeQGl7Qvf+Ayg0eCZ272YZ4Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.25.0",
+        "@babel/parser": "^7.25.3",
+        "@babel/types": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "metro": "0.81.5",
+        "metro-babel-transformer": "0.81.5",
+        "metro-cache": "0.81.5",
+        "metro-cache-key": "0.81.5",
+        "metro-minify-terser": "0.81.5",
+        "metro-source-map": "0.81.5",
+        "metro-transform-plugins": "0.81.5",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/metro/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "license": "MIT"
+    },
+    "node_modules/metro/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/metro/node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "license": "MIT"
+    },
+    "node_modules/metro/node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/metro/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/metro/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/nested-error-stacks": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz",
+      "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
+      "license": "MIT"
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.5"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-package-arg": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
+      "integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "proc-log": "^4.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^5.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "license": "MIT"
+    },
+    "node_modules/ob1": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.81.5.tgz",
+      "integrity": "sha512-iNpbeXPLmaiT9I5g16gFFFjsF3sGxLpYG2EGP3dfFB4z+l9X60mp/yRzStHhMtuNt8qmf7Ww80nOPQHngHhnIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+      "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^2.0.0",
+        "log-symbols": "^2.2.0",
+        "strip-ansi": "^5.2.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/parse-png": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-png/-/parse-png-2.1.0.tgz",
+      "integrity": "sha512-Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pngjs": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/plist/node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/plist/node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.11.0.tgz",
+      "integrity": "sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-devtools-core": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-5.3.2.tgz",
+      "integrity": "sha512-crr9HkVrDiJ0A4zot89oS0Cgv0Oa4OG1Em4jit3P3ZxZSKPMYyMjfwMqgcJna9o625g8oN87rBm8SWWrSTBZxg==",
+      "license": "MIT",
+      "dependencies": {
+        "shell-quote": "^1.6.1",
+        "ws": "^7"
+      }
+    },
+    "node_modules/react-devtools-core/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-native": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.76.3.tgz",
+      "integrity": "sha512-0TUhgmlouRNf6yuDIIAdbQl0g1VsONgCMsLs7Et64hjj5VLMCA7np+4dMrZvGZ3wRNqzgeyT9oWJsUm49AcwSQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/create-cache-key-function": "^29.6.3",
+        "@react-native/assets-registry": "0.76.3",
+        "@react-native/codegen": "0.76.3",
+        "@react-native/community-cli-plugin": "0.76.3",
+        "@react-native/gradle-plugin": "0.76.3",
+        "@react-native/js-polyfills": "0.76.3",
+        "@react-native/normalize-colors": "0.76.3",
+        "@react-native/virtualized-lists": "0.76.3",
+        "abort-controller": "^3.0.0",
+        "anser": "^1.4.9",
+        "ansi-regex": "^5.0.0",
+        "babel-jest": "^29.7.0",
+        "babel-plugin-syntax-hermes-parser": "^0.23.1",
+        "base64-js": "^1.5.1",
+        "chalk": "^4.0.0",
+        "commander": "^12.0.0",
+        "event-target-shim": "^5.0.1",
+        "flow-enums-runtime": "^0.0.6",
+        "glob": "^7.1.1",
+        "invariant": "^2.2.4",
+        "jest-environment-node": "^29.6.3",
+        "jsc-android": "^250231.0.0",
+        "memoize-one": "^5.0.0",
+        "metro-runtime": "^0.81.0",
+        "metro-source-map": "^0.81.0",
+        "mkdirp": "^0.5.1",
+        "nullthrows": "^1.1.1",
+        "pretty-format": "^29.7.0",
+        "promise": "^8.3.0",
+        "react-devtools-core": "^5.3.1",
+        "react-refresh": "^0.14.0",
+        "regenerator-runtime": "^0.13.2",
+        "scheduler": "0.24.0-canary-efb381bbf-20230505",
+        "semver": "^7.1.3",
+        "stacktrace-parser": "^0.1.10",
+        "whatwg-fetch": "^3.0.0",
+        "ws": "^6.2.3",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "react-native": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.6",
+        "react": "^18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native/node_modules/@react-native/codegen": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.76.3.tgz",
+      "integrity": "sha512-oJCH/jbYeGmFJql8/y76gqWCCd74pyug41yzYAjREso1Z7xL88JhDyKMvxEnfhSdMOZYVl479N80xFiXPy3ZYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.3",
+        "glob": "^7.1.1",
+        "hermes-parser": "0.23.1",
+        "invariant": "^2.2.4",
+        "jscodeshift": "^0.14.0",
+        "mkdirp": "^0.5.1",
+        "nullthrows": "^1.1.1",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      }
+    },
+    "node_modules/react-native/node_modules/@react-native/normalize-colors": {
+      "version": "0.76.3",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.76.3.tgz",
+      "integrity": "sha512-Yrpmrh4IDEupUUM/dqVxhAN8QW1VEUR3Qrk2lzJC1jB2s46hDe0hrMP2vs12YJqlzshteOthjwXQlY0TgIzgbg==",
+      "license": "MIT"
+    },
+    "node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.23.1.tgz",
+      "integrity": "sha512-uNLD0tk2tLUjGFdmCk+u/3FEw2o+BAwW4g+z2QVlxJrzZYOOPADroEcNtTPt5lNiScctaUmnsTkVEnOwZUOLhA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-parser": "0.23.1"
+      }
+    },
+    "node_modules/react-native/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/react-native/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/react-native/node_modules/promise": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "asap": "~2.0.6"
+      }
+    },
+    "node_modules/react-native/node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-native/node_modules/scheduler": {
+      "version": "0.24.0-canary-efb381bbf-20230505",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.24.0-canary-efb381bbf-20230505.tgz",
+      "integrity": "sha512-ABvovCDe/k9IluqSh4/ISoq8tIJnW8euVAWYt5j/bg6dRnqwQwiGO1F/V4AyK96NGF/FB04FhOUDuWj8IKfABA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-native/node_modules/ws": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.6.tgz",
+      "integrity": "sha512-XTrf1gv7kXoVf1hbC3PAyAiPgR8Wz1blcrYIjEsUmr08BLksT41R8KbjmS9408C2ERx7v1JDLD/BkpLEttjfKA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readline": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==",
+      "license": "BSD"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.21.5.tgz",
+      "integrity": "sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "0.15.2",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "license": "MIT"
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+      "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
+    },
+    "node_modules/regexpu-core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
+      "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.2.2",
+        "regjsgen": "^0.8.0",
+        "regjsparser": "^0.13.0",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+      "license": "MIT"
+    },
+    "node_modules/regjsparser": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
+      "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~3.1.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/remove-trailing-slash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
+      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==",
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requireg": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/requireg/-/requireg-0.2.2.tgz",
+      "integrity": "sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==",
+      "dependencies": {
+        "nested-error-stacks": "~2.0.1",
+        "rc": "~1.2.7",
+        "resolve": "~1.7.1"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/requireg/node_modules/resolve": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-parse": "^1.0.5"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-workspace-root": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-workspace-root/-/resolve-workspace-root-2.0.1.tgz",
+      "integrity": "sha512-nR23LHAvaI6aHtMg6RWoaHpdR4D881Nydkzi2CixINyg9T00KgaJdJI6Vwty+Ps8WLxZHuxsS0BseWjxSA4C+w==",
+      "license": "MIT"
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-plist": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.3.1.tgz",
+      "integrity": "sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==",
+      "license": "MIT",
+      "dependencies": {
+        "bplist-creator": "0.1.0",
+        "bplist-parser": "0.3.1",
+        "plist": "^3.0.5"
+      }
+    },
+    "node_modules/simple-plist/node_modules/bplist-creator": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
+      "integrity": "sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==",
+      "license": "MIT",
+      "dependencies": {
+        "stream-buffers": "2.2.x"
+      }
+    },
+    "node_modules/simple-plist/node_modules/bplist-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz",
+      "integrity": "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "1.6.x"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+      "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ssri": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
+      "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "license": "MIT"
+    },
+    "node_modules/stacktrace-parser": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+      "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-buffers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/structured-headers": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-0.4.1.tgz",
+      "integrity": "sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==",
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/temp": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/temp/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/temp/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/tempy": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.7.1.tgz",
+      "integrity": "sha512-vXPxwOyaNVi9nyczO16mxmHGpl6ASC5/TVhRRHpqeYHvKQm58EaWNvZXxAhR0lYYnBOQFjXjhzeLsaXdjxLjRg==",
+      "license": "MIT",
+      "dependencies": {
+        "del": "^6.0.0",
+        "is-stream": "^2.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^0.16.0",
+        "unique-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/type-fest": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
+    "node_modules/throat": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+      "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
+      "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
+      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+      "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unique-filename": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vlq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
+      "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
+      "license": "MIT"
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/whatwg-url-without-unicode": {
+      "version": "8.0.0-3",
+      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
+      "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.4.3",
+        "punycode": "^2.1.1",
+        "webidl-conversions": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/whatwg-url-without-unicode/node_modules/webidl-conversions": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wonka": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.6.tgz",
+      "integrity": "sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==",
+      "license": "MIT"
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xcode": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
+      "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "simple-plist": "^1.1.0",
+        "uuid": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/xcode/node_modules/uuid": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+      "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
+      "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/core": {
+      "name": "@pennair/integration-core",
+      "version": "0.0.0"
+    },
+    "packages/mobile": {
+      "name": "@pennair/mobile",
+      "version": "0.0.0",
+      "dependencies": {
+        "@pennair/integration-core": "*",
+        "expo": "~52.0.0",
+        "react": "^18.3.1",
+        "react-native": "0.76.3"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "typescript": "^5.7.2"
+      }
+    },
+    "packages/orchestrator": {
+      "name": "@pennair/orchestrator",
+      "version": "0.0.0",
+      "dependencies": {
+        "@pennair/integration-core": "*",
+        "fastify": "^5.1.0"
+      },
+      "devDependencies": {
+        "@pennair/pi-agent": "*"
+      }
+    },
+    "packages/pi-agent": {
+      "name": "@pennair/pi-agent",
+      "version": "0.0.0",
+      "dependencies": {
+        "fastify": "^5.1.0"
+      }
+    },
+    "packages/web": {
+      "name": "@pennair/web",
+      "version": "0.0.0",
+      "dependencies": {
+        "@pennair/integration-core": "*",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.3",
+        "vite": "^5.4.11"
+      }
+    }
+  }
+}

--- a/controls/sae_2025_ws/integration/package-lock.json
+++ b/controls/sae_2025_ws/integration/package-lock.json
@@ -3483,6 +3483,28 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
@@ -3552,6 +3574,45 @@
       "dependencies": {
         "dequal": "^2.0.3"
       }
+    },
+    "node_modules/@fastify/multipart": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-9.4.0.tgz",
+      "integrity": "sha512-Z404bzZeLSXTBmp/trCBuoVFX28pM7rhv849Q5TsbTFZHuk1lc4QjQITTPK92DKVpXmNtJXeHSSc7GYvqFpxAQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@fastify/deepmerge": "^3.0.0",
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0",
+        "secure-json-parse": "^4.0.0"
+      }
+    },
+    "node_modules/@fastify/multipart/node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/proxy-addr": {
       "version": "5.1.0",
@@ -3711,7 +3772,6 @@
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -14700,9 +14760,11 @@
       "name": "@pennair/orchestrator",
       "version": "0.0.0",
       "dependencies": {
+        "@fastify/multipart": "^9.0.1",
         "@fastify/websocket": "^11.0.2",
         "@pennair/integration-core": "*",
         "fastify": "^5.1.0",
+        "tar": "^7.4.3",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -14713,13 +14775,107 @@
         "rclnodejs": "^2.1.1"
       }
     },
+    "packages/orchestrator/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/orchestrator/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/orchestrator/node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/orchestrator/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "packages/pi-agent": {
       "name": "@pennair/pi-agent",
       "version": "0.0.0",
       "dependencies": {
+        "@fastify/multipart": "^9.0.1",
         "@fastify/websocket": "^11.0.2",
         "@pennair/integration-core": "*",
-        "fastify": "^5.1.0"
+        "fastify": "^5.1.0",
+        "tar": "^7.4.3"
+      }
+    },
+    "packages/pi-agent/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pi-agent/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/pi-agent/node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/pi-agent/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/web": {

--- a/controls/sae_2025_ws/integration/package-lock.json
+++ b/controls/sae_2025_ws/integration/package-lock.json
@@ -3573,6 +3573,27 @@
         "ipaddr.js": "^2.1.0"
       }
     },
+    "node_modules/@fastify/websocket": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/websocket/-/websocket-11.3.0.tgz",
+      "integrity": "sha512-g89ag4BCcD9YP5wBZXixzoLnuf5j89p/sXFcfpCiv2pdEkYYukBEoK3heVzqsp0EAtszVDc2BBZG0KZqeAShIA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.3",
+        "fastify-plugin": "^6.0.0",
+        "ws": "^8.16.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -3683,6 +3704,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@isaacs/ttlcache": {
@@ -4056,6 +4090,27 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@rclnodejs/ref-array-di": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rclnodejs/ref-array-di/-/ref-array-di-1.2.2.tgz",
+      "integrity": "sha512-BHslJ1wmmaiPQ2rPZrO9Du9Cd/eQjZ+N5T84poFZk9JFJkYatbtXALbjWTgoHWpl6Cvm415NfwsGc2xkjzFPxw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "array-index": "^1.0.0",
+        "debug": "^4.3.1"
+      }
+    },
+    "node_modules/@rclnodejs/ref-struct-di": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@rclnodejs/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
+      "integrity": "sha512-UqFrk6tXEo3d6byHLUqsfJzONDZDUDU/g8fpkj2Xxy8CF0r7QRQ3wGyQxBS+GFzf7yByWBSddPhOj1EsGB0R3Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.3.1"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -5139,6 +5194,16 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "license": "MIT"
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -5604,6 +5669,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -5826,6 +5901,37 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/array-index": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
+      "integrity": "sha512-jesyNbBkLQgGZMSwA1FanaFjalb1mZUGxGeUEkSDidzgrbjBGhvizJkaItdhkt8eIHFOJC7nDsrXk+BaehTdRw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^2.2.0",
+        "es6-symbol": "^3.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/array-index/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/array-index/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -6216,6 +6322,26 @@
       "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bplist-creator": {
@@ -6994,6 +7120,20 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -7204,6 +7344,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -7253,6 +7405,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/error-ex": {
@@ -7323,6 +7485,49 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/esbuild": {
@@ -7482,6 +7687,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -7575,6 +7796,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/event-target-shim": {
@@ -7883,6 +8115,16 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "type": "^2.7.2"
+      }
+    },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -8072,6 +8314,22 @@
         "toad-cache": "^3.7.0"
       }
     },
+    "node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -8124,7 +8382,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -8156,6 +8414,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -8299,6 +8564,13 @@
       "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
       "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/foreachasync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+      "integrity": "sha512-J+ler7Ta54FwwNcx6wQRDhTIbNeyDcARMkOcguEqnEdtm0jKvN3Li3PDAb2Du3ubJYEWfYL83XMROXdsXAXycw==",
+      "license": "Apache2",
+      "optional": true
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -9351,6 +9623,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -10654,11 +10936,28 @@
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "license": "MIT"
     },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/node-dir": {
       "version": "0.1.17",
@@ -10701,6 +11000,117 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/node-gyp": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10714,6 +11124,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/normalize-path": {
@@ -11189,7 +11615,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -11629,6 +12055,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rclnodejs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rclnodejs/-/rclnodejs-2.1.1.tgz",
+      "integrity": "sha512-8CC50fYRrOgTLSVSFhlnFv3hf8qs+eQbqcell7t38I4SYtbdCssDa+awEawiH3PD08VN5t6BBUUmaecD9+k0vw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@rclnodejs/ref-array-di": "^1.2.2",
+        "@rclnodejs/ref-struct-di": "^1.1.1",
+        "bindings": "^1.5.0",
+        "debug": "^4.4.0",
+        "json-bigint": "^1.0.0",
+        "node-addon-api": "^8.3.1",
+        "node-gyp": "^12.2.0",
+        "rxjs": "^7.8.1",
+        "walk": "^2.3.15",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "generate-ros-messages": "scripts/generate_messages.cjs",
+        "rclnodejs-web": "bin/rclnodejs-web.js",
+        "rosocket": "rosocket/cli.js"
+      },
+      "engines": {
+        "node": ">= 20.20.2"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -11875,6 +12329,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readline": {
@@ -12214,6 +12682,16 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -12708,6 +13186,21 @@
       "license": "Unlicense",
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -13210,7 +13703,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -13319,6 +13812,13 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -13565,6 +14065,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -13757,6 +14263,16 @@
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "license": "MIT"
+    },
+    "node_modules/walk": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
+      "integrity": "sha512-4eRTBZljBfIISK1Vnt69Gvr2w/wc3U6Vtrw7qiN5iqYJPH7LElcYh/iU4XWhdCy2dZqv1ToMyYlybDylfG/5Vg==",
+      "license": "(MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "foreachasync": "^3.0.0"
+      }
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -14184,17 +14700,24 @@
       "name": "@pennair/orchestrator",
       "version": "0.0.0",
       "dependencies": {
+        "@fastify/websocket": "^11.0.2",
         "@pennair/integration-core": "*",
-        "fastify": "^5.1.0"
+        "fastify": "^5.1.0",
+        "ws": "^8.18.0"
       },
       "devDependencies": {
-        "@pennair/pi-agent": "*"
+        "@pennair/pi-agent": "*",
+        "@types/ws": "^8.5.13"
+      },
+      "optionalDependencies": {
+        "rclnodejs": "^2.1.1"
       }
     },
     "packages/pi-agent": {
       "name": "@pennair/pi-agent",
       "version": "0.0.0",
       "dependencies": {
+        "@fastify/websocket": "^11.0.2",
         "@pennair/integration-core": "*",
         "fastify": "^5.1.0"
       }

--- a/controls/sae_2025_ws/integration/package-lock.json
+++ b/controls/sae_2025_ws/integration/package-lock.json
@@ -11754,6 +11754,16 @@
         }
       }
     },
+    "node_modules/react-native-safe-area-context": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.12.0.tgz",
+      "integrity": "sha512-ukk5PxcF4p3yu6qMZcmeiZgowhb5AsKRnil54YFUUAXVIS7PJcMHGGC+q44fCiBg44/1AJk5njGMez1m9H0BVQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native/node_modules/@react-native/codegen": {
       "version": "0.76.3",
       "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.76.3.tgz",
@@ -14162,7 +14172,8 @@
         "@pennair/integration-core": "*",
         "expo": "~52.0.0",
         "react": "^18.3.1",
-        "react-native": "0.76.3"
+        "react-native": "0.76.3",
+        "react-native-safe-area-context": "4.12.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.12",
@@ -14184,6 +14195,7 @@
       "name": "@pennair/pi-agent",
       "version": "0.0.0",
       "dependencies": {
+        "@pennair/integration-core": "*",
         "fastify": "^5.1.0"
       }
     },

--- a/controls/sae_2025_ws/integration/package.json
+++ b/controls/sae_2025_ws/integration/package.json
@@ -8,8 +8,10 @@
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "lint": "eslint .",
+    "pretest": "npm run build --workspaces --if-present",
     "test": "vitest run",
-    "typecheck": "tsc --build"
+    "pretypecheck": "npm run build --workspaces --if-present",
+    "typecheck": "npm run typecheck --workspaces --if-present"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/controls/sae_2025_ws/integration/package.json
+++ b/controls/sae_2025_ws/integration/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "pennair-integration",
+  "private": true,
+  "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "npm run build --workspaces --if-present",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "typecheck": "tsc --build"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.15.0",
+    "@types/node": "^22.9.0",
+    "eslint": "^9.15.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.7.2",
+    "typescript-eslint": "^8.15.0",
+    "vitest": "^2.1.5"
+  }
+}

--- a/controls/sae_2025_ws/integration/packages/core/package.json
+++ b/controls/sae_2025_ws/integration/packages/core/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@pennair/integration-core",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --build",
+    "test": "vitest run"
+  }
+}

--- a/controls/sae_2025_ws/integration/packages/core/package.json
+++ b/controls/sae_2025_ws/integration/packages/core/package.json
@@ -9,5 +9,8 @@
     "build": "tsc --build tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
+  },
+  "dependencies": {
+    "yaml": "^2.6.1"
   }
 }

--- a/controls/sae_2025_ws/integration/packages/core/package.json
+++ b/controls/sae_2025_ws/integration/packages/core/package.json
@@ -6,7 +6,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   }
 }

--- a/controls/sae_2025_ws/integration/packages/core/src/discovery.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/discovery.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { discoverPis } from "./discovery.js";
+
+describe("discoverPis", () => {
+  it("returns only hostnames that respond ok to /health", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      const reachable = url.toString().includes("air-01.local");
+      return { ok: reachable } as Response;
+    });
+
+    const found = await discoverPis({
+      prefixes: ["air"],
+      suffixes: [1, 2],
+      port: 8090,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(found).toEqual([{ hostname: "air-01.local" }]);
+  });
+
+  it("treats a fetch rejection (unreachable host) as not found", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network error");
+    });
+
+    const found = await discoverPis({
+      prefixes: ["air"],
+      suffixes: [1],
+      port: 8090,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(found).toEqual([]);
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/core/src/discovery.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/discovery.ts
@@ -1,0 +1,63 @@
+export interface DiscoveryOptions {
+  /** Hostname prefixes to probe, e.g. ["air", "payload"]. */
+  prefixes: string[];
+  /** Numeric suffixes to try for each prefix, e.g. [1, 2, ..., 20]. */
+  suffixes: number[];
+  /** Port the pi-agent health endpoint listens on. */
+  port: number;
+  /** Per-probe timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Injectable for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface DiscoveredPi {
+  hostname: string;
+}
+
+function candidateHostnames(options: DiscoveryOptions): string[] {
+  const padded = (n: number) => String(n).padStart(2, "0");
+  const hostnames: string[] = [];
+  for (const prefix of options.prefixes) {
+    for (const suffix of options.suffixes) {
+      hostnames.push(`${prefix}-${padded(suffix)}.local`);
+    }
+  }
+  return hostnames;
+}
+
+async function probeOne(
+  hostname: string,
+  port: number,
+  timeoutMs: number,
+  fetchImpl: typeof fetch,
+): Promise<DiscoveredPi | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(`http://${hostname}:${port}/health`, {
+      signal: controller.signal,
+    });
+    return response.ok ? { hostname } : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Probes a known range of Pi hostnames directly (no mDNS service-browsing,
+ * which browsers/React Native can't do) since this fleet's Pis follow a
+ * fixed naming convention (air-0x.local, payload-0x.local).
+ */
+export async function discoverPis(options: DiscoveryOptions): Promise<DiscoveredPi[]> {
+  const timeoutMs = options.timeoutMs ?? 1000;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const results = await Promise.all(
+    candidateHostnames(options).map((hostname) =>
+      probeOne(hostname, options.port, timeoutMs, fetchImpl),
+    ),
+  );
+  return results.filter((result): result is DiscoveredPi => result !== null);
+}

--- a/controls/sae_2025_ws/integration/packages/core/src/fleet-board.edge-cases.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/fleet-board.edge-cases.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { computeFleetReadiness, summarizeFleetBoard } from "./fleet-board.js";
+import type { FleetBoardDevice } from "./types.js";
+
+describe("computeFleetReadiness: connected=true but runtimeState=offline", () => {
+  // This combination looks contradictory at a glance, but it's real and
+  // reachable: pi-agent-client.ts's missionStatus() falls back to exactly
+  // `state: "offline"` when ITS OWN probe fails/times out (see its
+  // `onUnreachable` default), independently of isHealthy()'s /health probe.
+  // fetchFleetBoard fans both calls out via Promise.all with *different*
+  // per-call timeouts (HEALTH_TIMEOUT_MS=5s vs MISSION_STATUS_TIMEOUT_MS=
+  // 20s), so it's entirely possible for /health to succeed (connected: true)
+  // while /api/mission/status independently times out or 5xxs on the same
+  // poll (runtimeState: "offline"). Not a synthetic edge case -- it's the
+  // real fallback value substituted by missionStatus() itself.
+  it("is not ready, and reuses the same note as a genuinely running/errored runtime", () => {
+    const result = computeFleetReadiness({ connected: true, buildInstalled: true, runtimeState: "offline" });
+    expect(result.ready).toBe(false);
+    // Documents current behavior rather than asserting a "should": the note
+    // produced here is identical to the one produced when runtimeState is
+    // "running" or "error" (see fleet-board.test.ts's existing case). There
+    // is no distinct note for "connected, but we couldn't determine runtime
+    // state" -- an operator sees "Runtime not ready to launch" for both a Pi
+    // that's mid-mission and one whose status probe merely timed out this
+    // poll, which is a real ambiguity in the board UI, if not a crash bug.
+    expect(result.notes).toEqual(["Runtime not ready to launch"]);
+  });
+});
+
+describe("summarizeFleetBoard: duplicate hostnames in the device list", () => {
+  function device(overrides: Partial<FleetBoardDevice>): FleetBoardDevice {
+    return {
+      hostname: "air-01.local",
+      connected: true,
+      buildInstalled: true,
+      runtimeState: "stopped",
+      runtimeRunning: false,
+      ready: true,
+      notes: [],
+      ...overrides,
+    };
+  }
+
+  // discoverPis() (packages/core/src/discovery.ts) builds its candidate
+  // list as the cross product of `prefixes` x `suffixes`
+  // (candidateHostnames), with no de-duplication of `prefixes` itself. The
+  // orchestrator's DISCOVERY_PREFIXES env var is split on "," with no
+  // trim/filter (packages/orchestrator/src/index.ts's discoveryParams()),
+  // so a duplicated prefix (e.g. "air,air" from a copy-paste config
+  // mistake) makes discoverPis() probe and return the exact same hostname
+  // twice. fetchFleetBoard has no hostname-uniqueness safeguard downstream
+  // of discovery, and summarizeFleetBoard just filters/counts the array it
+  // is given -- so a single physical Pi would be double-counted in every
+  // summary bucket it belongs to, and FleetBoard.tsx would render two
+  // <li key={device.hostname}> cards sharing a React key.
+  it("double-counts a hostname that appears twice, rather than de-duplicating by hostname", () => {
+    const devices = [device({}), device({})];
+    expect(summarizeFleetBoard(devices)).toEqual({
+      totalDevices: 2,
+      connectedDevices: 2,
+      buildInstalledDevices: 2,
+      runningDevices: 0,
+      readyDevices: 2,
+    });
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/core/src/fleet-board.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/fleet-board.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { computeFleetReadiness, summarizeFleetBoard } from "./fleet-board.js";
+import type { FleetBoardDevice } from "./types.js";
+
+describe("computeFleetReadiness", () => {
+  it("is ready when connected, build installed, and runtime is stopped", () => {
+    const result = computeFleetReadiness({ connected: true, buildInstalled: true, runtimeState: "stopped" });
+    expect(result).toEqual({ ready: true, notes: [] });
+  });
+
+  it("is ready when runtime is not_prepared too", () => {
+    const result = computeFleetReadiness({ connected: true, buildInstalled: true, runtimeState: "not_prepared" });
+    expect(result.ready).toBe(true);
+  });
+
+  it("is not ready and notes an unreachable Pi", () => {
+    const result = computeFleetReadiness({ connected: false, buildInstalled: false, runtimeState: "offline" });
+    expect(result.ready).toBe(false);
+    expect(result.notes).toContain("Pi unreachable");
+    // An unreachable Pi's runtime state can't meaningfully be "not ready to
+    // launch" -- that note is reserved for a connected-but-not-idle Pi.
+    expect(result.notes).not.toContain("Runtime not ready to launch");
+  });
+
+  it("notes a missing build separately from connectivity", () => {
+    const result = computeFleetReadiness({ connected: true, buildInstalled: false, runtimeState: "stopped" });
+    expect(result.ready).toBe(false);
+    expect(result.notes).toEqual(["No installed build"]);
+  });
+
+  it("notes a running/error runtime as not ready to launch, only when connected", () => {
+    const running = computeFleetReadiness({ connected: true, buildInstalled: true, runtimeState: "running" });
+    expect(running.ready).toBe(false);
+    expect(running.notes).toEqual(["Runtime not ready to launch"]);
+
+    const errored = computeFleetReadiness({ connected: true, buildInstalled: true, runtimeState: "error" });
+    expect(errored.ready).toBe(false);
+    expect(errored.notes).toEqual(["Runtime not ready to launch"]);
+  });
+});
+
+describe("summarizeFleetBoard", () => {
+  function device(overrides: Partial<FleetBoardDevice>): FleetBoardDevice {
+    return {
+      hostname: "air-01.local",
+      connected: false,
+      buildInstalled: false,
+      runtimeState: "offline",
+      runtimeRunning: false,
+      ready: false,
+      notes: [],
+      ...overrides,
+    };
+  }
+
+  it("rolls up counts across devices", () => {
+    const devices = [
+      device({ hostname: "a", connected: true, buildInstalled: true, runtimeRunning: true, ready: false }),
+      device({ hostname: "b", connected: true, buildInstalled: true, ready: true }),
+      device({ hostname: "c", connected: false }),
+    ];
+    expect(summarizeFleetBoard(devices)).toEqual({
+      totalDevices: 3,
+      connectedDevices: 2,
+      buildInstalledDevices: 2,
+      runningDevices: 1,
+      readyDevices: 1,
+    });
+  });
+
+  it("handles an empty fleet", () => {
+    expect(summarizeFleetBoard([])).toEqual({
+      totalDevices: 0,
+      connectedDevices: 0,
+      buildInstalledDevices: 0,
+      runningDevices: 0,
+      readyDevices: 0,
+    });
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/core/src/fleet-board.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/fleet-board.ts
@@ -1,0 +1,45 @@
+import type { FleetBoardDevice, FleetBoardSummary, LaunchState } from "./types.js";
+
+export interface FleetReadinessInput {
+  connected: boolean;
+  buildInstalled: boolean;
+  runtimeState: LaunchState;
+}
+
+/**
+ * Mirrors the old dashboard's `FleetReadinessSummary` computation
+ * (`connected && build_installed && runtime in {stopped, not_prepared}`),
+ * minus the old system's `vehicle_assigned` criterion -- that required a
+ * persisted Pi-to-fleet-vehicle assignment the old board itself only ever
+ * populated from ad hoc client-side session state (never persisted
+ * server-side), and cross-referencing fleet YAML vehicle entries isn't
+ * built yet in this rewrite. Scoped out of Phase 5, not silently dropped.
+ */
+export function computeFleetReadiness(input: FleetReadinessInput): { ready: boolean; notes: string[] } {
+  const notes: string[] = [];
+  if (!input.connected) {
+    notes.push("Pi unreachable");
+  }
+  if (!input.buildInstalled) {
+    notes.push("No installed build");
+  }
+  const runtimeReady = input.runtimeState === "stopped" || input.runtimeState === "not_prepared";
+  if (input.connected && !runtimeReady) {
+    notes.push("Runtime not ready to launch");
+  }
+
+  return {
+    ready: input.connected && input.buildInstalled && runtimeReady,
+    notes,
+  };
+}
+
+export function summarizeFleetBoard(devices: FleetBoardDevice[]): FleetBoardSummary {
+  return {
+    totalDevices: devices.length,
+    connectedDevices: devices.filter((device) => device.connected).length,
+    buildInstalledDevices: devices.filter((device) => device.buildInstalled).length,
+    runningDevices: devices.filter((device) => device.runtimeRunning).length,
+    readyDevices: devices.filter((device) => device.ready).length,
+  };
+}

--- a/controls/sae_2025_ws/integration/packages/core/src/fleet-document.kind-override-bug.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/fleet-document.kind-override-bug.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { normalizeIntegrationFleetDocument } from "./fleet-document.js";
+
+/**
+ * Regression test for a surprising silent-data-loss path in
+ * normalizeIntegrationFleetDocument (fleet-document.ts).
+ *
+ * `missionTargetByName[missionName]` used to be checked *before* the
+ * vehicle's own already-explicit `kind`, not just as a fallback for when
+ * `kind` is unset. So if a vehicle already had an explicit `kind: "uav"`
+ * (chosen directly via the "kind" field in FleetEditor.tsx's vehicle.common
+ * section, a real editable field per tools/schema-export/schema_export.py's
+ * section_fields(("name", "mission", "mission_path", "kind"))), and its
+ * `mission` field was set to a mission whose inferred target disagreed, the
+ * mission's inferred target silently won over the user's explicit choice on
+ * the next save/load -- and since normalizeIntegrationFleetDocument also
+ * deletes px4_airframe_id/px4_namespace for any non-"uav" kind,
+ * previously-set hardware fields for that vehicle were silently wiped too,
+ * with no warning surfaced anywhere (FleetEditor.tsx's save() just calls
+ * normalizeIntegrationFleetDocument and writes the result).
+ *
+ * This exact precedence was a faithful 1:1 port of the old dashboard's
+ * App.jsx normalizeIntegrationFleetDocument (see git show
+ * 37c30468^:controls/sae_2025_ws/src/integration/frontend/src/App.jsx around
+ * line 814) -- not a new regression introduced by the port, but a real,
+ * reachable bug worth fixing now that it's been found: an explicit user
+ * choice should win over inference, not the other way around.
+ */
+describe("normalizeIntegrationFleetDocument respects an explicit kind over mission-target inference (regression)", () => {
+  it("keeps a vehicle's explicitly-set kind even when the mission's inferred target disagrees, and does not drop px4 fields", () => {
+    const doc = normalizeIntegrationFleetDocument(
+      {
+        vehicles: [
+          {
+            name: "air-01",
+            kind: "uav", // explicitly chosen by the user via the FleetEditor kind field
+            mission: "corner_pickup", // a mission whose registry target is "payload"
+            px4_airframe_id: 5,
+            px4_namespace: "air01",
+          },
+        ],
+      },
+      { corner_pickup: "payload" },
+    );
+
+    expect(doc.vehicles[0].kind).toBe("uav");
+    expect(doc.vehicles[0]).toHaveProperty("px4_airframe_id", 5);
+    expect(doc.vehicles[0]).toHaveProperty("px4_namespace", "air01");
+  });
+
+  it("still infers kind from the mission when the vehicle has no explicit kind set", () => {
+    const doc = normalizeIntegrationFleetDocument(
+      { vehicles: [{ name: "pay-01", mission: "corner_pickup" }] },
+      { corner_pickup: "payload" },
+    );
+    expect(doc.vehicles[0].kind).toBe("payload");
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/core/src/fleet-document.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/fleet-document.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import {
+  calibrationChoicesFromFleetSchema,
+  coerceFleetFieldValue,
+  deleteObjectPathValue,
+  emptyFleetEditorDocument,
+  getObjectPathValue,
+  hasFleetFieldValue,
+  normalizeFleetEditorDocument,
+  normalizeIntegrationFleetDocument,
+  parseFleetEditorDocument,
+  renderFleetBlockValue,
+  renderFleetEditorDocument,
+  setObjectPathValue,
+  uniqueFleetVehicleName,
+  writeFleetFieldValue,
+} from "./fleet-document.js";
+import type { FleetSchema, SchemaField } from "./types.js";
+
+describe("normalizeFleetEditorDocument / emptyFleetEditorDocument", () => {
+  it("coerces missing backend/defaults/vehicles into their canonical shapes", () => {
+    const doc = normalizeFleetEditorDocument({});
+    expect(doc).toEqual({ backend: {}, defaults: {}, vehicles: [] });
+  });
+
+  it("drops non-object vehicle entries", () => {
+    const doc = normalizeFleetEditorDocument({ vehicles: [{ name: "a" }, "not an object", 42, null] });
+    expect(doc.vehicles).toEqual([{ name: "a" }]);
+  });
+
+  it("emptyFleetEditorDocument defaults backend.kind to hardware", () => {
+    expect(emptyFleetEditorDocument()).toEqual({ backend: { kind: "hardware" }, defaults: {}, vehicles: [] });
+  });
+});
+
+describe("parseFleetEditorDocument / renderFleetEditorDocument", () => {
+  it("parses real fleet YAML via the yaml package", () => {
+    const text = "backend:\n  kind: hardware\ndefaults:\n  camera_calibration_file: cal.yaml\nvehicles:\n  - name: air-01\n    kind: uav\n";
+    const result = parseFleetEditorDocument(text);
+    expect(result.error).toBe("");
+    expect(result.doc?.vehicles).toEqual([{ name: "air-01", kind: "uav" }]);
+  });
+
+  it("returns an empty doc for blank input", () => {
+    const result = parseFleetEditorDocument("");
+    expect(result.error).toBe("");
+    expect(result.doc).toEqual(emptyFleetEditorDocument());
+  });
+
+  it("captures a parse error without throwing", () => {
+    const result = parseFleetEditorDocument("backend: [unterminated");
+    expect(result.doc).toBeNull();
+    expect(result.error).toBeTruthy();
+  });
+
+  it("round-trips parse -> render -> parse", () => {
+    const original = parseFleetEditorDocument(
+      "backend:\n  kind: hardware\nvehicles:\n  - name: air-01\n    kind: uav\n",
+    );
+    const rendered = renderFleetEditorDocument(original.doc);
+    const reparsed = parseFleetEditorDocument(rendered);
+    expect(reparsed.doc).toEqual(original.doc);
+  });
+});
+
+describe("normalizeIntegrationFleetDocument", () => {
+  it("forces backend.kind to hardware and a default px4_path", () => {
+    const doc = normalizeIntegrationFleetDocument({ backend: {} });
+    expect(doc.backend).toEqual({ kind: "hardware", px4_path: "~/PX4-Autopilot" });
+  });
+
+  it("preserves an explicit px4_path", () => {
+    const doc = normalizeIntegrationFleetDocument({ backend: { px4_path: "/custom/path" } });
+    expect(doc.backend.px4_path).toBe("/custom/path");
+  });
+
+  it("strips defaults.auto_launch", () => {
+    const doc = normalizeIntegrationFleetDocument({ defaults: { auto_launch: true, other: 1 } });
+    expect(doc.defaults).toEqual({ other: 1 });
+  });
+
+  it("derives vehicle.mission from mission_path when mission is unset, and drops legacy keys", () => {
+    const doc = normalizeIntegrationFleetDocument({
+      vehicles: [
+        {
+          name: "air-01",
+          mission_path: "/repo/uav/missions/patrol.yaml",
+          controllable: true,
+          px4_instance: 1,
+          payload_controller: "x",
+          auto_launch: true,
+        },
+      ],
+    });
+    expect(doc.vehicles[0]).toEqual({ name: "air-01", mission: "patrol" });
+  });
+
+  it("infers vehicle.kind from missionTargetByName when kind is unset", () => {
+    const doc = normalizeIntegrationFleetDocument(
+      { vehicles: [{ name: "pay-01", mission: "corner_pickup" }] },
+      { corner_pickup: "payload" },
+    );
+    expect(doc.vehicles[0].kind).toBe("payload");
+  });
+
+  it("strips px4_airframe_id/px4_namespace for non-uav vehicles", () => {
+    const doc = normalizeIntegrationFleetDocument({
+      vehicles: [{ name: "pay-01", kind: "payload", px4_airframe_id: 5, px4_namespace: "x" }],
+    });
+    expect(doc.vehicles[0]).not.toHaveProperty("px4_airframe_id");
+    expect(doc.vehicles[0]).not.toHaveProperty("px4_namespace");
+  });
+
+  it("keeps px4_airframe_id/px4_namespace for uav vehicles", () => {
+    const doc = normalizeIntegrationFleetDocument({
+      vehicles: [{ name: "air-01", kind: "uav", px4_airframe_id: 5, px4_namespace: "x" }],
+    });
+    expect(doc.vehicles[0].px4_airframe_id).toBe(5);
+    expect(doc.vehicles[0].px4_namespace).toBe("x");
+  });
+});
+
+describe("getObjectPathValue / setObjectPathValue / deleteObjectPathValue", () => {
+  it("gets a nested value by mixed string/number path", () => {
+    const root = { vehicles: [{ name: "a" }, { name: "b", px4_airframe_id: 3 }] };
+    expect(getObjectPathValue(root, ["vehicles", 1, "px4_airframe_id"])).toBe(3);
+    expect(getObjectPathValue(root, ["vehicles", 5, "px4_airframe_id"])).toBeUndefined();
+  });
+
+  it("sets a value, auto-vivifying intermediate objects/arrays", () => {
+    const root: Record<string, unknown> = {};
+    setObjectPathValue(root, ["vehicles", 0, "name"], "air-01");
+    expect(root).toEqual({ vehicles: [{ name: "air-01" }] });
+  });
+
+  it("deletes a value by path, removing array entries via splice", () => {
+    const root = { vehicles: [{ name: "a" }, { name: "b" }] };
+    deleteObjectPathValue(root, ["vehicles", 0]);
+    expect(root.vehicles).toEqual([{ name: "b" }]);
+  });
+
+  it("deletes an object key", () => {
+    const root = { vehicles: [{ name: "a", kind: "uav" }] };
+    deleteObjectPathValue(root, ["vehicles", 0, "kind"]);
+    expect(root.vehicles[0]).toEqual({ name: "a" });
+  });
+});
+
+describe("hasFleetFieldValue", () => {
+  it("treats false and 0 as present, not absent", () => {
+    expect(hasFleetFieldValue(false)).toBe(true);
+    expect(hasFleetFieldValue(0)).toBe(true);
+  });
+  it("treats empty string/array/object as absent", () => {
+    expect(hasFleetFieldValue("")).toBe(false);
+    expect(hasFleetFieldValue([])).toBe(false);
+    expect(hasFleetFieldValue({})).toBe(false);
+    expect(hasFleetFieldValue(undefined)).toBe(false);
+  });
+  it("treats a non-empty array/object/string as present", () => {
+    expect(hasFleetFieldValue([1])).toBe(true);
+    expect(hasFleetFieldValue({ a: 1 })).toBe(true);
+    expect(hasFleetFieldValue("x")).toBe(true);
+  });
+});
+
+describe("coerceFleetFieldValue / writeFleetFieldValue", () => {
+  const boolField: SchemaField = { name: "controllable", schemaType: "boolean" };
+  const numberField: SchemaField = { name: "px4_instance", schemaType: "integer" };
+  const tupleField: SchemaField = { name: "offset", schemaType: "tuple" };
+  const textField: SchemaField = { name: "mission", schemaType: "string" };
+
+  it("coerces booleans/numbers/tuples/text per schemaFieldInputKind", () => {
+    expect(coerceFleetFieldValue(boolField, "anything")).toBe(true);
+    expect(coerceFleetFieldValue(numberField, "3")).toBe(3);
+    expect(coerceFleetFieldValue(numberField, "")).toBeUndefined();
+    expect(coerceFleetFieldValue(tupleField, [1, 2, 3])).toEqual([1, 2, 3]);
+    expect(coerceFleetFieldValue(tupleField, [1, "x", 3])).toBeUndefined();
+    expect(coerceFleetFieldValue(textField, "patrol")).toBe("patrol");
+    expect(coerceFleetFieldValue(textField, "")).toBeUndefined();
+  });
+
+  it("writeFleetFieldValue deletes the path when the coerced value is empty", () => {
+    const doc = normalizeFleetEditorDocument({ vehicles: [{ name: "a", mission: "patrol" }] });
+    const updated = writeFleetFieldValue(doc, ["vehicles", 0, "mission"], textField, "");
+    expect(updated.vehicles[0]).not.toHaveProperty("mission");
+  });
+
+  it("writeFleetFieldValue sets the path when the coerced value is present, including false/0", () => {
+    const doc = normalizeFleetEditorDocument({ vehicles: [{ name: "a" }] });
+    const updated = writeFleetFieldValue(doc, ["vehicles", 0, "controllable"], boolField, false);
+    expect(updated.vehicles[0].controllable).toBe(false);
+  });
+});
+
+describe("renderFleetBlockValue", () => {
+  it("passes strings through as-is", () => {
+    expect(renderFleetBlockValue("raw text")).toBe("raw text");
+  });
+  it("stringifies non-string values as YAML", () => {
+    expect(renderFleetBlockValue({ a: 1 })).toBe("a: 1");
+  });
+  it("returns '' for null/undefined", () => {
+    expect(renderFleetBlockValue(null)).toBe("");
+    expect(renderFleetBlockValue(undefined)).toBe("");
+  });
+});
+
+describe("uniqueFleetVehicleName", () => {
+  it("returns the base name if unused", () => {
+    const doc = normalizeFleetEditorDocument({ vehicles: [{ name: "air-01" }] });
+    expect(uniqueFleetVehicleName(doc, "air-02")).toBe("air-02");
+  });
+  it("appends an incrementing suffix on collision", () => {
+    const doc = normalizeFleetEditorDocument({ vehicles: [{ name: "vehicle" }] });
+    expect(uniqueFleetVehicleName(doc)).toBe("vehicle_1");
+  });
+});
+
+describe("calibrationChoicesFromFleetSchema", () => {
+  it("pulls camera_calibration_file choices out of the defaults section", () => {
+    const schema: FleetSchema = {
+      sections: [
+        { name: "backend", fields: [] },
+        { name: "defaults", fields: [{ name: "camera_calibration_file", choices: ["a.yaml", "b.yaml"] }] },
+      ],
+    };
+    expect(calibrationChoicesFromFleetSchema(schema)).toEqual(["a.yaml", "b.yaml"]);
+  });
+  it("returns [] when the section/field is missing", () => {
+    expect(calibrationChoicesFromFleetSchema({ sections: [] })).toEqual([]);
+    expect(calibrationChoicesFromFleetSchema(null)).toEqual([]);
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/core/src/fleet-document.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/fleet-document.ts
@@ -1,0 +1,275 @@
+import * as YAML from "yaml";
+import { schemaFieldInputKind } from "./schema-field.js";
+import type {
+  FleetEditorDocument,
+  FleetSchema,
+  ObjectPathSegment,
+  ParsedFleetDocument,
+  SchemaField,
+} from "./types.js";
+
+export function cloneYamlValue<T>(value: T): T {
+  if (value === null || value === undefined) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function normalizeFleetEditorDocument(raw: unknown): FleetEditorDocument {
+  const doc = (raw && typeof raw === "object" && !Array.isArray(raw) ? cloneYamlValue(raw) : {}) as Record<
+    string,
+    unknown
+  >;
+
+  if (!doc.backend || typeof doc.backend !== "object" || Array.isArray(doc.backend)) {
+    doc.backend = {};
+  }
+  if (!doc.defaults || typeof doc.defaults !== "object" || Array.isArray(doc.defaults)) {
+    doc.defaults = {};
+  }
+  if (!Array.isArray(doc.vehicles)) {
+    doc.vehicles = [];
+  }
+  doc.vehicles = (doc.vehicles as unknown[])
+    .filter((vehicle) => vehicle && typeof vehicle === "object" && !Array.isArray(vehicle))
+    .map((vehicle) => ({ ...(vehicle as Record<string, unknown>) }));
+
+  return doc as unknown as FleetEditorDocument;
+}
+
+export function emptyFleetEditorDocument(): FleetEditorDocument {
+  return normalizeFleetEditorDocument({
+    backend: { kind: "hardware" },
+    defaults: {},
+    vehicles: [],
+  });
+}
+
+/**
+ * Unlike mission YAML, fleet YAML uses a real parser (the `yaml` npm
+ * package) -- fleet docs don't need the same comment/formatting-preserving
+ * surgical-edit treatment mission YAML does.
+ */
+export function parseFleetEditorDocument(text: string | undefined | null): ParsedFleetDocument {
+  const rawText = `${text ?? ""}`;
+  if (!rawText.trim()) {
+    return { rawText, doc: emptyFleetEditorDocument(), error: "" };
+  }
+
+  try {
+    const parsed = YAML.parse(rawText) as unknown;
+    return { rawText, doc: normalizeFleetEditorDocument(parsed || {}), error: "" };
+  } catch (error) {
+    return { rawText, doc: null, error: (error as Error)?.message || "Failed to parse fleet YAML." };
+  }
+}
+
+export function renderFleetEditorDocument(doc: unknown): string {
+  return YAML.stringify(normalizeFleetEditorDocument(doc), { lineWidth: 0 }).trimEnd();
+}
+
+export function missionNameFromPathString(path: string | undefined | null): string {
+  const normalized = `${path ?? ""}`.trim().replace(/\\/g, "/");
+  if (!normalized) return "";
+  const basename = normalized.split("/").pop() || "";
+  return basename.replace(/\.ya?ml$/i, "");
+}
+
+/**
+ * Migration/compat normalizer applied on every fleet-doc load and save:
+ * canonicalizes whatever the user pasted/loaded into the current fleet
+ * schema, dropping legacy per-vehicle keys and deriving `mission`/`kind`.
+ * Mirrors the old dashboard's `normalizeIntegrationFleetDocument`.
+ */
+export function normalizeIntegrationFleetDocument(
+  doc: unknown,
+  missionTargetByName: Record<string, string> = {},
+): FleetEditorDocument {
+  const next = normalizeFleetEditorDocument(doc);
+  const backend =
+    next.backend && typeof next.backend === "object" && !Array.isArray(next.backend) ? { ...next.backend } : {};
+  next.backend = {
+    kind: "hardware",
+    px4_path: `${backend.px4_path || "~/PX4-Autopilot"}`.trim() || "~/PX4-Autopilot",
+  };
+
+  const defaults =
+    next.defaults && typeof next.defaults === "object" && !Array.isArray(next.defaults) ? { ...next.defaults } : {};
+  delete defaults.auto_launch;
+  next.defaults = defaults;
+
+  next.vehicles = (next.vehicles || []).map((vehicle) => {
+    const normalizedVehicle: Record<string, unknown> = { ...vehicle };
+    const missionName = `${
+      normalizedVehicle.mission || missionNameFromPathString(normalizedVehicle.mission_path as string) || ""
+    }`.trim();
+    const inferredKind = `${missionTargetByName[missionName] || normalizedVehicle.kind || ""}`.trim();
+
+    delete normalizedVehicle.controllable;
+    delete normalizedVehicle.mission_path;
+    delete normalizedVehicle.px4_instance;
+    delete normalizedVehicle.payload_controller;
+    delete normalizedVehicle.auto_launch;
+
+    if (missionName) {
+      normalizedVehicle.mission = missionName;
+    } else {
+      delete normalizedVehicle.mission;
+    }
+
+    if (inferredKind) {
+      normalizedVehicle.kind = inferredKind;
+    } else {
+      delete normalizedVehicle.kind;
+    }
+
+    if (`${normalizedVehicle.kind || ""}`.trim() !== "uav") {
+      delete normalizedVehicle.px4_airframe_id;
+      delete normalizedVehicle.px4_namespace;
+    }
+
+    return normalizedVehicle;
+  });
+
+  return next;
+}
+
+export function getObjectPathValue(root: unknown, path: ObjectPathSegment[]): unknown {
+  return path.reduce((current: unknown, key) => {
+    if (current === null || current === undefined) return undefined;
+    if (typeof key === "number") {
+      return Array.isArray(current) ? current[key] : undefined;
+    }
+    return typeof current === "object" ? (current as Record<string, unknown>)[key] : undefined;
+  }, root);
+}
+
+export function setObjectPathValue(root: unknown, path: ObjectPathSegment[], value: unknown): void {
+  if (!path.length) return;
+  let current = root as Record<string, unknown> | unknown[];
+  for (let index = 0; index < path.length - 1; index += 1) {
+    const key = path[index];
+    const nextKey = path[index + 1];
+    const nextValue: Record<string, unknown> | unknown[] = typeof nextKey === "number" ? [] : {};
+    if (typeof key === "number") {
+      if (!Array.isArray(current)) return;
+      current[key] = current[key] ?? nextValue;
+      current = current[key] as Record<string, unknown> | unknown[];
+      continue;
+    }
+    const obj = current as Record<string, unknown>;
+    if (!obj[key] || typeof obj[key] !== "object") {
+      obj[key] = nextValue;
+    }
+    current = obj[key] as Record<string, unknown> | unknown[];
+  }
+  const finalKey = path[path.length - 1];
+  if (typeof finalKey === "number") {
+    if (Array.isArray(current)) {
+      current[finalKey] = value;
+    }
+    return;
+  }
+  (current as Record<string, unknown>)[finalKey] = value;
+}
+
+export function deleteObjectPathValue(root: unknown, path: ObjectPathSegment[]): void {
+  if (!path.length) return;
+  let current: unknown = root;
+  for (let index = 0; index < path.length - 1; index += 1) {
+    const key = path[index];
+    if (typeof key === "number") {
+      if (!Array.isArray(current)) return;
+      current = current[key];
+      continue;
+    }
+    if (!current || typeof current !== "object") return;
+    current = (current as Record<string, unknown>)[key];
+  }
+  if (!current || typeof current !== "object") return;
+  const finalKey = path[path.length - 1];
+  if (typeof finalKey === "number") {
+    if (Array.isArray(current)) {
+      current.splice(finalKey, 1);
+    }
+    return;
+  }
+  delete (current as Record<string, unknown>)[finalKey];
+}
+
+/** "Is this value non-empty/non-default" -- explicitly true for `false`/`0`, so those aren't mistaken for absent. */
+export function hasFleetFieldValue(value: unknown): boolean {
+  if (value === false || value === 0) return true;
+  if (Array.isArray(value)) {
+    return value.some((item) => hasFleetFieldValue(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.keys(value).length > 0;
+  }
+  return `${value ?? ""}`.trim() !== "";
+}
+
+export function coerceFleetFieldValue(field: SchemaField, nextValue: unknown): unknown {
+  const kind = schemaFieldInputKind(field);
+  if (kind === "boolean") {
+    return Boolean(nextValue);
+  }
+  if (kind === "number") {
+    const raw = `${nextValue ?? ""}`.trim();
+    if (!raw) return undefined;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  if (kind === "tuple") {
+    const arr = Array.isArray(nextValue) ? nextValue : [];
+    const normalized = arr.map((value) => Number(value));
+    return normalized.every((value) => Number.isFinite(value)) ? normalized : undefined;
+  }
+  if (kind === "block") {
+    return nextValue;
+  }
+  const text = `${nextValue ?? ""}`;
+  return text.trim() ? text : undefined;
+}
+
+export function writeFleetFieldValue(
+  doc: unknown,
+  path: ObjectPathSegment[],
+  field: SchemaField,
+  nextValue: unknown,
+): FleetEditorDocument {
+  const nextDoc = normalizeFleetEditorDocument(doc);
+  const normalized = coerceFleetFieldValue(field, nextValue);
+  if (!hasFleetFieldValue(normalized)) {
+    deleteObjectPathValue(nextDoc, path);
+    return normalizeFleetEditorDocument(nextDoc);
+  }
+  setObjectPathValue(nextDoc, path, normalized);
+  return normalizeFleetEditorDocument(nextDoc);
+}
+
+export function renderFleetBlockValue(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  return YAML.stringify(value, { lineWidth: 0 }).trimEnd();
+}
+
+export function uniqueFleetVehicleName(doc: FleetEditorDocument | undefined | null, baseName = "vehicle"): string {
+  const existing = new Set(
+    (doc?.vehicles || []).map((vehicle) => `${vehicle?.name || ""}`.trim()).filter(Boolean),
+  );
+  if (!existing.has(baseName)) return baseName;
+  let index = 1;
+  while (existing.has(`${baseName}_${index}`)) {
+    index += 1;
+  }
+  return `${baseName}_${index}`;
+}
+
+export function calibrationChoicesFromFleetSchema(schema: FleetSchema | undefined | null): string[] {
+  const defaultsSection = Array.isArray(schema?.sections)
+    ? schema.sections.find((section) => section?.name === "defaults")
+    : null;
+  const calibrationField = Array.isArray(defaultsSection?.fields)
+    ? defaultsSection.fields.find((field) => field?.name === "camera_calibration_file")
+    : null;
+  return Array.isArray(calibrationField?.choices) ? calibrationField.choices.map((choice) => `${choice}`).filter(Boolean) : [];
+}

--- a/controls/sae_2025_ws/integration/packages/core/src/fleet-document.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/fleet-document.ts
@@ -101,7 +101,12 @@ export function normalizeIntegrationFleetDocument(
     const missionName = `${
       normalizedVehicle.mission || missionNameFromPathString(normalizedVehicle.mission_path as string) || ""
     }`.trim();
-    const inferredKind = `${missionTargetByName[missionName] || normalizedVehicle.kind || ""}`.trim();
+    // An already-explicit kind (chosen directly via FleetEditor's "kind"
+    // field) must win over inferring it from the mission -- otherwise
+    // changing/re-saving with a mission whose registry target disagrees
+    // silently overrides the user's own choice and, as a side effect, wipes
+    // px4_airframe_id/px4_namespace below with no warning.
+    const inferredKind = `${normalizedVehicle.kind || missionTargetByName[missionName] || ""}`.trim();
 
     delete normalizedVehicle.controllable;
     delete normalizedVehicle.mission_path;

--- a/controls/sae_2025_ws/integration/packages/core/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export * from "./discovery.js";

--- a/controls/sae_2025_ws/integration/packages/core/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/index.ts
@@ -1,3 +1,7 @@
 export * from "./types.js";
 export * from "./discovery.js";
 export * from "./orchestrator-client.js";
+export * from "./yaml-text.js";
+export * from "./mission-document.js";
+export * from "./schema-field.js";
+export * from "./fleet-document.js";

--- a/controls/sae_2025_ws/integration/packages/core/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/index.ts
@@ -5,3 +5,4 @@ export * from "./yaml-text.js";
 export * from "./mission-document.js";
 export * from "./schema-field.js";
 export * from "./fleet-document.js";
+export * from "./fleet-board.js";

--- a/controls/sae_2025_ws/integration/packages/core/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./types.js";
 export * from "./discovery.js";
+export * from "./orchestrator-client.js";

--- a/controls/sae_2025_ws/integration/packages/core/src/mission-document.duplicate-name-bug.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/mission-document.duplicate-name-bug.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { parseMissionDocument, updateMissionDocumentMode } from "./mission-document.js";
+
+/**
+ * Documents why MissionEditor.tsx's mode rename handler must validate
+ * uniqueness (and reject the reserved "start" name) *before* ever calling
+ * `updateMissionDocumentMode` -- fixed there (`renameSelectedMode`), not
+ * here. `updateMissionDocumentMode`'s `doc.modes.map((mode) => mode.name ===
+ * modeName ? updater(...) : mode)` matches *every* mode with a given name by
+ * design (it's the same mechanism `addMode`/every field edit relies on), so
+ * if the UI ever let two modes collide, this pure function would apply
+ * edits to both at once and `removeMode`'s filter would remove both
+ * simultaneously -- silently corrupting the mode the user can no longer even
+ * see/select. Both assertions below pass: they document the core function's
+ * real (by-design, name-keyed) contract, which is exactly why the guard has
+ * to live in the component, not here.
+ */
+describe("mission mode rename collisions (regression)", () => {
+  it("allows renaming a mode to collide with an existing mode's name (including the reserved 'start')", () => {
+    const doc = parseMissionDocument(
+      "modes:\n  start:\n    mode: uav.vtol.TakeoffMode\n    params: {}\n  cruise:\n    mode: uav.NavGPSMode\n    params: {}\n",
+    );
+    expect(doc.modes.map((m) => m.name)).toEqual(["start", "cruise"]);
+
+    // Simulates the Name-field onChange handler: rename "cruise" -> "start".
+    const renamed = updateMissionDocumentMode(doc, "cruise", (mode) => ({ ...mode, name: "start" }));
+
+    // Bug: nothing prevented this. Two modes now share the reserved name.
+    expect(renamed.modes.map((m) => m.name)).toEqual(["start", "start"]);
+  });
+
+  it("applies a subsequent edit to BOTH colliding modes at once, corrupting the one the UI can no longer address", () => {
+    const doc = parseMissionDocument(
+      "modes:\n  start:\n    mode: uav.vtol.TakeoffMode\n    params: {}\n  cruise:\n    mode: uav.NavGPSMode\n    params: {}\n",
+    );
+    const renamed = updateMissionDocumentMode(doc, "cruise", (mode) => ({ ...mode, name: "start" }));
+
+    // MissionEditor's `selectedMode = doc.modes.find(m => m.name === "start")`
+    // would only ever show the FIRST "start" entry to the user...
+    const visibleToUser = renamed.modes.find((m) => m.name === "start");
+    expect(visibleToUser?.mode).toBe("uav.vtol.TakeoffMode");
+
+    // ...but any further edit keyed by that same name silently mutates BOTH.
+    const edited = updateMissionDocumentMode(renamed, "start", (mode) => ({ ...mode, mode: "uav.LandingMode" }));
+    const stillNamedStart = edited.modes.filter((m) => m.name === "start");
+    expect(stillNamedStart).toHaveLength(2);
+    // Bug: the user thought they edited one mode; they edited two,
+    // including the original real entrypoint mode's target class, silently.
+    expect(stillNamedStart.map((m) => m.mode)).toEqual(["uav.LandingMode", "uav.LandingMode"]);
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/core/src/mission-document.leading-comment-bug.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/mission-document.leading-comment-bug.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { parseMissionDocument, renderMissionDocument, updateMissionDocumentMode } from "./mission-document.js";
+
+/**
+ * Regression test for a real data-loss bug: several real mission YAML files
+ * in the repo have a header comment before the top-level `modes:` key, e.g.
+ * controls/sae_2025_ws/src/payload/missions/payload_apriltag_approach.yaml:
+ *
+ *   # Payload approaches a single AprilTag and terminates cleanly once close enough.
+ *   modes:
+ *     start:
+ *       ...
+ *
+ * (also: uav/missions/test_straight_course.yaml, payload/missions/
+ * payload_corner_navigate_sim.yaml, payload_dlz_navigate_sim.yaml,
+ * payload_dual_approach_sim.yaml.)
+ *
+ * `renderMissionDocument` used to rebuild the document from scratch as
+ * `["modes:", ...doc.modes...]` whenever `doc.modes.length` was truthy,
+ * discarding any content that appeared before the `modes:` line -- header
+ * comments, or any other top-level key -- the moment a single field of a
+ * single mode was edited and the document re-rendered (which is exactly
+ * what `updateMissionDocumentMode`, used by every field edit in
+ * MissionEditor.tsx, does on every call). Fixed by capturing that leading
+ * content as `ParsedMissionDocument.preamble` at parse time and
+ * re-prepending it on render.
+ *
+ * The existing round-trip test in mission-document.test.ts
+ * ("round-trips through render without losing modes/params/transitions")
+ * uses a SAMPLE_MISSION_YAML that itself starts with `start_mode: takeoff\n`
+ * before `modes:`, but only asserts that modes/mode/transitions survive --
+ * it never checked whether that leading line survives, so this regression
+ * went uncaught until now.
+ */
+describe("renderMissionDocument preamble preservation (regression)", () => {
+  it("keeps a header comment that appeared before `modes:` across a single-field edit", () => {
+    const original = "# Payload approaches a single AprilTag and terminates cleanly once close enough.\nmodes:\n  start:\n    mode: payload.PayloadAprilTagApproachMode\n    params:\n      tag_id: 0\n";
+    const doc = parseMissionDocument(original);
+    expect(doc.modes).toHaveLength(1);
+
+    // Editing an unrelated field (mode name stays the same, just re-synced).
+    const updated = updateMissionDocumentMode(doc, "start", (mode) => ({ ...mode }));
+
+    expect(updated.rawText).toContain("# Payload approaches a single AprilTag and terminates cleanly once close enough.");
+  });
+
+  it("keeps a leading top-level key (e.g. start_mode:) the same way", () => {
+    const original = "start_mode: takeoff\nmodes:\n  takeoff:\n    mode: uav.modes.takeoff.Takeoff\n    params: {}\n";
+    const doc = parseMissionDocument(original);
+    const rendered = renderMissionDocument(updateMissionDocumentMode(doc, "takeoff", (mode) => ({ ...mode })));
+    expect(rendered).toContain("start_mode: takeoff");
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/core/src/mission-document.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/mission-document.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import {
+  inferMissionTarget,
+  parseMissionDocument,
+  parseTransitionEntries,
+  publicModeId,
+  renderMissionDocument,
+  uniqueModeName,
+  updateMissionDocumentMode,
+} from "./mission-document.js";
+
+describe("publicModeId", () => {
+  it("strips the uav.modes. prefix", () => {
+    expect(publicModeId("uav.modes.takeoff.Takeoff")).toBe("takeoff.Takeoff");
+  });
+  it("collapses a repeated trailing segment", () => {
+    expect(publicModeId("foo.Bar.Bar")).toBe("foo.Bar");
+  });
+  it("returns '' for non-strings", () => {
+    expect(publicModeId(undefined)).toBe("");
+    expect(publicModeId(42)).toBe("");
+  });
+});
+
+describe("inferMissionTarget", () => {
+  it("infers payload from a payload. prefix or segment", () => {
+    expect(inferMissionTarget("payload.corner_navigate.CornerNavigate")).toBe("payload");
+    expect(inferMissionTarget("some.payload.thing")).toBe("payload");
+  });
+  it("infers uav from a uav. prefix or segment", () => {
+    expect(inferMissionTarget("uav.takeoff.Takeoff")).toBe("uav");
+  });
+  it("returns '' when neither prefix matches", () => {
+    expect(inferMissionTarget("other.Thing")).toBe("");
+  });
+});
+
+describe("parseTransitionEntries", () => {
+  it("parses key: value lines, skipping comments and blanks", () => {
+    const raw = "success: cruise\n# a comment\n\nfailure: terminate\n";
+    expect(parseTransitionEntries(raw)).toEqual([
+      { key: "success", value: "cruise" },
+      { key: "failure", value: "terminate" },
+    ]);
+  });
+});
+
+const SAMPLE_MISSION_YAML = `start_mode: takeoff
+modes:
+  takeoff:
+    mode: uav.modes.takeoff.Takeoff
+    params:
+      target_altitude: 10.0
+    transitions:
+      success: cruise
+      failure: terminate
+
+  cruise:
+    mode: uav.modes.cruise.Cruise
+    params: {}
+    transitions:
+      success: land
+`;
+
+describe("parseMissionDocument / renderMissionDocument", () => {
+  it("parses modes, params, and transitions from real mission YAML", () => {
+    const doc = parseMissionDocument(SAMPLE_MISSION_YAML);
+    expect(doc.warnings).toEqual([]);
+    expect(doc.modes).toHaveLength(2);
+
+    const [takeoff, cruise] = doc.modes;
+    expect(takeoff.name).toBe("takeoff");
+    expect(takeoff.mode).toBe("takeoff.Takeoff");
+    expect(takeoff.paramsRaw).toBe("target_altitude: 10.0");
+    expect(takeoff.transitions).toEqual([
+      { key: "success", value: "cruise" },
+      { key: "failure", value: "terminate" },
+    ]);
+    // publicModeId strips the "uav.modes." prefix before inferMissionTarget
+    // ever sees it, so a mode ref under that exact convention loses its
+    // target-inference signal -- this is the real (faithfully-ported)
+    // behavior, not a gap introduced by the port. Modes that don't use the
+    // "uav.modes." prefix specifically still infer correctly (see below).
+    expect(takeoff.target).toBe("");
+    expect(takeoff.hasParams).toBe(true);
+    expect(takeoff.hasTransitions).toBe(true);
+
+    expect(cruise.name).toBe("cruise");
+    expect(cruise.transitions).toEqual([{ key: "success", value: "land" }]);
+    expect(doc.selectedTarget).toBe("");
+  });
+
+  it("infers a target when the mode ref doesn't use the uav.modes. prefix convention", () => {
+    const doc = parseMissionDocument(`modes:
+  land:
+    mode: uav.land.Land
+    params: {}
+    transitions: {}
+`);
+    expect(doc.modes[0].target).toBe("uav");
+    expect(doc.selectedTarget).toBe("uav");
+  });
+
+  it("warns when there's no top-level modes mapping", () => {
+    const doc = parseMissionDocument("start_mode: takeoff\n");
+    expect(doc.modes).toEqual([]);
+    expect(doc.warnings).toEqual(["Mission YAML does not contain a top-level modes mapping."]);
+  });
+
+  it("warns when modes is present but empty", () => {
+    const doc = parseMissionDocument("modes:\n");
+    expect(doc.warnings).toEqual(["Mission YAML has a modes block but no mode entries."]);
+  });
+
+  it("warns when modes mix targets", () => {
+    const mixed = `modes:
+  a:
+    mode: uav.takeoff.Takeoff
+    params: {}
+    transitions: {}
+  b:
+    mode: payload.corner.Corner
+    params: {}
+    transitions: {}
+`;
+    const doc = parseMissionDocument(mixed);
+    expect(doc.selectedTarget).toBe("");
+    expect(doc.warnings[0]).toMatch(/mix targets/);
+  });
+
+  it("round-trips through render without losing modes/params/transitions", () => {
+    const doc = parseMissionDocument(SAMPLE_MISSION_YAML);
+    const rendered = renderMissionDocument(doc);
+    const reparsed = parseMissionDocument(rendered);
+    expect(reparsed.modes.map((m) => ({ name: m.name, mode: m.mode, transitions: m.transitions }))).toEqual(
+      doc.modes.map((m) => ({ name: m.name, mode: m.mode, transitions: m.transitions })),
+    );
+  });
+
+  it("falls back to rawText when there are no modes to render", () => {
+    const doc = parseMissionDocument("start_mode: takeoff\n");
+    expect(renderMissionDocument(doc)).toBe("start_mode: takeoff\n");
+  });
+});
+
+describe("updateMissionDocumentMode", () => {
+  it("applies an updater to the named mode and resyncs rawText", () => {
+    // mode.mode always holds the already-public-id form (post-publicModeId)
+    // when read from parseMissionDocument -- updaters write that same form,
+    // renderMissionDocument doesn't re-normalize on write.
+    const doc = parseMissionDocument(SAMPLE_MISSION_YAML);
+    const updated = updateMissionDocumentMode(doc, "takeoff", (mode) => ({ ...mode, mode: "takeoff.Takeoff2" }));
+    const takeoff = updated.modes.find((m) => m.name === "takeoff");
+    expect(takeoff?.mode).toBe("takeoff.Takeoff2");
+    expect(updated.rawText).toContain("mode: takeoff.Takeoff2");
+  });
+
+  it("leaves other modes untouched", () => {
+    const doc = parseMissionDocument(SAMPLE_MISSION_YAML);
+    const updated = updateMissionDocumentMode(doc, "takeoff", (mode) => ({ ...mode, mode: "changed" }));
+    const cruise = updated.modes.find((m) => m.name === "cruise");
+    expect(cruise?.mode).toBe("cruise.Cruise");
+  });
+});
+
+describe("uniqueModeName", () => {
+  it("returns the base name if unused", () => {
+    const doc = parseMissionDocument(SAMPLE_MISSION_YAML);
+    expect(uniqueModeName(doc, "land")).toBe("land");
+  });
+  it("appends an incrementing suffix on collision", () => {
+    const doc = parseMissionDocument(SAMPLE_MISSION_YAML);
+    expect(uniqueModeName(doc, "takeoff")).toBe("takeoff_1");
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/core/src/mission-document.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/mission-document.test.ts
@@ -141,6 +141,32 @@ describe("parseMissionDocument / renderMissionDocument", () => {
     const doc = parseMissionDocument("start_mode: takeoff\n");
     expect(renderMissionDocument(doc)).toBe("start_mode: takeoff\n");
   });
+
+  it("does not inject params: {} for a mode that never had a params key, mirroring hasTransitions", () => {
+    const doc = parseMissionDocument(`modes:
+  land:
+    mode: uav.LandingMode
+`);
+    expect(doc.modes[0].hasParams).toBe(false);
+    const rendered = renderMissionDocument(updateMissionDocumentMode(doc, "land", (mode) => ({ ...mode })));
+    expect(rendered).not.toContain("params");
+  });
+
+  it("still emits a params representation for a mode that explicitly had an empty params key", () => {
+    const doc = parseMissionDocument(`modes:
+  land:
+    mode: uav.LandingMode
+    params: {}
+`);
+    expect(doc.modes[0].hasParams).toBe(true);
+    // paramsRaw captures the literal "{}" text, which renders through the
+    // nested-block path (valid, equivalent YAML, just different formatting
+    // from the compact inline form) -- what matters here is hasParams:true
+    // still causes *some* params key to survive, unlike the hasParams:false
+    // case above where none should appear at all.
+    const rendered = renderMissionDocument(updateMissionDocumentMode(doc, "land", (mode) => ({ ...mode })));
+    expect(rendered).toMatch(/params:/);
+  });
 });
 
 describe("updateMissionDocumentMode", () => {

--- a/controls/sae_2025_ws/integration/packages/core/src/mission-document.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/mission-document.ts
@@ -1,0 +1,212 @@
+import { dedentBlock, indentBlock, parseInlineYamlValue, stripYamlComment } from "./yaml-text.js";
+import type { MissionMode, ParsedMissionDocument, TransitionEntry } from "./types.js";
+
+/**
+ * Strips the `uav.modes.` prefix and collapses a repeated trailing segment
+ * (`foo.Bar.Bar` -> `foo.Bar`) -- a convention from the old flat
+ * `mode_registry.json` class-path format. Mode refs stored in mission YAML
+ * still use this shape, so it's still the right normalization for text
+ * already on disk, independent of how the live mode registry now shapes
+ * itself server-side.
+ */
+export function publicModeId(modeRef: unknown): string {
+  if (typeof modeRef !== "string") return "";
+  const trimmed = modeRef.trim();
+  const withoutPrefix = trimmed.startsWith("uav.modes.") ? trimmed.slice("uav.modes.".length) : trimmed;
+  const parts = withoutPrefix.split(".");
+  if (parts.length > 1 && parts.at(-1) === parts.at(-2)) {
+    return parts.slice(0, -1).join(".");
+  }
+  return withoutPrefix;
+}
+
+/**
+ * Best-effort target-kind inference from a mode id's dotted-path prefix.
+ * The live mode registry no longer carries a `mission_target` field (see
+ * ModeMetadata's `target`, which the server derives from `RegisteredMode`'s
+ * vehicle-class list) -- this string-prefix heuristic is a fallback for
+ * mode refs parsed directly out of mission YAML text.
+ */
+export function inferMissionTarget(modeId: unknown): "uav" | "payload" | "" {
+  if (typeof modeId !== "string") return "";
+  if (modeId.startsWith("payload.") || modeId.includes(".payload.")) return "payload";
+  if (modeId.startsWith("uav.") || modeId.includes(".uav.")) return "uav";
+  return "";
+}
+
+export function parseTransitionEntries(rawText: string): TransitionEntry[] {
+  return rawText
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#") && line.includes(":"))
+    .map((line) => {
+      const idx = line.indexOf(":");
+      const key = line.slice(0, idx).trim();
+      const value = stripYamlComment(line.slice(idx + 1));
+      return { key, value };
+    })
+    .filter((entry) => entry.key);
+}
+
+/**
+ * Hand-rolled line-scanner for mission YAML (not a real YAML parser, by
+ * design) -- preserves comments/formatting in `paramsRaw`/`transitionsRaw`
+ * that a real parse-mutate-serialize round trip would lose. Mirrors the old
+ * dashboard's `parseMissionDocument` exactly.
+ */
+export function parseMissionDocument(text: string | undefined | null): ParsedMissionDocument {
+  const rawText = `${text ?? ""}`;
+  const lines = rawText.split("\n");
+  const modesLineIndex = lines.findIndex((line) => /^\s*modes:\s*$/.test(line));
+
+  if (modesLineIndex < 0) {
+    return {
+      rawText,
+      modes: [],
+      selectedTarget: "",
+      warnings: ["Mission YAML does not contain a top-level modes mapping."],
+    };
+  }
+
+  const modeStarts: { name: string; line: number }[] = [];
+  for (let index = modesLineIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    const match = line.match(/^ {2}([^:#\s][^:]*)\s*:\s*$/);
+    if (match) {
+      modeStarts.push({ name: match[1], line: index });
+    }
+  }
+
+  if (modeStarts.length === 0) {
+    return {
+      rawText,
+      modes: [],
+      selectedTarget: "",
+      warnings: ["Mission YAML has a modes block but no mode entries."],
+    };
+  }
+
+  const modes: MissionMode[] = modeStarts.map((modeStart, index) => {
+    const nextLine = modeStarts[index + 1]?.line ?? lines.length;
+    const blockLines = lines.slice(modeStart.line, nextLine);
+
+    let mode = "";
+    let paramsRaw = "";
+    let transitionsRaw = "";
+    let modeLine = -1;
+    let paramsLine = -1;
+    let transitionsLine = -1;
+
+    for (let i = 0; i < blockLines.length; i += 1) {
+      const line = blockLines[i];
+      if (modeLine < 0 && /^\s{4}(?:mode|class):\s*/.test(line)) {
+        modeLine = i;
+        mode = publicModeId(stripYamlComment(parseInlineYamlValue(line)));
+        continue;
+      }
+      if (paramsLine < 0 && /^\s{4}params:\s*/.test(line)) {
+        paramsLine = i;
+        const inline = stripYamlComment(parseInlineYamlValue(line));
+        const section: string[] = [];
+        if (inline) section.push(inline);
+        for (let j = i + 1; j < blockLines.length; j += 1) {
+          const nested = blockLines[j];
+          if (/^\s{4}[A-Za-z0-9_.-]+\s*:\s*/.test(nested)) break;
+          section.push(nested);
+        }
+        paramsRaw = dedentBlock(section.join("\n"), 6);
+        continue;
+      }
+      if (transitionsLine < 0 && /^\s{4}transitions:\s*/.test(line)) {
+        transitionsLine = i;
+        const inline = stripYamlComment(parseInlineYamlValue(line));
+        const section: string[] = [];
+        if (inline) section.push(inline);
+        for (let j = i + 1; j < blockLines.length; j += 1) {
+          const nested = blockLines[j];
+          if (/^\s{4}[A-Za-z0-9_.-]+\s*:\s*/.test(nested)) break;
+          section.push(nested);
+        }
+        transitionsRaw = dedentBlock(section.join("\n"), 6);
+      }
+    }
+
+    const transitions = parseTransitionEntries(transitionsRaw);
+    const target = inferMissionTarget(mode);
+
+    return {
+      name: modeStart.name,
+      mode,
+      paramsRaw,
+      transitionsRaw,
+      transitions,
+      target,
+      hasParams: paramsLine >= 0,
+      hasTransitions: transitionsLine >= 0,
+    };
+  });
+
+  const inferredTargets = [...new Set(modes.map((mode) => mode.target).filter(Boolean))];
+
+  return {
+    rawText,
+    modes,
+    selectedTarget: inferredTargets.length === 1 ? inferredTargets[0] : "",
+    warnings: inferredTargets.length > 1 ? [`Mission modes mix targets: ${inferredTargets.join(", ")}`] : [],
+  };
+}
+
+export function renderMissionDocument(doc: ParsedMissionDocument | undefined | null): string {
+  if (!doc?.modes?.length) return doc?.rawText || "";
+
+  const lines: string[] = ["modes:"];
+  doc.modes.forEach((mode, index) => {
+    lines.push(`  ${mode.name}:`);
+    lines.push(`    mode: ${mode.mode || ""}`);
+
+    if (mode.paramsRaw && `${mode.paramsRaw}`.trim()) {
+      lines.push("    params:");
+      lines.push(...indentBlock(mode.paramsRaw.trimEnd(), 6).split("\n"));
+    } else {
+      lines.push("    params: {}");
+    }
+
+    if (mode.transitions?.length) {
+      lines.push("    transitions:");
+      mode.transitions.forEach((entry) => {
+        lines.push(`      ${entry.key}: ${entry.value}`);
+      });
+    } else if (mode.hasTransitions) {
+      lines.push("    transitions: {}");
+    }
+
+    if (index < doc.modes.length - 1) {
+      lines.push("");
+    }
+  });
+
+  return lines.join("\n");
+}
+
+export function updateMissionDocumentMode(
+  doc: ParsedMissionDocument,
+  modeName: string,
+  updater: (mode: MissionMode) => MissionMode,
+): ParsedMissionDocument {
+  const next: ParsedMissionDocument = {
+    ...doc,
+    modes: doc.modes.map((mode) => (mode.name === modeName ? updater({ ...mode }) : mode)),
+  };
+  next.rawText = renderMissionDocument(next);
+  return next;
+}
+
+export function uniqueModeName(doc: ParsedMissionDocument, baseName = "mode"): string {
+  const names = new Set(doc.modes.map((mode) => mode.name));
+  if (!names.has(baseName)) return baseName;
+  let index = 1;
+  while (names.has(`${baseName}_${index}`)) {
+    index += 1;
+  }
+  return `${baseName}_${index}`;
+}

--- a/controls/sae_2025_ws/integration/packages/core/src/mission-document.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/mission-document.ts
@@ -1,6 +1,9 @@
 import { dedentBlock, indentBlock, parseInlineYamlValue, stripYamlComment } from "./yaml-text.js";
 import type { MissionMode, ParsedMissionDocument, TransitionEntry } from "./types.js";
 
+// Depth of a mode's params/transitions content: 2 (mode name) + 4 (field key) spaces.
+const MODE_FIELD_CONTENT_INDENT = 6;
+
 /**
  * Strips the `uav.modes.` prefix and collapses a repeated trailing segment
  * (`foo.Bar.Bar` -> `foo.Bar`) -- a convention from the old flat
@@ -123,7 +126,7 @@ export function parseMissionDocument(text: string | undefined | null): ParsedMis
           if (/^\s{4}[A-Za-z0-9_.-]+\s*:\s*/.test(nested)) break;
           section.push(nested);
         }
-        paramsRaw = dedentBlock(section.join("\n"), 6);
+        paramsRaw = dedentBlock(section.join("\n"), MODE_FIELD_CONTENT_INDENT);
         continue;
       }
       if (transitionsLine < 0 && /^\s{4}transitions:\s*/.test(line)) {
@@ -136,7 +139,7 @@ export function parseMissionDocument(text: string | undefined | null): ParsedMis
           if (/^\s{4}[A-Za-z0-9_.-]+\s*:\s*/.test(nested)) break;
           section.push(nested);
         }
-        transitionsRaw = dedentBlock(section.join("\n"), 6);
+        transitionsRaw = dedentBlock(section.join("\n"), MODE_FIELD_CONTENT_INDENT);
       }
     }
 
@@ -180,7 +183,7 @@ export function renderMissionDocument(doc: ParsedMissionDocument | undefined | n
 
     if (mode.paramsRaw && `${mode.paramsRaw}`.trim()) {
       lines.push("    params:");
-      lines.push(...indentBlock(mode.paramsRaw.trimEnd(), 6).split("\n"));
+      lines.push(...indentBlock(mode.paramsRaw.trimEnd(), MODE_FIELD_CONTENT_INDENT).split("\n"));
     } else if (mode.hasParams) {
       lines.push("    params: {}");
     }

--- a/controls/sae_2025_ws/integration/packages/core/src/mission-document.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/mission-document.ts
@@ -62,11 +62,19 @@ export function parseMissionDocument(text: string | undefined | null): ParsedMis
   if (modesLineIndex < 0) {
     return {
       rawText,
+      preamble: "",
       modes: [],
       selectedTarget: "",
       warnings: ["Mission YAML does not contain a top-level modes mapping."],
     };
   }
+
+  // Anything before the `modes:` key (header comments, other top-level
+  // keys) -- rendered with zero modes falls back to rawText untouched, but
+  // once modes exist, render rebuilds the document from `doc.modes` alone,
+  // so this has to be captured now and re-prepended on render or it's lost
+  // the moment a single field is edited.
+  const preamble = lines.slice(0, modesLineIndex).join("\n");
 
   const modeStarts: { name: string; line: number }[] = [];
   for (let index = modesLineIndex + 1; index < lines.length; index += 1) {
@@ -80,6 +88,7 @@ export function parseMissionDocument(text: string | undefined | null): ParsedMis
   if (modeStarts.length === 0) {
     return {
       rawText,
+      preamble,
       modes: [],
       selectedTarget: "",
       warnings: ["Mission YAML has a modes block but no mode entries."],
@@ -150,6 +159,7 @@ export function parseMissionDocument(text: string | undefined | null): ParsedMis
 
   return {
     rawText,
+    preamble,
     modes,
     selectedTarget: inferredTargets.length === 1 ? inferredTargets[0] : "",
     warnings: inferredTargets.length > 1 ? [`Mission modes mix targets: ${inferredTargets.join(", ")}`] : [],
@@ -159,7 +169,11 @@ export function parseMissionDocument(text: string | undefined | null): ParsedMis
 export function renderMissionDocument(doc: ParsedMissionDocument | undefined | null): string {
   if (!doc?.modes?.length) return doc?.rawText || "";
 
-  const lines: string[] = ["modes:"];
+  const lines: string[] = [];
+  if (doc.preamble && doc.preamble.trim()) {
+    lines.push(doc.preamble, "");
+  }
+  lines.push("modes:");
   doc.modes.forEach((mode, index) => {
     lines.push(`  ${mode.name}:`);
     lines.push(`    mode: ${mode.mode || ""}`);
@@ -167,7 +181,7 @@ export function renderMissionDocument(doc: ParsedMissionDocument | undefined | n
     if (mode.paramsRaw && `${mode.paramsRaw}`.trim()) {
       lines.push("    params:");
       lines.push(...indentBlock(mode.paramsRaw.trimEnd(), 6).split("\n"));
-    } else {
+    } else if (mode.hasParams) {
       lines.push("    params: {}");
     }
 

--- a/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { OrchestratorClient } from "./orchestrator-client.js";
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as Response;
+}
+
+describe("OrchestratorClient", () => {
+  it("discoverPis returns the list of Pis the orchestrator reports", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ pis: [{ hostname: "air-01.local" }] }));
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(await client.discoverPis()).toEqual([{ hostname: "air-01.local" }]);
+  });
+
+  it("discoverPis returns an empty list if the orchestrator is unreachable", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network error");
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(await client.discoverPis()).toEqual([]);
+  });
+
+  it("wifiStatus passes the hostname through as a query param", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      expect(url.toString()).toBe("http://localhost:8080/api/wifi/status?hostname=air-01.local");
+      return jsonResponse({ success: true, connections: [] });
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    const status = await client.wifiStatus("air-01.local");
+    expect(status.success).toBe(true);
+  });
+
+  it("wifiConnect posts hostname/ssid/password as JSON", async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      expect(init?.method).toBe("POST");
+      expect(JSON.parse(init?.body as string)).toEqual({
+        hostname: "air-01.local",
+        ssid: "pennair_5G",
+        password: "hunter2",
+      });
+      return jsonResponse({ success: true, output: "Pi connected to pennair_5G" });
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    const result = await client.wifiConnect("air-01.local", "pennair_5G", "hunter2");
+    expect(result).toEqual({ success: true, output: "Pi connected to pennair_5G" });
+  });
+
+  it("strips a trailing slash from baseUrl", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      expect(url.toString()).toBe("http://localhost:8080/api/discovery");
+      return jsonResponse({ pis: [] });
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080/", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    await client.discoverPis();
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.test.ts
@@ -186,4 +186,19 @@ describe("OrchestratorClient", () => {
     expect(result.success).toBe(false);
     expect(result.devices).toEqual([]);
   });
+
+  it("passes an abort signal on every request, so a wedged orchestrator can't hang a call forever", async () => {
+    // Regression test: getJson/postJson used to issue fetch with no signal
+    // at all -- a wedged orchestrator (TCP accepted, response never sent)
+    // would hang every OrchestratorClient method forever, since fetch has no
+    // default overall-request timeout once connected.
+    const fetchImpl = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return jsonResponse({ pis: [] });
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    await client.discoverPis();
+    expect(fetchImpl).toHaveBeenCalled();
+  });
 });

--- a/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.test.ts
@@ -160,4 +160,30 @@ describe("OrchestratorClient", () => {
 
     expect(await client.writeFleetFile("air-01.local", "example_fleet", "vehicles: []")).toEqual({ success: true });
   });
+
+  it("fleetBoard fetches the board summary", async () => {
+    const board = {
+      success: true,
+      devices: [{ hostname: "air-01.local", connected: true, buildInstalled: true, runtimeState: "stopped", runtimeRunning: false, ready: true, notes: [] }],
+      summary: { totalDevices: 1, connectedDevices: 1, buildInstalledDevices: 1, runningDevices: 0, readyDevices: 1 },
+    };
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      expect(url.toString()).toBe("http://localhost:8080/api/fleet/board");
+      return jsonResponse(board);
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(await client.fleetBoard()).toEqual(board);
+  });
+
+  it("fleetBoard returns an empty board if the orchestrator is unreachable", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network error");
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    const result = await client.fleetBoard();
+    expect(result.success).toBe(false);
+    expect(result.devices).toEqual([]);
+  });
 });

--- a/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.test.ts
@@ -58,4 +58,39 @@ describe("OrchestratorClient", () => {
 
     await client.discoverPis();
   });
+
+  it("startMission posts vehicleName as JSON", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      expect(url.toString()).toBe("http://localhost:8080/api/mission/start");
+      expect(JSON.parse(init?.body as string)).toEqual({ vehicleName: "air-01" });
+      return jsonResponse({ success: true, output: "Mission runtime running" });
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(await client.startMission("air-01")).toEqual({ success: true, output: "Mission runtime running" });
+  });
+
+  it("triggerFailsafe posts vehicleName as JSON", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      expect(url.toString()).toBe("http://localhost:8080/api/mission/failsafe");
+      return jsonResponse({ success: true, output: "failsafe triggered" });
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(await client.triggerFailsafe("air-01")).toEqual({ success: true, output: "failsafe triggered" });
+  });
+
+  it("missionLogsUrl converts http(s) to ws(s) and passes hostname as a query param", () => {
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080" });
+    expect(client.missionLogsUrl("air-01.local")).toBe(
+      "ws://localhost:8080/ws/mission/logs?hostname=air-01.local",
+    );
+  });
+
+  it("missionLogsUrl handles an https baseUrl", () => {
+    const client = new OrchestratorClient({ baseUrl: "https://ops.example.com" });
+    expect(client.missionLogsUrl("air-01.local")).toBe(
+      "wss://ops.example.com/ws/mission/logs?hostname=air-01.local",
+    );
+  });
 });

--- a/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.test.ts
@@ -93,4 +93,71 @@ describe("OrchestratorClient", () => {
       "wss://ops.example.com/ws/mission/logs?hostname=air-01.local",
     );
   });
+
+  it("schema passes the hostname through as a query param", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      expect(url.toString()).toBe("http://localhost:8080/api/schema?hostname=air-01.local");
+      return jsonResponse({ success: true, schema: { modes: {}, fleet: { sections: [] }, missions: [], availableFleets: [] } });
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    const result = await client.schema("air-01.local");
+    expect(result.success).toBe(true);
+  });
+
+  it("missionNames passes the hostname through as a query param", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      expect(url.toString()).toBe("http://localhost:8080/api/mission/mission-names?hostname=air-01.local");
+      return jsonResponse({ success: true, missions: ["patrol"] });
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(await client.missionNames("air-01.local")).toEqual({ success: true, missions: ["patrol"] });
+  });
+
+  it("readMissionFile passes hostname and name through as query params", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      expect(url.toString()).toBe("http://localhost:8080/api/mission/mission-file?hostname=air-01.local&name=patrol");
+      return jsonResponse({ success: true, content: "modes: {}" });
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(await client.readMissionFile("air-01.local", "patrol")).toEqual({ success: true, content: "modes: {}" });
+  });
+
+  it("writeMissionFile posts hostname/name/content as JSON", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      expect(url.toString()).toBe("http://localhost:8080/api/mission/mission-file");
+      expect(JSON.parse(init?.body as string)).toEqual({ hostname: "air-01.local", name: "patrol", content: "modes: {}" });
+      return jsonResponse({ success: true });
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(await client.writeMissionFile("air-01.local", "patrol", "modes: {}")).toEqual({ success: true });
+  });
+
+  it("readFleetFile passes hostname and name through as query params", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      expect(url.toString()).toBe("http://localhost:8080/api/fleet/fleet-file?hostname=air-01.local&name=example_fleet");
+      return jsonResponse({ success: true, content: "vehicles: []" });
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(await client.readFleetFile("air-01.local", "example_fleet")).toEqual({ success: true, content: "vehicles: []" });
+  });
+
+  it("writeFleetFile posts hostname/name/content as JSON", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      expect(url.toString()).toBe("http://localhost:8080/api/fleet/fleet-file");
+      expect(JSON.parse(init?.body as string)).toEqual({
+        hostname: "air-01.local",
+        name: "example_fleet",
+        content: "vehicles: []",
+      });
+      return jsonResponse({ success: true });
+    });
+    const client = new OrchestratorClient({ baseUrl: "http://localhost:8080", fetchImpl: fetchImpl as unknown as typeof fetch });
+
+    expect(await client.writeFleetFile("air-01.local", "example_fleet", "vehicles: []")).toEqual({ success: true });
+  });
 });

--- a/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.ts
@@ -1,0 +1,91 @@
+import type { WifiScanResult, WifiStatus } from "./types.js";
+
+export interface OrchestratorClientOptions {
+  /** e.g. "http://localhost:8080" -- the one thing web/mobile clients talk to. */
+  baseUrl: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface DiscoveredPiSummary {
+  hostname: string;
+}
+
+interface SimpleResult {
+  success: boolean;
+  output?: string;
+  error?: string;
+}
+
+/**
+ * The only client web/mobile need -- talks to the orchestrator, never to a
+ * Pi's pi-agent directly. The orchestrator does its own discovery and relays
+ * device-ops calls to whichever Pi is named.
+ */
+export class OrchestratorClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: OrchestratorClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, "");
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async discoverPis(): Promise<DiscoveredPiSummary[]> {
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}/api/discovery`);
+      if (!response.ok) return [];
+      const body = (await response.json()) as { pis: DiscoveredPiSummary[] };
+      return body.pis;
+    } catch {
+      return [];
+    }
+  }
+
+  async wifiStatus(hostname: string): Promise<WifiStatus> {
+    return this.getJson<WifiStatus>(
+      `/api/wifi/status?hostname=${encodeURIComponent(hostname)}`,
+      { success: false, connections: [], error: "orchestrator unreachable" },
+    );
+  }
+
+  async wifiScan(hostname: string): Promise<WifiScanResult> {
+    return this.getJson<WifiScanResult>(
+      `/api/wifi/scan?hostname=${encodeURIComponent(hostname)}`,
+      { success: false, networks: [], error: "orchestrator unreachable" },
+    );
+  }
+
+  async wifiConnect(hostname: string, ssid: string, password: string): Promise<SimpleResult> {
+    return this.postJson<SimpleResult>("/api/wifi/connect", { hostname, ssid, password });
+  }
+
+  async wifiHotspot(hostname: string): Promise<SimpleResult> {
+    return this.postJson<SimpleResult>("/api/wifi/hotspot", { hostname });
+  }
+
+  private async getJson<T>(path: string, onUnreachable: T): Promise<T> {
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`);
+      if (!response.ok) return onUnreachable;
+      return (await response.json()) as T;
+    } catch {
+      return onUnreachable;
+    }
+  }
+
+  private async postJson<T extends { success: boolean; error?: string }>(
+    path: string,
+    body: unknown,
+  ): Promise<T> {
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      return (await response.json()) as T;
+    } catch {
+      return { success: false, error: "orchestrator unreachable" } as T;
+    }
+  }
+}

--- a/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.ts
@@ -1,4 +1,4 @@
-import type { WifiScanResult, WifiStatus } from "./types.js";
+import type { LaunchStatus, WifiScanResult, WifiStatus } from "./types.js";
 
 export interface OrchestratorClientOptions {
   /** e.g. "http://localhost:8080" -- the one thing web/mobile clients talk to. */
@@ -61,6 +61,35 @@ export class OrchestratorClient {
 
   async wifiHotspot(hostname: string): Promise<SimpleResult> {
     return this.postJson<SimpleResult>("/api/wifi/hotspot", { hostname });
+  }
+
+  async missionStatus(hostname: string): Promise<LaunchStatus> {
+    return this.getJson<LaunchStatus>(
+      `/api/mission/status?hostname=${encodeURIComponent(hostname)}`,
+      { success: false, running: false, state: "offline", error: "orchestrator unreachable" },
+    );
+  }
+
+  async prepareMission(hostname: string): Promise<SimpleResult> {
+    return this.postJson<SimpleResult>("/api/mission/prepare", { hostname });
+  }
+
+  async stopMission(hostname: string): Promise<SimpleResult> {
+    return this.postJson<SimpleResult>("/api/mission/stop", { hostname });
+  }
+
+  async startMission(vehicleName: string): Promise<SimpleResult> {
+    return this.postJson<SimpleResult>("/api/mission/start", { vehicleName });
+  }
+
+  async triggerFailsafe(vehicleName: string): Promise<SimpleResult> {
+    return this.postJson<SimpleResult>("/api/mission/failsafe", { vehicleName });
+  }
+
+  /** WebSocket URL for streaming mission logs for the given Pi -- connect with a plain WebSocket. */
+  missionLogsUrl(hostname: string): string {
+    const wsBase = this.baseUrl.replace(/^http/, "ws");
+    return `${wsBase}/ws/mission/logs?hostname=${encodeURIComponent(hostname)}`;
   }
 
   private async getJson<T>(path: string, onUnreachable: T): Promise<T> {

--- a/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.ts
@@ -1,4 +1,11 @@
-import type { LaunchStatus, WifiScanResult, WifiStatus } from "./types.js";
+import type {
+  FileResult,
+  LaunchStatus,
+  MissionNamesResult,
+  SchemaExportResult,
+  WifiScanResult,
+  WifiStatus,
+} from "./types.js";
 
 export interface OrchestratorClientOptions {
   /** e.g. "http://localhost:8080" -- the one thing web/mobile clients talk to. */
@@ -90,6 +97,42 @@ export class OrchestratorClient {
   missionLogsUrl(hostname: string): string {
     const wsBase = this.baseUrl.replace(/^http/, "ws");
     return `${wsBase}/ws/mission/logs?hostname=${encodeURIComponent(hostname)}`;
+  }
+
+  async schema(hostname: string): Promise<SchemaExportResult> {
+    return this.getJson<SchemaExportResult>(
+      `/api/schema?hostname=${encodeURIComponent(hostname)}`,
+      { success: false, error: "orchestrator unreachable" },
+    );
+  }
+
+  async missionNames(hostname: string): Promise<MissionNamesResult> {
+    return this.getJson<MissionNamesResult>(
+      `/api/mission/mission-names?hostname=${encodeURIComponent(hostname)}`,
+      { success: false, missions: [], error: "orchestrator unreachable" },
+    );
+  }
+
+  async readMissionFile(hostname: string, name: string): Promise<FileResult> {
+    return this.getJson<FileResult>(
+      `/api/mission/mission-file?hostname=${encodeURIComponent(hostname)}&name=${encodeURIComponent(name)}`,
+      { success: false, error: "orchestrator unreachable" },
+    );
+  }
+
+  async writeMissionFile(hostname: string, name: string, content: string): Promise<FileResult> {
+    return this.postJson<FileResult>("/api/mission/mission-file", { hostname, name, content });
+  }
+
+  async readFleetFile(hostname: string, name: string): Promise<FileResult> {
+    return this.getJson<FileResult>(
+      `/api/fleet/fleet-file?hostname=${encodeURIComponent(hostname)}&name=${encodeURIComponent(name)}`,
+      { success: false, error: "orchestrator unreachable" },
+    );
+  }
+
+  async writeFleetFile(hostname: string, name: string, content: string): Promise<FileResult> {
+    return this.postJson<FileResult>("/api/fleet/fleet-file", { hostname, name, content });
   }
 
   private async getJson<T>(path: string, onUnreachable: T): Promise<T> {

--- a/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.ts
@@ -34,6 +34,8 @@ interface SimpleResult {
 // no default overall-request timeout once connected, only a connect-timeout.
 const DEFAULT_TIMEOUT_MS = 90_000;
 
+const ORCHESTRATOR_UNREACHABLE_ERROR = "orchestrator unreachable";
+
 /**
  * The only client web/mobile need -- talks to the orchestrator, never to a
  * Pi's pi-agent directly. The orchestrator does its own discovery and relays
@@ -64,14 +66,14 @@ export class OrchestratorClient {
   async wifiStatus(hostname: string): Promise<WifiStatus> {
     return this.getJson<WifiStatus>(
       `/api/wifi/status?hostname=${encodeURIComponent(hostname)}`,
-      { success: false, connections: [], error: "orchestrator unreachable" },
+      { success: false, connections: [], error: ORCHESTRATOR_UNREACHABLE_ERROR },
     );
   }
 
   async wifiScan(hostname: string): Promise<WifiScanResult> {
     return this.getJson<WifiScanResult>(
       `/api/wifi/scan?hostname=${encodeURIComponent(hostname)}`,
-      { success: false, networks: [], error: "orchestrator unreachable" },
+      { success: false, networks: [], error: ORCHESTRATOR_UNREACHABLE_ERROR },
     );
   }
 
@@ -86,7 +88,7 @@ export class OrchestratorClient {
   async missionStatus(hostname: string): Promise<LaunchStatus> {
     return this.getJson<LaunchStatus>(
       `/api/mission/status?hostname=${encodeURIComponent(hostname)}`,
-      { success: false, running: false, state: "offline", error: "orchestrator unreachable" },
+      { success: false, running: false, state: "offline", error: ORCHESTRATOR_UNREACHABLE_ERROR },
     );
   }
 
@@ -115,21 +117,21 @@ export class OrchestratorClient {
   async schema(hostname: string): Promise<SchemaExportResult> {
     return this.getJson<SchemaExportResult>(
       `/api/schema?hostname=${encodeURIComponent(hostname)}`,
-      { success: false, error: "orchestrator unreachable" },
+      { success: false, error: ORCHESTRATOR_UNREACHABLE_ERROR },
     );
   }
 
   async missionNames(hostname: string): Promise<MissionNamesResult> {
     return this.getJson<MissionNamesResult>(
       `/api/mission/mission-names?hostname=${encodeURIComponent(hostname)}`,
-      { success: false, missions: [], error: "orchestrator unreachable" },
+      { success: false, missions: [], error: ORCHESTRATOR_UNREACHABLE_ERROR },
     );
   }
 
   async readMissionFile(hostname: string, name: string): Promise<FileResult> {
     return this.getJson<FileResult>(
       `/api/mission/mission-file?hostname=${encodeURIComponent(hostname)}&name=${encodeURIComponent(name)}`,
-      { success: false, error: "orchestrator unreachable" },
+      { success: false, error: ORCHESTRATOR_UNREACHABLE_ERROR },
     );
   }
 
@@ -140,7 +142,7 @@ export class OrchestratorClient {
   async readFleetFile(hostname: string, name: string): Promise<FileResult> {
     return this.getJson<FileResult>(
       `/api/fleet/fleet-file?hostname=${encodeURIComponent(hostname)}&name=${encodeURIComponent(name)}`,
-      { success: false, error: "orchestrator unreachable" },
+      { success: false, error: ORCHESTRATOR_UNREACHABLE_ERROR },
     );
   }
 
@@ -153,7 +155,7 @@ export class OrchestratorClient {
       success: false,
       devices: [],
       summary: { totalDevices: 0, connectedDevices: 0, buildInstalledDevices: 0, runningDevices: 0, readyDevices: 0 },
-      error: "orchestrator unreachable",
+      error: ORCHESTRATOR_UNREACHABLE_ERROR,
     });
   }
 
@@ -183,7 +185,7 @@ export class OrchestratorClient {
       });
       return (await response.json()) as T;
     } catch {
-      return { success: false, error: "orchestrator unreachable" } as T;
+      return { success: false, error: ORCHESTRATOR_UNREACHABLE_ERROR } as T;
     }
   }
 }

--- a/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.ts
@@ -24,6 +24,16 @@ interface SimpleResult {
   error?: string;
 }
 
+// Sized to exceed the orchestrator's own largest per-operation relay timeout
+// to pi-agent (wifi connect, 80s -- see pi-agent-client.ts's
+// WIFI_CONNECT_TIMEOUT_MS) plus margin, so the orchestrator's own timeout
+// fires first and returns a graceful {success:false,...} JSON body rather
+// than this client severing the connection first. Without an explicit
+// timeout here, a wedged orchestrator (accepts the TCP connection but never
+// responds) would hang every OrchestratorClient method forever -- fetch has
+// no default overall-request timeout once connected, only a connect-timeout.
+const DEFAULT_TIMEOUT_MS = 90_000;
+
 /**
  * The only client web/mobile need -- talks to the orchestrator, never to a
  * Pi's pi-agent directly. The orchestrator does its own discovery and relays
@@ -40,7 +50,9 @@ export class OrchestratorClient {
 
   async discoverPis(): Promise<DiscoveredPiSummary[]> {
     try {
-      const response = await this.fetchImpl(`${this.baseUrl}/api/discovery`);
+      const response = await this.fetchImpl(`${this.baseUrl}/api/discovery`, {
+        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+      });
       if (!response.ok) return [];
       const body = (await response.json()) as { pis: DiscoveredPiSummary[] };
       return body.pis;
@@ -145,9 +157,11 @@ export class OrchestratorClient {
     });
   }
 
-  private async getJson<T>(path: string, onUnreachable: T): Promise<T> {
+  private async getJson<T>(path: string, onUnreachable: T, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<T> {
     try {
-      const response = await this.fetchImpl(`${this.baseUrl}${path}`);
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        signal: AbortSignal.timeout(timeoutMs),
+      });
       if (!response.ok) return onUnreachable;
       return (await response.json()) as T;
     } catch {
@@ -158,12 +172,14 @@ export class OrchestratorClient {
   private async postJson<T extends { success: boolean; error?: string }>(
     path: string,
     body: unknown,
+    timeoutMs: number = DEFAULT_TIMEOUT_MS,
   ): Promise<T> {
     try {
       const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
+        signal: AbortSignal.timeout(timeoutMs),
       });
       return (await response.json()) as T;
     } catch {

--- a/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/orchestrator-client.ts
@@ -1,5 +1,6 @@
 import type {
   FileResult,
+  FleetBoardResult,
   LaunchStatus,
   MissionNamesResult,
   SchemaExportResult,
@@ -133,6 +134,15 @@ export class OrchestratorClient {
 
   async writeFleetFile(hostname: string, name: string, content: string): Promise<FileResult> {
     return this.postJson<FileResult>("/api/fleet/fleet-file", { hostname, name, content });
+  }
+
+  async fleetBoard(): Promise<FleetBoardResult> {
+    return this.getJson<FleetBoardResult>("/api/fleet/board", {
+      success: false,
+      devices: [],
+      summary: { totalDevices: 0, connectedDevices: 0, buildInstalledDevices: 0, runningDevices: 0, readyDevices: 0 },
+      error: "orchestrator unreachable",
+    });
   }
 
   private async getJson<T>(path: string, onUnreachable: T): Promise<T> {

--- a/controls/sae_2025_ws/integration/packages/core/src/schema-field.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/schema-field.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultParamsRawForMode,
+  effectiveSchemaFieldValue,
+  fieldHelpText,
+  normalizeModeRegistry,
+  schemaFieldInputKind,
+  writeSchemaFieldValue,
+} from "./schema-field.js";
+import type { ModeMetadata, SchemaField } from "./types.js";
+
+describe("schemaFieldInputKind", () => {
+  it("returns select when choices are present, regardless of schemaType", () => {
+    expect(schemaFieldInputKind({ name: "x", choices: ["a", "b"], schemaType: "string" })).toBe("select");
+  });
+  it("maps boolean/bool to boolean", () => {
+    expect(schemaFieldInputKind({ name: "x", schemaType: "boolean" })).toBe("boolean");
+    expect(schemaFieldInputKind({ name: "x", schemaType: "bool" })).toBe("boolean");
+  });
+  it("maps integer/number/int/float to number", () => {
+    for (const t of ["integer", "number", "int", "float"] as const) {
+      expect(schemaFieldInputKind({ name: "x", schemaType: t })).toBe("number");
+    }
+  });
+  it("maps tuple to tuple", () => {
+    expect(schemaFieldInputKind({ name: "x", schemaType: "tuple" })).toBe("tuple");
+  });
+  it("maps array/object/union/list/dict to block", () => {
+    for (const t of ["array", "object", "union", "list", "dict"] as const) {
+      expect(schemaFieldInputKind({ name: "x", schemaType: t })).toBe("block");
+    }
+  });
+  it("defaults to text, and handles a missing field", () => {
+    expect(schemaFieldInputKind({ name: "x" })).toBe("text");
+    expect(schemaFieldInputKind(null)).toBe("text");
+  });
+});
+
+describe("fieldHelpText", () => {
+  it("prefers description when present", () => {
+    expect(fieldHelpText({ name: "x", description: "the real help text" })).toBe("the real help text");
+  });
+  it("falls back to annotation unless it's a low-signal bare type name", () => {
+    expect(fieldHelpText({ name: "x", annotation: "the vehicle's target altitude in meters" })).toBe(
+      "the vehicle's target altitude in meters",
+    );
+    expect(fieldHelpText({ name: "x", annotation: "int" })).toBe("");
+    expect(fieldHelpText({ name: "x", annotation: "bool" })).toBe("");
+  });
+  it("returns '' when neither is present", () => {
+    expect(fieldHelpText({ name: "x" })).toBe("");
+  });
+});
+
+describe("effectiveSchemaFieldValue / writeSchemaFieldValue", () => {
+  const boolField: SchemaField = { name: "enabled", schemaType: "boolean" };
+  const numberField: SchemaField = { name: "speed", schemaType: "float", default: 1.5 };
+  const tupleField: SchemaField = { name: "position", schemaType: "tuple" };
+  const textField: SchemaField = { name: "label", schemaType: "string", default: "fallback" };
+
+  it("reads the field's default when absent from paramsRaw", () => {
+    expect(effectiveSchemaFieldValue("", boolField)).toBe("");
+    expect(effectiveSchemaFieldValue("", numberField)).toBe(1.5);
+  });
+
+  it("reads and coerces a boolean field", () => {
+    expect(effectiveSchemaFieldValue("enabled: true", boolField)).toBe(true);
+    expect(effectiveSchemaFieldValue("enabled: false", boolField)).toBe(false);
+  });
+
+  it("reads and coerces a number field, falling back to default on garbage", () => {
+    expect(effectiveSchemaFieldValue("speed: 3.5", numberField)).toBe(3.5);
+    expect(effectiveSchemaFieldValue("speed: notanumber", numberField)).toBe(1.5);
+  });
+
+  it("reads and coerces a tuple field", () => {
+    expect(effectiveSchemaFieldValue("position: [1, 2, 3]", tupleField)).toEqual([1, 2, 3]);
+  });
+
+  it("reads a text field as-is", () => {
+    expect(effectiveSchemaFieldValue("label: hello", textField)).toBe("hello");
+  });
+
+  it("writes each kind back into paramsRaw and round-trips through a read", () => {
+    let raw = "";
+    raw = writeSchemaFieldValue(raw, boolField, true);
+    expect(effectiveSchemaFieldValue(raw, boolField)).toBe(true);
+
+    raw = writeSchemaFieldValue(raw, numberField, 9.9);
+    expect(effectiveSchemaFieldValue(raw, numberField)).toBe(9.9);
+
+    raw = writeSchemaFieldValue(raw, tupleField, [4, 5, 6]);
+    expect(effectiveSchemaFieldValue(raw, tupleField)).toEqual([4, 5, 6]);
+
+    raw = writeSchemaFieldValue(raw, textField, "new label");
+    expect(effectiveSchemaFieldValue(raw, textField)).toBe("new label");
+  });
+});
+
+describe("normalizeModeRegistry", () => {
+  it("flattens {target: entries[]} into a lookup keyed by both public mode id and class path", () => {
+    const takeoff: ModeMetadata = {
+      name: "Takeoff",
+      mode: "uav.modes.takeoff.Takeoff",
+      classPath: "uav.modes.takeoff:Takeoff",
+      params: [],
+    };
+    const flat = normalizeModeRegistry({ uav: [takeoff] });
+    expect(flat["takeoff.Takeoff"]).toBe(takeoff);
+    expect(flat["uav.modes.takeoff:Takeoff"]).toBe(takeoff);
+  });
+
+  it("handles an empty/undefined registry", () => {
+    expect(normalizeModeRegistry(undefined)).toEqual({});
+    expect(normalizeModeRegistry({})).toEqual({});
+  });
+});
+
+describe("defaultParamsRawForMode", () => {
+  it("builds a default params fragment, skipping missing/null/array/object defaults", () => {
+    const metadata: ModeMetadata = {
+      name: "Takeoff",
+      mode: "takeoff.Takeoff",
+      params: [
+        { name: "target_altitude", schemaType: "float", default: 10.0 },
+        { name: "enabled", schemaType: "boolean", default: true },
+        { name: "offset", schemaType: "tuple", default: [1, 2, 3] },
+        { name: "no_default", schemaType: "string" },
+        { name: "explicitly_missing", schemaType: "string", default: 5, defaultKind: "missing" },
+        { name: "list_field", schemaType: "array", default: [1, 2] },
+      ],
+    };
+    const raw = defaultParamsRawForMode(metadata);
+    expect(raw).toBe("target_altitude: 10\nenabled: true\noffset: [1, 2, 3]");
+  });
+
+  it("returns '' for a mode with no params", () => {
+    expect(defaultParamsRawForMode({ name: "x", mode: "x", params: [] })).toBe("");
+    expect(defaultParamsRawForMode(null)).toBe("");
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/core/src/schema-field.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/schema-field.ts
@@ -1,0 +1,113 @@
+import { getYamlBlockValue, setYamlBlockValue } from "./yaml-text.js";
+import { publicModeId } from "./mission-document.js";
+import type { ModeMetadata, ModeRegistryByTarget, SchemaField, SchemaFieldInputKind } from "./types.js";
+
+export function schemaFieldInputKind(field: SchemaField | undefined | null): SchemaFieldInputKind {
+  if (!field) return "text";
+  if (field.choices?.length) return "select";
+  if (field.schemaType === "boolean" || field.schemaType === "bool") return "boolean";
+  if (
+    field.schemaType === "integer" ||
+    field.schemaType === "number" ||
+    field.schemaType === "int" ||
+    field.schemaType === "float"
+  ) {
+    return "number";
+  }
+  if (field.schemaType === "tuple") return "tuple";
+  if (
+    field.schemaType === "array" ||
+    field.schemaType === "object" ||
+    field.schemaType === "union" ||
+    field.schemaType === "list" ||
+    field.schemaType === "dict"
+  ) {
+    return "block";
+  }
+  return "text";
+}
+
+const LOW_SIGNAL_SCHEMA_ANNOTATIONS = new Set(["str", "int", "float", "bool", "enum", "list", "dict", "mapping"]);
+
+export function fieldHelpText(field: SchemaField | undefined | null): string {
+  if (field?.description) return field.description;
+  const annotation = `${field?.annotation || ""}`.trim().toLowerCase();
+  if (!annotation || LOW_SIGNAL_SCHEMA_ANNOTATIONS.has(annotation)) return "";
+  return field?.annotation || "";
+}
+
+export function effectiveSchemaFieldValue(paramsRaw: string, field: SchemaField): unknown {
+  const blockValue = getYamlBlockValue(paramsRaw, field.name);
+  if (!blockValue) {
+    return field.default ?? "";
+  }
+
+  const kind = schemaFieldInputKind(field);
+  if (kind === "boolean") {
+    return `${blockValue}`.trim().toLowerCase() === "true";
+  }
+  if (kind === "number") {
+    const parsed = Number(`${blockValue}`.trim());
+    return Number.isFinite(parsed) ? parsed : (field.default ?? 0);
+  }
+  if (kind === "tuple") {
+    const stripped = `${blockValue}`.replace(/^\[/, "").replace(/\]$/, "");
+    return stripped.split(",").map((part) => Number(part.trim()) || 0);
+  }
+  return blockValue;
+}
+
+export function writeSchemaFieldValue(paramsRaw: string, field: SchemaField, nextValue: unknown): string {
+  const kind = schemaFieldInputKind(field);
+  if (kind === "boolean") {
+    return setYamlBlockValue(paramsRaw, field.name, nextValue ? "true" : "false");
+  }
+  if (kind === "number") {
+    return setYamlBlockValue(paramsRaw, field.name, `${nextValue}`);
+  }
+  if (kind === "tuple") {
+    const arr = Array.isArray(nextValue) ? nextValue : [0, 0, 0];
+    const normalized = [arr[0] ?? 0, arr[1] ?? 0, arr[2] ?? 0].map((v) => Number(v) || 0);
+    return setYamlBlockValue(paramsRaw, field.name, `[${normalized.join(", ")}]`);
+  }
+  return setYamlBlockValue(paramsRaw, field.name, `${nextValue || ""}`);
+}
+
+/** Flattens `{target: ModeMetadata[]}` into a lookup keyed by both public mode id and class path. */
+export function normalizeModeRegistry(modeRegistry: ModeRegistryByTarget | undefined | null): Record<string, ModeMetadata> {
+  const flat: Record<string, ModeMetadata> = {};
+  Object.values(modeRegistry || {}).forEach((entries) => {
+    (entries || []).forEach((entry) => {
+      const modeRef = publicModeId(entry.mode || entry.classPath || "");
+      if (modeRef) {
+        flat[modeRef] = entry;
+      }
+      if (entry.classPath) {
+        flat[entry.classPath] = entry;
+      }
+    });
+  });
+  return flat;
+}
+
+export function defaultParamsRawForMode(metadata: ModeMetadata | undefined | null): string {
+  if (!metadata?.params?.length) return "";
+  const lines: string[] = [];
+  metadata.params.forEach((field) => {
+    if (field.defaultKind === "missing") return;
+    if (field.default === null || field.default === undefined) return;
+    if (field.schemaType === "tuple" && Array.isArray(field.default)) {
+      lines.push(`${field.name}: [${field.default.join(", ")}]`);
+      return;
+    }
+    if (field.schemaType === "boolean") {
+      lines.push(`${field.name}: ${field.default ? "true" : "false"}`);
+      return;
+    }
+    if (field.schemaType === "array" || field.schemaType === "object") {
+      return;
+    }
+    lines.push(`${field.name}: ${field.default}`);
+  });
+  return lines.join("\n");
+}

--- a/controls/sae_2025_ws/integration/packages/core/src/types.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/types.ts
@@ -1,14 +1,3 @@
-export interface PiTarget {
-  targetId: string;
-  label: string;
-  hostname: string;
-  vehicleName: string;
-  enabled: boolean;
-}
-
-export type NetworkRole = "default" | "ap" | "client";
-export type ApSelection = "ordered_then_strongest" | "strongest";
-
 export interface WifiConnection {
   name: string;
   type: string;
@@ -46,14 +35,6 @@ export interface WifiScanResult {
   error?: string;
 }
 
-export type MissionPhase =
-  | "idle"
-  | "preparing"
-  | "running"
-  | "stopping"
-  | "error"
-  | "offline";
-
 export type LaunchState = "running" | "stopped" | "not_prepared" | "error" | "offline";
 
 export interface LaunchStatus {
@@ -62,23 +43,6 @@ export interface LaunchStatus {
   state: LaunchState;
   pid?: string;
   error?: string;
-}
-
-export interface MissionRuntimeState {
-  phase: MissionPhase;
-  launchState: LaunchState;
-  running: boolean;
-  pid?: string;
-  message?: string;
-  error?: string;
-  updatedAt: number;
-}
-
-export interface BuildSource {
-  kind: "none" | "github" | "local_artifact" | "local_codebase";
-  summary: string;
-  fleetFile?: string;
-  updatedAt?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/controls/sae_2025_ws/integration/packages/core/src/types.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/types.ts
@@ -80,3 +80,118 @@ export interface BuildSource {
   fleetFile?: string;
   updatedAt?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Mission/fleet YAML editor types (Phase 4)
+// ---------------------------------------------------------------------------
+
+export type SchemaFieldType =
+  | "boolean"
+  | "bool"
+  | "integer"
+  | "number"
+  | "int"
+  | "float"
+  | "tuple"
+  | "array"
+  | "object"
+  | "union"
+  | "list"
+  | "dict"
+  | "string";
+
+export interface SchemaField {
+  name: string;
+  schemaType?: SchemaFieldType;
+  choices?: string[];
+  default?: unknown;
+  defaultKind?: "missing" | "present";
+  description?: string;
+  annotation?: string;
+  required?: boolean;
+  nullable?: boolean;
+}
+
+export type SchemaFieldInputKind = "select" | "boolean" | "number" | "tuple" | "block" | "text";
+
+export interface ModeMetadata {
+  name: string;
+  mode: string;
+  classPath?: string;
+  target?: "uav" | "payload" | "";
+  description?: string;
+  requiredVisionNodes?: string[];
+  transitionLabels?: string[];
+  params: SchemaField[];
+}
+
+/** Flat lookup of mode registry entries, keyed by both the public mode id and the class path (mirrors `normalizeModeRegistry`). */
+export type ModeRegistryByTarget = Record<string, ModeMetadata[]>;
+
+export interface TransitionEntry {
+  key: string;
+  value: string;
+}
+
+export interface MissionMode {
+  name: string;
+  mode: string;
+  paramsRaw: string;
+  transitionsRaw: string;
+  transitions: TransitionEntry[];
+  target: "uav" | "payload" | "";
+  hasParams: boolean;
+  hasTransitions: boolean;
+}
+
+export interface ParsedMissionDocument {
+  rawText: string;
+  modes: MissionMode[];
+  selectedTarget: "uav" | "payload" | "";
+  warnings: string[];
+}
+
+export interface FleetBackend {
+  kind?: string;
+  px4_path?: string;
+  [key: string]: unknown;
+}
+
+export interface FleetVehicle {
+  name?: string;
+  kind?: string;
+  mission?: string;
+  px4_airframe_id?: unknown;
+  px4_namespace?: unknown;
+  [key: string]: unknown;
+}
+
+export interface FleetEditorDocument {
+  backend: FleetBackend;
+  defaults: Record<string, unknown>;
+  vehicles: FleetVehicle[];
+}
+
+export interface ParsedFleetDocument {
+  rawText: string;
+  doc: FleetEditorDocument | null;
+  error: string;
+}
+
+export type ObjectPathSegment = string | number;
+
+export interface FleetSchemaSection {
+  name: string;
+  label?: string;
+  fields: SchemaField[];
+}
+
+export interface FleetSchema {
+  sections: FleetSchemaSection[];
+  backendKinds?: string[];
+}
+
+export interface MissionCatalogEntry {
+  name: string;
+  target: "uav" | "payload" | "";
+}

--- a/controls/sae_2025_ws/integration/packages/core/src/types.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/types.ts
@@ -22,6 +22,14 @@ export interface WifiStatus {
   currentWifi?: string;
   currentMode?: string;
   effectiveRole?: string;
+  policySource?: string;
+  runtimeActive?: boolean;
+  missionStarted?: boolean;
+  travelRouterLocked?: boolean;
+  switchingDisabled?: boolean;
+  localApProfile?: string;
+  travelRouterProfile?: string;
+  allowedApHosts?: string[];
   connections: WifiConnection[];
   error?: string;
 }

--- a/controls/sae_2025_ws/integration/packages/core/src/types.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/types.ts
@@ -198,6 +198,37 @@ export interface MissionCatalogEntry {
   target: "uav" | "payload" | "";
 }
 
+// ---------------------------------------------------------------------------
+// Fleet board (Phase 5)
+// ---------------------------------------------------------------------------
+
+export interface FleetBoardDevice {
+  hostname: string;
+  connected: boolean;
+  buildInstalled: boolean;
+  releaseId?: string;
+  buildInfo?: string;
+  runtimeState: LaunchState;
+  runtimeRunning: boolean;
+  ready: boolean;
+  notes: string[];
+}
+
+export interface FleetBoardSummary {
+  totalDevices: number;
+  connectedDevices: number;
+  buildInstalledDevices: number;
+  runningDevices: number;
+  readyDevices: number;
+}
+
+export interface FleetBoardResult {
+  success: boolean;
+  devices: FleetBoardDevice[];
+  summary: FleetBoardSummary;
+  error?: string;
+}
+
 export interface SchemaExportResult {
   success: boolean;
   schema?: {

--- a/controls/sae_2025_ws/integration/packages/core/src/types.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/types.ts
@@ -146,6 +146,8 @@ export interface MissionMode {
 
 export interface ParsedMissionDocument {
   rawText: string;
+  /** Raw text of any top-level content before the `modes:` key (header comments, other keys) -- preserved verbatim on render instead of being discarded. */
+  preamble: string;
   modes: MissionMode[];
   selectedTarget: "uav" | "payload" | "";
   warnings: string[];

--- a/controls/sae_2025_ws/integration/packages/core/src/types.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/types.ts
@@ -56,6 +56,14 @@ export type MissionPhase =
 
 export type LaunchState = "running" | "stopped" | "not_prepared" | "error" | "offline";
 
+export interface LaunchStatus {
+  success: boolean;
+  running: boolean;
+  state: LaunchState;
+  pid?: string;
+  error?: string;
+}
+
 export interface MissionRuntimeState {
   phase: MissionPhase;
   launchState: LaunchState;

--- a/controls/sae_2025_ws/integration/packages/core/src/types.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/types.ts
@@ -1,0 +1,66 @@
+export interface PiTarget {
+  targetId: string;
+  label: string;
+  hostname: string;
+  vehicleName: string;
+  enabled: boolean;
+}
+
+export type NetworkRole = "default" | "ap" | "client";
+export type ApSelection = "ordered_then_strongest" | "strongest";
+
+export interface WifiConnection {
+  name: string;
+  type: string;
+  device: string;
+  state: string;
+}
+
+export interface WifiStatus {
+  success: boolean;
+  isHotspot?: boolean;
+  currentWifi?: string;
+  currentMode?: string;
+  effectiveRole?: string;
+  connections: WifiConnection[];
+  error?: string;
+}
+
+export interface WifiNetwork {
+  ssid: string;
+  signal: number;
+  security: string;
+}
+
+export interface WifiScanResult {
+  success: boolean;
+  networks: WifiNetwork[];
+  error?: string;
+}
+
+export type MissionPhase =
+  | "idle"
+  | "preparing"
+  | "running"
+  | "stopping"
+  | "error"
+  | "offline";
+
+export type LaunchState = "running" | "stopped" | "not_prepared" | "error" | "offline";
+
+export interface MissionRuntimeState {
+  phase: MissionPhase;
+  launchState: LaunchState;
+  running: boolean;
+  pid?: string;
+  message?: string;
+  error?: string;
+  updatedAt: number;
+}
+
+export interface BuildSource {
+  kind: "none" | "github" | "local_artifact" | "local_codebase";
+  summary: string;
+  fleetFile?: string;
+  updatedAt?: string;
+}

--- a/controls/sae_2025_ws/integration/packages/core/src/types.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/types.ts
@@ -195,3 +195,26 @@ export interface MissionCatalogEntry {
   name: string;
   target: "uav" | "payload" | "";
 }
+
+export interface SchemaExportResult {
+  success: boolean;
+  schema?: {
+    modes: ModeRegistryByTarget;
+    fleet: FleetSchema;
+    missions: MissionCatalogEntry[];
+    availableFleets: string[];
+  };
+  error?: string;
+}
+
+export interface MissionNamesResult {
+  success: boolean;
+  missions: string[];
+  error?: string;
+}
+
+export interface FileResult {
+  success: boolean;
+  content?: string;
+  error?: string;
+}

--- a/controls/sae_2025_ws/integration/packages/core/src/yaml-text.block-sequence-bug.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/yaml-text.block-sequence-bug.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import * as YAML from "yaml";
+import { getYamlBlockValue, setYamlBlockValue } from "./yaml-text.js";
+
+/**
+ * Regression test for a real data-corruption bug found while testing Phase
+ * 4's mission-graph editor against real mission YAML from the repo (e.g.
+ * controls/sae_2025_ws/src/uav/missions/mission.yaml's `GPS` mode):
+ *
+ *   coordinates:
+ *     - [[5, 10, -10], 1, LOCAL]
+ *
+ * `getYamlBlockValue` correctly extracts this single-item YAML block
+ * sequence as the raw string "- [[5, 10, -10], 1, LOCAL]" (including the
+ * leading "- " block-sequence indicator, since it's not a real parser).
+ *
+ * `setYamlBlockValue` used to only nest a value as `key:\n  <indented
+ * value>` when the value contained an embedded "\n" -- a single-item block
+ * sequence's value has no embedded newline, so it took the inline branch and
+ * got written back as `coordinates: - [[5, 10, -10], 1, LOCAL]` on one line,
+ * which is not valid YAML (a block-sequence "-" can't follow "key:" on the
+ * same line). Fixed by also checking whether the trimmed value itself starts
+ * with a block-sequence indicator.
+ */
+describe("setYamlBlockValue with a single-item YAML block sequence (regression)", () => {
+  it("round-trips a real-shaped `coordinates:\\n  - [[...]]` block value back into valid YAML", () => {
+    const original = "coordinates:\n  - [[5, 10, -10], 1, LOCAL]";
+    const value = getYamlBlockValue(original, "coordinates");
+    expect(value).toBe("- [[5, 10, -10], 1, LOCAL]");
+
+    const rewritten = setYamlBlockValue(original, "coordinates", value);
+
+    expect(rewritten).toBe(original);
+    expect(() => YAML.parse(rewritten)).not.toThrow();
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/core/src/yaml-text.test.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/yaml-text.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  dedentBlock,
+  escapeRegex,
+  getYamlBlockValue,
+  getYamlFieldValue,
+  indentBlock,
+  parseInlineYamlValue,
+  parseYamlScalar,
+  serializeYamlScalar,
+  setYamlBlockValue,
+  setYamlFieldValue,
+  splitInlineComment,
+  splitTopLevelYamlEntries,
+  stripYamlComment,
+  unquoteYamlScalar,
+} from "./yaml-text.js";
+
+describe("escapeRegex", () => {
+  it("escapes regex metacharacters", () => {
+    expect(escapeRegex("a.b*c")).toBe("a\\.b\\*c");
+  });
+});
+
+describe("splitInlineComment", () => {
+  it("splits at the first ' #'", () => {
+    expect(splitInlineComment("value # a comment")).toEqual({ value: "value", comment: " # a comment" });
+  });
+  it("returns no comment when none present", () => {
+    expect(splitInlineComment("plain value")).toEqual({ value: "plain value", comment: "" });
+  });
+});
+
+describe("unquoteYamlScalar", () => {
+  it("strips matching single or double quotes", () => {
+    expect(unquoteYamlScalar("'hi'")).toBe("hi");
+    expect(unquoteYamlScalar('"hi"')).toBe("hi");
+    expect(unquoteYamlScalar("hi")).toBe("hi");
+  });
+});
+
+describe("parseYamlScalar / serializeYamlScalar", () => {
+  it("round-trips booleans", () => {
+    expect(parseYamlScalar("true", "boolean")).toBe(true);
+    expect(parseYamlScalar("FALSE", "boolean")).toBe(false);
+    expect(serializeYamlScalar(true, "boolean")).toBe("true");
+  });
+  it("round-trips integers, defaulting to 0 on garbage", () => {
+    expect(parseYamlScalar("42", "integer")).toBe(42);
+    expect(parseYamlScalar("nope", "integer")).toBe(0);
+    expect(serializeYamlScalar(7, "integer")).toBe("7");
+  });
+  it("round-trips array3, defaulting to [0,0,0] on wrong length", () => {
+    expect(parseYamlScalar("[1, 2, 3]", "array3")).toEqual([1, 2, 3]);
+    expect(parseYamlScalar("[1, 2]", "array3")).toEqual([0, 0, 0]);
+    expect(serializeYamlScalar([1, 2, 3], "array3")).toBe("[1, 2, 3]");
+  });
+  it("quotes strings containing colon/hash/whitespace, passes plain strings through", () => {
+    expect(serializeYamlScalar("plain", "text")).toBe("plain");
+    expect(serializeYamlScalar("has: colon", "text")).toBe("'has: colon'");
+    expect(serializeYamlScalar("", "text")).toBe("''");
+  });
+});
+
+describe("getYamlFieldValue / setYamlFieldValue", () => {
+  it("gets a flat key's value anywhere in the content", () => {
+    const content = "foo: 1\nbar: hello\n";
+    expect(getYamlFieldValue(content, "bar", "text")).toBe("hello");
+  });
+  it("returns type-appropriate defaults when the key is absent", () => {
+    expect(getYamlFieldValue("", "missing", "boolean")).toBe(false);
+    expect(getYamlFieldValue("", "missing", "array3")).toEqual([0, 0, 0]);
+    expect(getYamlFieldValue("", "missing", "text")).toBe("");
+  });
+  it("sets an existing key in place, preserving inline comments", () => {
+    const content = "debug: false # keep this\nmission: foo\n";
+    const updated = setYamlFieldValue(content, "debug", "boolean", true);
+    expect(updated).toContain("debug: true # keep this");
+  });
+  it("appends the key when absent", () => {
+    const updated = setYamlFieldValue("mission: foo", "debug", "boolean", true);
+    expect(updated).toContain("debug: true");
+  });
+});
+
+describe("indentBlock / dedentBlock", () => {
+  it("indents non-blank lines only", () => {
+    expect(indentBlock("a\n\nb", 2)).toBe("  a\n\n  b");
+  });
+  it("dedents up to the given width and trims", () => {
+    expect(dedentBlock("      a\n      b\n", 6)).toBe("a\nb");
+  });
+});
+
+describe("parseInlineYamlValue / stripYamlComment", () => {
+  it("extracts the value after the first colon", () => {
+    expect(parseInlineYamlValue("key: value")).toBe("value");
+    expect(parseInlineYamlValue("no colon")).toBe("");
+  });
+  it("strips a trailing ' #' comment", () => {
+    expect(stripYamlComment("value # comment")).toBe("value");
+    expect(stripYamlComment("value")).toBe("value");
+  });
+});
+
+describe("splitTopLevelYamlEntries / getYamlBlockValue / setYamlBlockValue", () => {
+  const fragment = "target_position: [1, 2, 3]\napproach_speed: 0.5\nnested:\n  a: 1\n  b: 2\n";
+
+  it("splits top-level entries with their line spans", () => {
+    const entries = splitTopLevelYamlEntries(fragment);
+    expect(entries.map((e) => e.key)).toEqual(["target_position", "approach_speed", "nested"]);
+  });
+
+  it("gets an inline scalar value", () => {
+    expect(getYamlBlockValue(fragment, "approach_speed")).toBe("0.5");
+  });
+
+  it("gets a nested block value, dedented", () => {
+    expect(getYamlBlockValue(fragment, "nested")).toBe("a: 1\nb: 2");
+  });
+
+  it("returns '' for an absent key", () => {
+    expect(getYamlBlockValue(fragment, "missing")).toBe("");
+  });
+
+  it("sets a new key when absent", () => {
+    const updated = setYamlBlockValue("", "speed", "1.5");
+    expect(updated).toBe("speed: 1.5");
+  });
+
+  it("replaces an existing key's value", () => {
+    const updated = setYamlBlockValue("speed: 1.5\nother: x", "speed", "2.0");
+    expect(updated).toContain("speed: 2.0");
+    expect(updated).toContain("other: x");
+  });
+
+  it("removes the key entirely when set to an empty value", () => {
+    const updated = setYamlBlockValue("speed: 1.5\nother: x", "speed", "");
+    expect(updated).not.toContain("speed");
+    expect(updated).toContain("other: x");
+  });
+
+  it("writes a multi-line value as an indented nested block", () => {
+    const updated = setYamlBlockValue("", "nested", "a: 1\nb: 2");
+    expect(updated).toBe("nested:\n  a: 1\n  b: 2");
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/core/src/yaml-text.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/yaml-text.ts
@@ -187,7 +187,13 @@ export function getYamlBlockValue(content: string | undefined | null, key: strin
 }
 
 export function setYamlBlockValue(content: string | undefined | null, key: string, rawValue: unknown): string {
-  const lines = normalizeYamlFragment(content).split("\n").filter(Boolean);
+  // Must stay index-consistent with splitTopLevelYamlEntries's own split (no
+  // filtering blank lines out) -- entry.start/end are computed against that
+  // unfiltered array, so splicing into a filtered copy desyncs the indices
+  // and corrupts/duplicates keys whenever the fragment has a blank interior
+  // line (e.g. a multi-line params block with a blank line between items).
+  const normalized = normalizeYamlFragment(content);
+  const lines = normalized ? normalized.split("\n") : [];
   const entries = splitTopLevelYamlEntries(content);
   const existing = entries.find((item) => item.key === key);
   const nextLines = [...lines];
@@ -198,7 +204,13 @@ export function setYamlBlockValue(content: string | undefined | null, key: strin
 
   const trimmed = `${rawValue ?? ""}`.trim();
   if (trimmed) {
-    const replacement = trimmed.includes("\n") ? [`${key}:`, ...indentBlock(trimmed, 2).split("\n")] : [`${key}: ${trimmed}`];
+    // A single-item YAML block sequence ("- [[5, 10, -10], 1, LOCAL]", as
+    // getYamlBlockValue returns it verbatim, leading "- " included) has no
+    // embedded newline but still can't follow "key: " on the same line --
+    // "key: - foo" isn't valid YAML (a block-sequence indicator can't share
+    // a line with its mapping key). Needs the nested-block form too.
+    const needsOwnLine = trimmed.includes("\n") || /^-(\s|$)/.test(trimmed);
+    const replacement = needsOwnLine ? [`${key}:`, ...indentBlock(trimmed, 2).split("\n")] : [`${key}: ${trimmed}`];
     const insertAt = existing ? existing.start : nextLines.length;
     nextLines.splice(insertAt, 0, ...replacement);
   }

--- a/controls/sae_2025_ws/integration/packages/core/src/yaml-text.ts
+++ b/controls/sae_2025_ws/integration/packages/core/src/yaml-text.ts
@@ -1,0 +1,207 @@
+/**
+ * Line/regex-oriented YAML text helpers -- deliberately not a real YAML
+ * parser. Ported 1:1 from the old dashboard's `App.jsx` (functions of the
+ * same name), which used this surgical-edit approach specifically to
+ * preserve comments/formatting/unparsed content in mission YAML files that a
+ * real parse-mutate-serialize round trip would lose.
+ */
+
+export type YamlScalarValue = string | boolean | number | number[];
+
+export function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function splitInlineComment(valuePart: string): { value: string; comment: string } {
+  const idx = valuePart.indexOf(" #");
+  if (idx >= 0) {
+    return { value: valuePart.slice(0, idx).trim(), comment: valuePart.slice(idx) };
+  }
+  return { value: valuePart.trim(), comment: "" };
+}
+
+export function unquoteYamlScalar(value: string): string {
+  if ((value.startsWith("'") && value.endsWith("'")) || (value.startsWith('"') && value.endsWith('"'))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+export function parseYamlScalar(raw: string, type: string): YamlScalarValue {
+  const value = raw.trim();
+  if (type === "boolean") {
+    return value.toLowerCase() === "true";
+  }
+  if (type === "integer") {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  if (type === "array3") {
+    const stripped = value.replace(/^\[/, "").replace(/\]$/, "");
+    const parts = stripped
+      .split(",")
+      .map((p) => p.trim())
+      .filter(Boolean);
+    if (parts.length !== 3) return [0, 0, 0];
+    return parts.map((p) => Number(p) || 0);
+  }
+  return unquoteYamlScalar(value);
+}
+
+export function serializeYamlScalar(value: unknown, type: string): string {
+  if (type === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (type === "integer") {
+    const parsed = Number.parseInt(`${value ?? 0}`, 10);
+    return `${Number.isFinite(parsed) ? parsed : 0}`;
+  }
+  if (type === "array3") {
+    const arr = Array.isArray(value) ? value : [0, 0, 0];
+    const normalized = [arr[0], arr[1], arr[2]].map((v) => Number(v) || 0);
+    return `[${normalized.join(", ")}]`;
+  }
+
+  const text = `${value ?? ""}`;
+  if (text === "") return "''";
+  if (/[:#\s]/.test(text)) {
+    return `'${text.replace(/'/g, "''")}'`;
+  }
+  return text;
+}
+
+/** Regex-based get of a flat top-level `key: value` line anywhere in `content`. */
+export function getYamlFieldValue(content: string, key: string, type: string): YamlScalarValue {
+  const keyRe = new RegExp(`^\\s*${escapeRegex(key)}\\s*:\\s*(.*)$`, "m");
+  const match = content.match(keyRe);
+  if (!match) {
+    if (type === "boolean") return false;
+    if (type === "array3") return [0, 0, 0];
+    return "";
+  }
+  const { value } = splitInlineComment(match[1]);
+  return parseYamlScalar(value, type);
+}
+
+/** Regex-based set of a flat top-level `key: value` line, appending it if absent. */
+export function setYamlFieldValue(content: string, key: string, type: string, value: unknown): string {
+  const lines = content.split("\n");
+  const keyRe = new RegExp(`^(\\s*${escapeRegex(key)}\\s*:\\s*)(.*)$`);
+  const serialized = serializeYamlScalar(value, type);
+  let updated = false;
+
+  const nextLines = lines.map((line) => {
+    const match = line.match(keyRe);
+    if (!match) return line;
+    updated = true;
+    const prefix = match[1];
+    const rest = match[2];
+    const { comment } = splitInlineComment(rest);
+    return `${prefix}${serialized}${comment}`;
+  });
+
+  if (!updated) {
+    nextLines.push(`${key}: ${serialized}`);
+  }
+
+  return nextLines.join("\n");
+}
+
+export function indentBlock(text: string, spaces: number): string {
+  const pad = " ".repeat(spaces);
+  return text
+    .split("\n")
+    .map((line) => (line.trim() ? `${pad}${line}` : line))
+    .join("\n");
+}
+
+export function dedentBlock(text: string, spaces: number): string {
+  const pattern = new RegExp(`^ {0,${spaces}}`);
+  return text
+    .split("\n")
+    .map((line) => line.replace(pattern, ""))
+    .join("\n")
+    .trim();
+}
+
+export function parseInlineYamlValue(line: string): string {
+  const idx = line.indexOf(":");
+  if (idx < 0) return "";
+  return line.slice(idx + 1).trim();
+}
+
+export function stripYamlComment(value: string): string {
+  const idx = value.indexOf(" #");
+  return idx >= 0 ? value.slice(0, idx).trim() : value.trim();
+}
+
+export function normalizeYamlFragment(content: string | undefined | null): string {
+  const text = `${content ?? ""}`;
+  const trimmed = text.trim();
+  if (!trimmed || trimmed === "{}" || trimmed === "null") return "";
+  return text;
+}
+
+export interface YamlFragmentEntry {
+  key: string;
+  value: string;
+  start: number;
+  end: number;
+  lines: string[];
+}
+
+/** Splits a raw multi-line YAML fragment into top-level `key: ...` entries with their line spans, without a real parser. */
+export function splitTopLevelYamlEntries(content: string | undefined | null): YamlFragmentEntry[] {
+  const text = normalizeYamlFragment(content);
+  if (!text) return [];
+  const lines = text.split("\n");
+  const entries: YamlFragmentEntry[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const match = line.match(/^([A-Za-z0-9_.-]+)\s*:\s*(.*)$/);
+    if (!match) continue;
+    const start = index;
+    let end = lines.length;
+    for (let next = index + 1; next < lines.length; next += 1) {
+      if (/^[A-Za-z0-9_.-]+\s*:\s*(.*)$/.test(lines[next])) {
+        end = next;
+        break;
+      }
+    }
+    entries.push({ key: match[1], value: match[2], start, end, lines: lines.slice(start, end) });
+    index = end - 1;
+  }
+
+  return entries;
+}
+
+export function getYamlBlockValue(content: string | undefined | null, key: string): string {
+  const entry = splitTopLevelYamlEntries(content).find((item) => item.key === key);
+  if (!entry) return "";
+
+  const inline = stripYamlComment(entry.value || "");
+  if (inline) return inline;
+  if (entry.lines.length <= 1) return "";
+  return dedentBlock(entry.lines.slice(1).join("\n"), 2).trimEnd();
+}
+
+export function setYamlBlockValue(content: string | undefined | null, key: string, rawValue: unknown): string {
+  const lines = normalizeYamlFragment(content).split("\n").filter(Boolean);
+  const entries = splitTopLevelYamlEntries(content);
+  const existing = entries.find((item) => item.key === key);
+  const nextLines = [...lines];
+
+  if (existing) {
+    nextLines.splice(existing.start, existing.end - existing.start);
+  }
+
+  const trimmed = `${rawValue ?? ""}`.trim();
+  if (trimmed) {
+    const replacement = trimmed.includes("\n") ? [`${key}:`, ...indentBlock(trimmed, 2).split("\n")] : [`${key}: ${trimmed}`];
+    const insertAt = existing ? existing.start : nextLines.length;
+    nextLines.splice(insertAt, 0, ...replacement);
+  }
+
+  return nextLines.join("\n");
+}

--- a/controls/sae_2025_ws/integration/packages/core/tsconfig.build.json
+++ b/controls/sae_2025_ws/integration/packages/core/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/controls/sae_2025_ws/integration/packages/core/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/controls/sae_2025_ws/integration/packages/core/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/core/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/controls/sae_2025_ws/integration/packages/core/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/core/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src"
+    "composite": false,
+    "noEmit": true
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }

--- a/controls/sae_2025_ws/integration/packages/mobile/App.tsx
+++ b/controls/sae_2025_ws/integration/packages/mobile/App.tsx
@@ -1,0 +1,10 @@
+import { SafeAreaView, Text } from "react-native";
+
+export default function App() {
+  return (
+    <SafeAreaView>
+      <Text>PennAiR Fleet Ops</Text>
+      <Text>Phase 0 scaffold — wifi control lands in Phase 1.</Text>
+    </SafeAreaView>
+  );
+}

--- a/controls/sae_2025_ws/integration/packages/mobile/App.tsx
+++ b/controls/sae_2025_ws/integration/packages/mobile/App.tsx
@@ -1,10 +1,52 @@
-import { SafeAreaProvider } from "react-native-safe-area-context";
+import { useEffect, useState } from "react";
+import { Button, ScrollView, Text, TextInput } from "react-native";
+import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
+import { OrchestratorClient } from "@pennair/integration-core";
 import { WifiScreen } from "./WifiScreen.js";
+import { MissionScreen } from "./MissionScreen.js";
+
+const ORCHESTRATOR_URL = process.env.EXPO_PUBLIC_ORCHESTRATOR_URL ?? "http://localhost:8080";
+const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+
+function Dashboard() {
+  const [pis, setPis] = useState<string[]>([]);
+  const [hostname, setHostname] = useState("");
+
+  useEffect(() => {
+    client.discoverPis().then((discovered) => {
+      const hostnames = discovered.map((pi) => pi.hostname);
+      setPis(hostnames);
+      if (hostnames.length > 0 && !hostname) {
+        setHostname(hostnames[0]);
+      }
+    });
+    // Intentionally run once on mount; discovery is re-triggered by the button below.
+  }, []);
+
+  async function refreshDiscovery() {
+    setPis((await client.discoverPis()).map((pi) => pi.hostname));
+  }
+
+  return (
+    <SafeAreaView>
+      <ScrollView>
+        <Text>PennAiR Fleet Ops</Text>
+
+        <Text>Discovered: {pis.join(", ") || "(none yet)"}</Text>
+        <Button title="Rediscover" onPress={refreshDiscovery} />
+        <TextInput placeholder="Pi hostname (e.g. air-01.local)" value={hostname} onChangeText={setHostname} />
+
+        <WifiScreen hostname={hostname} />
+        <MissionScreen hostname={hostname} />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
 
 export default function App() {
   return (
     <SafeAreaProvider>
-      <WifiScreen />
+      <Dashboard />
     </SafeAreaProvider>
   );
 }

--- a/controls/sae_2025_ws/integration/packages/mobile/App.tsx
+++ b/controls/sae_2025_ws/integration/packages/mobile/App.tsx
@@ -1,10 +1,10 @@
-import { SafeAreaView, Text } from "react-native";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import { WifiScreen } from "./WifiScreen.js";
 
 export default function App() {
   return (
-    <SafeAreaView>
-      <Text>PennAiR Fleet Ops</Text>
-      <Text>Phase 0 scaffold — wifi control lands in Phase 1.</Text>
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <WifiScreen />
+    </SafeAreaProvider>
   );
 }

--- a/controls/sae_2025_ws/integration/packages/mobile/App.tsx
+++ b/controls/sae_2025_ws/integration/packages/mobile/App.tsx
@@ -1,12 +1,9 @@
 import { useEffect, useState } from "react";
 import { Button, ScrollView, Text, TextInput } from "react-native";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
-import { OrchestratorClient } from "@pennair/integration-core";
 import { WifiScreen } from "./WifiScreen.js";
 import { MissionScreen } from "./MissionScreen.js";
-
-const ORCHESTRATOR_URL = process.env.EXPO_PUBLIC_ORCHESTRATOR_URL ?? "http://localhost:8080";
-const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+import { client } from "./orchestratorClient.js";
 
 function Dashboard() {
   const [pis, setPis] = useState<string[]>([]);

--- a/controls/sae_2025_ws/integration/packages/mobile/MissionScreen.tsx
+++ b/controls/sae_2025_ws/integration/packages/mobile/MissionScreen.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from "react";
+import { Button, Text, TextInput, View } from "react-native";
+import { OrchestratorClient, type LaunchStatus } from "@pennair/integration-core";
+
+const ORCHESTRATOR_URL = process.env.EXPO_PUBLIC_ORCHESTRATOR_URL ?? "http://localhost:8080";
+const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+
+export function MissionScreen({ hostname }: { hostname: string }) {
+  const [vehicleName, setVehicleName] = useState("");
+  const [status, setStatus] = useState<LaunchStatus | null>(null);
+  const [message, setMessage] = useState("");
+  const [logs, setLogs] = useState("");
+  const [streaming, setStreaming] = useState(false);
+  // React Native ships a global WebSocket implementation -- same API as web.
+  const socketRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    return () => {
+      socketRef.current?.close();
+    };
+  }, []);
+
+  async function refreshStatus() {
+    if (!hostname) return;
+    setStatus(await client.missionStatus(hostname));
+  }
+
+  async function prepare() {
+    if (!hostname) return;
+    const result = await client.prepareMission(hostname);
+    setMessage(result.error ?? result.output ?? "");
+    await refreshStatus();
+  }
+
+  async function stop() {
+    if (!hostname) return;
+    const result = await client.stopMission(hostname);
+    setMessage(result.error ?? result.output ?? "");
+    await refreshStatus();
+  }
+
+  async function startMission() {
+    if (!vehicleName) return;
+    const result = await client.startMission(vehicleName);
+    setMessage(result.error ?? result.output ?? "");
+  }
+
+  async function failsafe() {
+    if (!vehicleName) return;
+    const result = await client.triggerFailsafe(vehicleName);
+    setMessage(result.error ?? result.output ?? "");
+  }
+
+  function toggleLogStream() {
+    if (socketRef.current) {
+      socketRef.current.close();
+      socketRef.current = null;
+      setStreaming(false);
+      return;
+    }
+    if (!hostname) return;
+    const socket = new WebSocket(client.missionLogsUrl(hostname));
+    socket.onmessage = (event) => setLogs((prev) => `${prev}${event.data}`);
+    socket.onerror = () => setMessage("Log stream error");
+    socket.onclose = () => setStreaming(false);
+    socketRef.current = socket;
+    setStreaming(true);
+  }
+
+  return (
+    <View>
+      <Text>Mission</Text>
+
+      <Button title="Refresh status" onPress={refreshStatus} disabled={!hostname} />
+      <Button title="Prepare (start process)" onPress={prepare} disabled={!hostname} />
+      <Button title="Stop (stop process)" onPress={stop} disabled={!hostname} />
+      <Button
+        title={streaming ? "Stop log stream" : "Stream logs"}
+        onPress={toggleLogStream}
+        disabled={!hostname}
+      />
+
+      {status && (
+        <View>
+          <Text>State: {status.state}</Text>
+          <Text>Running: {String(status.running)}</Text>
+          {status.pid && <Text>PID: {status.pid}</Text>}
+          {status.error && <Text>Error: {status.error}</Text>}
+        </View>
+      )}
+
+      <TextInput placeholder="Vehicle name (e.g. air-01)" value={vehicleName} onChangeText={setVehicleName} />
+      <Button title="Start mission" onPress={startMission} disabled={!vehicleName} />
+      <Button title="Failsafe" onPress={failsafe} disabled={!vehicleName} />
+
+      {message ? <Text>{message}</Text> : null}
+      {logs ? <Text>{logs}</Text> : null}
+    </View>
+  );
+}

--- a/controls/sae_2025_ws/integration/packages/mobile/MissionScreen.tsx
+++ b/controls/sae_2025_ws/integration/packages/mobile/MissionScreen.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Button, Text, TextInput, View } from "react-native";
-import { OrchestratorClient, type LaunchStatus } from "@pennair/integration-core";
-
-const ORCHESTRATOR_URL = process.env.EXPO_PUBLIC_ORCHESTRATOR_URL ?? "http://localhost:8080";
-const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+import type { LaunchStatus } from "@pennair/integration-core";
+import { client } from "./orchestratorClient.js";
 
 export function MissionScreen({ hostname }: { hostname: string }) {
   const [vehicleName, setVehicleName] = useState("");

--- a/controls/sae_2025_ws/integration/packages/mobile/WifiScreen.tsx
+++ b/controls/sae_2025_ws/integration/packages/mobile/WifiScreen.tsx
@@ -1,11 +1,7 @@
 import { useState } from "react";
 import { Button, Text, TextInput, View } from "react-native";
-import { OrchestratorClient, type WifiNetwork, type WifiStatus } from "@pennair/integration-core";
-
-// Same idea as the web env var, just React Native's convention instead of
-// Vite's -- see WifiCard.tsx in packages/web for the shared OrchestratorClient logic.
-const ORCHESTRATOR_URL = process.env.EXPO_PUBLIC_ORCHESTRATOR_URL ?? "http://localhost:8080";
-const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+import type { WifiNetwork, WifiStatus } from "@pennair/integration-core";
+import { client } from "./orchestratorClient.js";
 
 export function WifiScreen({ hostname }: { hostname: string }) {
   const [status, setStatus] = useState<WifiStatus | null>(null);

--- a/controls/sae_2025_ws/integration/packages/mobile/WifiScreen.tsx
+++ b/controls/sae_2025_ws/integration/packages/mobile/WifiScreen.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { Button, ScrollView, Text, TextInput, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { OrchestratorClient, type WifiNetwork, type WifiStatus } from "@pennair/integration-core";
+
+// Same idea as the web env var, just React Native's convention instead of
+// Vite's -- see WifiCard.tsx in packages/web for the shared OrchestratorClient logic.
+const ORCHESTRATOR_URL = process.env.EXPO_PUBLIC_ORCHESTRATOR_URL ?? "http://localhost:8080";
+const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+
+export function WifiScreen() {
+  const [pis, setPis] = useState<string[]>([]);
+  const [hostname, setHostname] = useState("");
+  const [status, setStatus] = useState<WifiStatus | null>(null);
+  const [networks, setNetworks] = useState<WifiNetwork[]>([]);
+  const [ssid, setSsid] = useState("");
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    client.discoverPis().then((discovered) => {
+      const hostnames = discovered.map((pi) => pi.hostname);
+      setPis(hostnames);
+      if (hostnames.length > 0 && !hostname) {
+        setHostname(hostnames[0]);
+      }
+    });
+    // Intentionally run once on mount; discovery is re-triggered by the button below.
+  }, []);
+
+  async function refreshDiscovery() {
+    setPis((await client.discoverPis()).map((pi) => pi.hostname));
+  }
+
+  async function refreshStatus() {
+    if (!hostname) return;
+    setStatus(await client.wifiStatus(hostname));
+  }
+
+  async function scan() {
+    if (!hostname) return;
+    const result = await client.wifiScan(hostname);
+    setNetworks(result.networks);
+    setMessage(result.error ?? "");
+  }
+
+  async function connect() {
+    if (!hostname || !ssid) return;
+    const result = await client.wifiConnect(hostname, ssid, password);
+    setMessage(result.error ?? result.output ?? "");
+    await refreshStatus();
+  }
+
+  async function activateHotspot() {
+    if (!hostname) return;
+    const result = await client.wifiHotspot(hostname);
+    setMessage(result.error ?? result.output ?? "");
+    await refreshStatus();
+  }
+
+  return (
+    <SafeAreaView>
+      <ScrollView>
+        <Text>Wifi</Text>
+
+        <Text>Discovered: {pis.join(", ") || "(none yet)"}</Text>
+        <Button title="Rediscover" onPress={refreshDiscovery} />
+
+        <TextInput placeholder="Pi hostname (e.g. air-01.local)" value={hostname} onChangeText={setHostname} />
+
+        <Button title="Refresh status" onPress={refreshStatus} disabled={!hostname} />
+        <Button title="Scan networks" onPress={scan} disabled={!hostname} />
+        <Button title="Activate hotspot" onPress={activateHotspot} disabled={!hostname} />
+
+        {status && (
+          <View>
+            <Text>Success: {String(status.success)}</Text>
+            <Text>Current wifi: {status.currentWifi ?? "(none)"}</Text>
+            <Text>Is hotspot: {String(status.isHotspot ?? false)}</Text>
+            {status.error && <Text>Error: {status.error}</Text>}
+          </View>
+        )}
+
+        {networks.map((n) => (
+          <Text key={n.ssid}>
+            {n.ssid} ({n.signal}%, {n.security || "open"})
+          </Text>
+        ))}
+
+        <TextInput placeholder="SSID" value={ssid} onChangeText={setSsid} />
+        <TextInput placeholder="Password" secureTextEntry value={password} onChangeText={setPassword} />
+        <Button title="Connect" onPress={connect} disabled={!hostname || !ssid} />
+
+        {message ? <Text>{message}</Text> : null}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/controls/sae_2025_ws/integration/packages/mobile/WifiScreen.tsx
+++ b/controls/sae_2025_ws/integration/packages/mobile/WifiScreen.tsx
@@ -77,6 +77,9 @@ export function WifiScreen() {
             <Text>Success: {String(status.success)}</Text>
             <Text>Current wifi: {status.currentWifi ?? "(none)"}</Text>
             <Text>Is hotspot: {String(status.isHotspot ?? false)}</Text>
+            <Text>Effective role: {status.effectiveRole ?? "(unknown)"}</Text>
+            <Text>Travel router locked: {String(status.travelRouterLocked ?? false)}</Text>
+            <Text>Allowed AP hosts: {status.allowedApHosts?.join(", ") || "(none)"}</Text>
             {status.error && <Text>Error: {status.error}</Text>}
           </View>
         )}

--- a/controls/sae_2025_ws/integration/packages/mobile/WifiScreen.tsx
+++ b/controls/sae_2025_ws/integration/packages/mobile/WifiScreen.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from "react";
-import { Button, ScrollView, Text, TextInput, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { useState } from "react";
+import { Button, Text, TextInput, View } from "react-native";
 import { OrchestratorClient, type WifiNetwork, type WifiStatus } from "@pennair/integration-core";
 
 // Same idea as the web env var, just React Native's convention instead of
@@ -8,29 +7,12 @@ import { OrchestratorClient, type WifiNetwork, type WifiStatus } from "@pennair/
 const ORCHESTRATOR_URL = process.env.EXPO_PUBLIC_ORCHESTRATOR_URL ?? "http://localhost:8080";
 const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
 
-export function WifiScreen() {
-  const [pis, setPis] = useState<string[]>([]);
-  const [hostname, setHostname] = useState("");
+export function WifiScreen({ hostname }: { hostname: string }) {
   const [status, setStatus] = useState<WifiStatus | null>(null);
   const [networks, setNetworks] = useState<WifiNetwork[]>([]);
   const [ssid, setSsid] = useState("");
   const [password, setPassword] = useState("");
   const [message, setMessage] = useState("");
-
-  useEffect(() => {
-    client.discoverPis().then((discovered) => {
-      const hostnames = discovered.map((pi) => pi.hostname);
-      setPis(hostnames);
-      if (hostnames.length > 0 && !hostname) {
-        setHostname(hostnames[0]);
-      }
-    });
-    // Intentionally run once on mount; discovery is re-triggered by the button below.
-  }, []);
-
-  async function refreshDiscovery() {
-    setPis((await client.discoverPis()).map((pi) => pi.hostname));
-  }
 
   async function refreshStatus() {
     if (!hostname) return;
@@ -59,43 +41,36 @@ export function WifiScreen() {
   }
 
   return (
-    <SafeAreaView>
-      <ScrollView>
-        <Text>Wifi</Text>
+    <View>
+      <Text>Wifi</Text>
 
-        <Text>Discovered: {pis.join(", ") || "(none yet)"}</Text>
-        <Button title="Rediscover" onPress={refreshDiscovery} />
+      <Button title="Refresh status" onPress={refreshStatus} disabled={!hostname} />
+      <Button title="Scan networks" onPress={scan} disabled={!hostname} />
+      <Button title="Activate hotspot" onPress={activateHotspot} disabled={!hostname} />
 
-        <TextInput placeholder="Pi hostname (e.g. air-01.local)" value={hostname} onChangeText={setHostname} />
+      {status && (
+        <View>
+          <Text>Success: {String(status.success)}</Text>
+          <Text>Current wifi: {status.currentWifi ?? "(none)"}</Text>
+          <Text>Is hotspot: {String(status.isHotspot ?? false)}</Text>
+          <Text>Effective role: {status.effectiveRole ?? "(unknown)"}</Text>
+          <Text>Travel router locked: {String(status.travelRouterLocked ?? false)}</Text>
+          <Text>Allowed AP hosts: {status.allowedApHosts?.join(", ") || "(none)"}</Text>
+          {status.error && <Text>Error: {status.error}</Text>}
+        </View>
+      )}
 
-        <Button title="Refresh status" onPress={refreshStatus} disabled={!hostname} />
-        <Button title="Scan networks" onPress={scan} disabled={!hostname} />
-        <Button title="Activate hotspot" onPress={activateHotspot} disabled={!hostname} />
+      {networks.map((n) => (
+        <Text key={n.ssid}>
+          {n.ssid} ({n.signal}%, {n.security || "open"})
+        </Text>
+      ))}
 
-        {status && (
-          <View>
-            <Text>Success: {String(status.success)}</Text>
-            <Text>Current wifi: {status.currentWifi ?? "(none)"}</Text>
-            <Text>Is hotspot: {String(status.isHotspot ?? false)}</Text>
-            <Text>Effective role: {status.effectiveRole ?? "(unknown)"}</Text>
-            <Text>Travel router locked: {String(status.travelRouterLocked ?? false)}</Text>
-            <Text>Allowed AP hosts: {status.allowedApHosts?.join(", ") || "(none)"}</Text>
-            {status.error && <Text>Error: {status.error}</Text>}
-          </View>
-        )}
+      <TextInput placeholder="SSID" value={ssid} onChangeText={setSsid} />
+      <TextInput placeholder="Password" secureTextEntry value={password} onChangeText={setPassword} />
+      <Button title="Connect" onPress={connect} disabled={!hostname || !ssid} />
 
-        {networks.map((n) => (
-          <Text key={n.ssid}>
-            {n.ssid} ({n.signal}%, {n.security || "open"})
-          </Text>
-        ))}
-
-        <TextInput placeholder="SSID" value={ssid} onChangeText={setSsid} />
-        <TextInput placeholder="Password" secureTextEntry value={password} onChangeText={setPassword} />
-        <Button title="Connect" onPress={connect} disabled={!hostname || !ssid} />
-
-        {message ? <Text>{message}</Text> : null}
-      </ScrollView>
-    </SafeAreaView>
+      {message ? <Text>{message}</Text> : null}
+    </View>
   );
 }

--- a/controls/sae_2025_ws/integration/packages/mobile/orchestratorClient.ts
+++ b/controls/sae_2025_ws/integration/packages/mobile/orchestratorClient.ts
@@ -1,0 +1,7 @@
+import { OrchestratorClient } from "@pennair/integration-core";
+
+// Expo's env var convention (process.env.EXPO_PUBLIC_*) instead of Vite's
+// (import.meta.env.VITE_*) -- see packages/web/src/orchestratorClient.ts.
+const ORCHESTRATOR_URL = process.env.EXPO_PUBLIC_ORCHESTRATOR_URL ?? "http://localhost:8080";
+
+export const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });

--- a/controls/sae_2025_ws/integration/packages/mobile/package.json
+++ b/controls/sae_2025_ws/integration/packages/mobile/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
-    "ios": "expo start --ios"
+    "ios": "expo start --ios",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@pennair/integration-core": "*",

--- a/controls/sae_2025_ws/integration/packages/mobile/package.json
+++ b/controls/sae_2025_ws/integration/packages/mobile/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@pennair/mobile",
+  "version": "0.0.0",
+  "private": true,
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios"
+  },
+  "dependencies": {
+    "@pennair/integration-core": "*",
+    "expo": "~52.0.0",
+    "react": "^18.3.1",
+    "react-native": "0.76.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "typescript": "^5.7.2"
+  }
+}

--- a/controls/sae_2025_ws/integration/packages/mobile/package.json
+++ b/controls/sae_2025_ws/integration/packages/mobile/package.json
@@ -2,7 +2,7 @@
   "name": "@pennair/mobile",
   "version": "0.0.0",
   "private": true,
-  "main": "expo-router/entry",
+  "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
@@ -13,7 +13,8 @@
     "@pennair/integration-core": "*",
     "expo": "~52.0.0",
     "react": "^18.3.1",
-    "react-native": "0.76.3"
+    "react-native": "0.76.3",
+    "react-native-safe-area-context": "4.12.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/controls/sae_2025_ws/integration/packages/mobile/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/mobile/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "jsx": "react-native",
+    "noEmit": true,
+    "composite": false
+  },
+  "include": ["App.tsx"]
+}

--- a/controls/sae_2025_ws/integration/packages/mobile/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/mobile/tsconfig.json
@@ -8,5 +8,5 @@
     "noEmit": true,
     "composite": false
   },
-  "include": ["App.tsx"]
+  "include": ["*.tsx"]
 }

--- a/controls/sae_2025_ws/integration/packages/orchestrator/package.json
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/package.json
@@ -6,7 +6,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
     "start": "node dist/index.js",
     "test": "vitest run"
   },

--- a/controls/sae_2025_ws/integration/packages/orchestrator/package.json
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@pennair/orchestrator",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --build",
+    "start": "node dist/index.js",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@pennair/integration-core": "*",
+    "fastify": "^5.1.0"
+  },
+  "devDependencies": {
+    "@pennair/pi-agent": "*"
+  }
+}

--- a/controls/sae_2025_ws/integration/packages/orchestrator/package.json
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/package.json
@@ -12,9 +12,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@fastify/multipart": "^9.0.1",
     "@fastify/websocket": "^11.0.2",
     "@pennair/integration-core": "*",
     "fastify": "^5.1.0",
+    "tar": "^7.4.3",
     "ws": "^8.18.0"
   },
   "optionalDependencies": {

--- a/controls/sae_2025_ws/integration/packages/orchestrator/package.json
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/package.json
@@ -12,10 +12,16 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@fastify/websocket": "^11.0.2",
     "@pennair/integration-core": "*",
-    "fastify": "^5.1.0"
+    "fastify": "^5.1.0",
+    "ws": "^8.18.0"
+  },
+  "optionalDependencies": {
+    "rclnodejs": "^2.1.1"
   },
   "devDependencies": {
-    "@pennair/pi-agent": "*"
+    "@pennair/pi-agent": "*",
+    "@types/ws": "^8.5.13"
   }
 }

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/build-source-store.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/build-source-store.test.ts
@@ -1,0 +1,62 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { BuildSourceStore } from "./build-source-store.js";
+
+describe("BuildSourceStore", () => {
+  let scratchDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    scratchDir = await mkdtemp(join(tmpdir(), "build-source-store-test-"));
+    storePath = join(scratchDir, "build-source.json");
+  });
+
+  afterEach(async () => {
+    await rm(scratchDir, { recursive: true, force: true });
+  });
+
+  it("defaults to kind:none with no file on disk", async () => {
+    const store = new BuildSourceStore(storePath);
+    await store.load();
+    expect(store.get()).toEqual({ kind: "none", summary: "No build source selected" });
+  });
+
+  it("persists a github selection to disk and reloads it in a fresh instance", async () => {
+    const store = new BuildSourceStore(storePath);
+    await store.load();
+    await store.setGithub({ githubSource: "release", tag: "build-42", name: "Build 42" });
+
+    const reloaded = new BuildSourceStore(storePath);
+    await reloaded.load();
+    expect(reloaded.get().kind).toBe("github");
+    expect(reloaded.get().tag).toBe("build-42");
+    expect(reloaded.get().summary).toBe("Build 42");
+  });
+
+  it("carries the selected fleetFile over when switching to a new github source", async () => {
+    const store = new BuildSourceStore(storePath);
+    await store.load();
+    await store.setFleetFile("example_fleet.yaml");
+    await store.setGithub({ githubSource: "release", tag: "build-42" });
+
+    expect(store.get().fleetFile).toBe("example_fleet.yaml");
+  });
+
+  it("clear() resets to kind:none", async () => {
+    const store = new BuildSourceStore(storePath);
+    await store.load();
+    await store.setLocalArtifact("build.tar.gz", "/tmp/cache/build.tar.gz", 12345);
+    await store.clear();
+
+    expect(store.get()).toMatchObject({ kind: "none" });
+  });
+
+  it("summarizes github actions sources using name/artifactName/artifactId in priority order", async () => {
+    const store = new BuildSourceStore(storePath);
+    await store.load();
+    await store.setGithub({ githubSource: "actions", artifactId: "999" });
+    expect(store.get().summary).toBe("GitHub Actions 999");
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/build-source-store.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/build-source-store.ts
@@ -1,0 +1,118 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export type BuildSourceKind = "none" | "github" | "local_artifact" | "local_codebase";
+export type GithubSource = "release" | "actions";
+
+export interface BuildSourceRecord {
+  kind: BuildSourceKind;
+  githubSource?: GithubSource;
+  tag?: string;
+  artifactId?: string;
+  runId?: string;
+  sha?: string;
+  commitSubject?: string;
+  name?: string;
+  date?: string;
+  downloadUrl?: string;
+  sizeMb?: number;
+  branch?: string;
+  artifactName?: string;
+  workflowName?: string;
+  workflowEvent?: string;
+  workflowConclusion?: string;
+  localArtifactPath?: string;
+  localArtifactSizeBytes?: number;
+  codebaseRoot?: string;
+  fleetFile?: string;
+  updatedAt?: string;
+}
+
+const EMPTY_RECORD: BuildSourceRecord = { kind: "none" };
+
+function summarize(record: BuildSourceRecord): string {
+  switch (record.kind) {
+    case "github":
+      if (record.githubSource === "release") return record.name || record.tag || "GitHub release";
+      return `GitHub Actions ${record.name || record.artifactName || record.artifactId || "artifact"}`;
+    case "local_artifact":
+      return record.artifactName || "Local artifact";
+    case "local_codebase":
+      return record.codebaseRoot || "Local codebase";
+    default:
+      return "No build source selected";
+  }
+}
+
+/**
+ * Persists which build is currently selected -- single slot, JSON file on
+ * disk, same shape as the old dashboard's `BuildSourceStore`. This lives on
+ * the orchestrator (not per-client), so it's shared across whichever
+ * clients talk to this orchestrator, matching the old system's behavior of
+ * one shared selection per backend instance.
+ */
+export class BuildSourceStore {
+  private current: BuildSourceRecord = EMPTY_RECORD;
+
+  constructor(private readonly path: string) {}
+
+  async load(): Promise<void> {
+    try {
+      const raw = await readFile(this.path, "utf-8");
+      this.current = JSON.parse(raw) as BuildSourceRecord;
+    } catch {
+      this.current = EMPTY_RECORD;
+    }
+  }
+
+  private async save(): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true });
+    await writeFile(this.path, JSON.stringify(this.current, null, 2), "utf-8");
+  }
+
+  get(): BuildSourceRecord & { summary: string } {
+    return { ...this.current, summary: summarize(this.current) };
+  }
+
+  async setGithub(record: Omit<BuildSourceRecord, "kind" | "fleetFile" | "updatedAt">): Promise<void> {
+    this.current = {
+      ...record,
+      kind: "github",
+      fleetFile: this.current.fleetFile,
+      updatedAt: new Date().toISOString(),
+    };
+    await this.save();
+  }
+
+  async setLocalArtifact(artifactName: string, localArtifactPath: string, sizeBytes: number): Promise<void> {
+    this.current = {
+      kind: "local_artifact",
+      artifactName,
+      localArtifactPath,
+      localArtifactSizeBytes: sizeBytes,
+      fleetFile: this.current.fleetFile,
+      updatedAt: new Date().toISOString(),
+    };
+    await this.save();
+  }
+
+  async setLocalCodebase(codebaseRoot: string): Promise<void> {
+    this.current = {
+      kind: "local_codebase",
+      codebaseRoot,
+      fleetFile: this.current.fleetFile,
+      updatedAt: new Date().toISOString(),
+    };
+    await this.save();
+  }
+
+  async setFleetFile(fleetFile: string): Promise<void> {
+    this.current = { ...this.current, fleetFile, updatedAt: new Date().toISOString() };
+    await this.save();
+  }
+
+  async clear(): Promise<void> {
+    this.current = { kind: "none", updatedAt: new Date().toISOString() };
+    await this.save();
+  }
+}

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/build-source-store.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/build-source-store.ts
@@ -74,36 +74,27 @@ export class BuildSourceStore {
     return { ...this.current, summary: summarize(this.current) };
   }
 
-  async setGithub(record: Omit<BuildSourceRecord, "kind" | "fleetFile" | "updatedAt">): Promise<void> {
-    this.current = {
-      ...record,
-      kind: "github",
-      fleetFile: this.current.fleetFile,
-      updatedAt: new Date().toISOString(),
-    };
+  /** Replaces the record with a new build source, preserving the fleet-file selection across the switch. */
+  private async replaceCurrent(record: Omit<BuildSourceRecord, "fleetFile" | "updatedAt">): Promise<void> {
+    this.current = { ...record, fleetFile: this.current.fleetFile, updatedAt: new Date().toISOString() };
     await this.save();
   }
 
+  async setGithub(record: Omit<BuildSourceRecord, "kind" | "fleetFile" | "updatedAt">): Promise<void> {
+    await this.replaceCurrent({ ...record, kind: "github" });
+  }
+
   async setLocalArtifact(artifactName: string, localArtifactPath: string, sizeBytes: number): Promise<void> {
-    this.current = {
+    await this.replaceCurrent({
       kind: "local_artifact",
       artifactName,
       localArtifactPath,
       localArtifactSizeBytes: sizeBytes,
-      fleetFile: this.current.fleetFile,
-      updatedAt: new Date().toISOString(),
-    };
-    await this.save();
+    });
   }
 
   async setLocalCodebase(codebaseRoot: string): Promise<void> {
-    this.current = {
-      kind: "local_codebase",
-      codebaseRoot,
-      fleetFile: this.current.fleetFile,
-      updatedAt: new Date().toISOString(),
-    };
-    await this.save();
+    await this.replaceCurrent({ kind: "local_codebase", codebaseRoot });
   }
 
   async setFleetFile(fleetFile: string): Promise<void> {

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.malformed-response.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.malformed-response.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { PiAgentClient } from "./pi-agent-client.js";
+import { fetchFleetBoard } from "./fleet-board.js";
+
+/**
+ * `fetchFleetBoard`'s per-Pi fan-out (fleet-board.ts) uses `Promise.all`
+ * (not `allSettled`) across `isHealthy()`/`missionStatus()`/`currentBuild()`,
+ * on the stated assumption that `PiAgentClient`'s own methods already
+ * degrade to a graceful `{success:false, ...}` shape instead of throwing.
+ * If that assumption were wrong, one malformed/weird Pi response would
+ * reject the outer `Promise.all` and wipe the *entire* board -- not just
+ * that one device's row.
+ *
+ * These tests exercise the specific edge the reasoning depends on:
+ * `getJson`'s `await response.json()` call throwing (malformed JSON body)
+ * needs to be caught by `getJson`'s own try/catch rather than propagating.
+ * Reading pi-agent-client.ts confirms `await response.json()` sits *inside*
+ * the try block for every `getJson`-backed method, and `isHealthy()` has its
+ * own independent try/catch -- so the assumption holds. These tests prove
+ * it holds rather than just re-reading the source.
+ */
+
+function malformedJsonFetch(): typeof fetch {
+  return (async () =>
+    new Response("not valid json{{{", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+describe("PiAgentClient resolves gracefully (never rejects) on a malformed JSON body", () => {
+  it("missionStatus() falls back to the unreachable shape instead of rejecting", async () => {
+    const client = new PiAgentClient({ hostname: "x", port: 1, fetchImpl: malformedJsonFetch() });
+    await expect(client.missionStatus()).resolves.toEqual({
+      success: false,
+      running: false,
+      state: "offline",
+      error: "unreachable",
+    });
+  });
+
+  it("currentBuild() falls back to the unreachable shape instead of rejecting", async () => {
+    const client = new PiAgentClient({ hostname: "x", port: 1, fetchImpl: malformedJsonFetch() });
+    await expect(client.currentBuild()).resolves.toEqual({
+      success: false,
+      installed: false,
+      error: "unreachable",
+    });
+  });
+
+  it("isHealthy() resolves false instead of rejecting when fetchImpl itself throws synchronously", async () => {
+    const throwingFetch = (() => {
+      throw new Error("DNS resolution failed");
+    }) as unknown as typeof fetch;
+    const client = new PiAgentClient({ hostname: "x", port: 1, fetchImpl: throwingFetch });
+    await expect(client.isHealthy()).resolves.toBe(false);
+  });
+});
+
+describe("fetchFleetBoard survives a malformed JSON body from one discovered Pi", () => {
+  it("does not reject the whole board when a discovered Pi's /api/mission/status returns malformed JSON", async () => {
+    const fetchImpl = (async (url: Parameters<typeof fetch>[0]) => {
+      const u = String(url);
+      if (u === "http://air-01.local:8090/health") {
+        return new Response(JSON.stringify({ status: "ok" }), { status: 200 });
+      }
+      if (u.startsWith("http://air-01.local:8090/api/mission/status")) {
+        // Malformed body: response.ok is true, but response.json() will throw.
+        return new Response("{not json", { status: 200 });
+      }
+      if (u.startsWith("http://air-01.local:8090/api/deploy/current")) {
+        return new Response(JSON.stringify({ success: true, installed: true, info: "Build 1" }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as typeof fetch;
+
+    // Proves the Promise.all-based fan-out doesn't reject: if it did, this
+    // whole `await` would throw and the test would fail with an unhandled
+    // rejection rather than reaching the assertions below.
+    const result = await fetchFleetBoard({
+      prefixes: ["air"],
+      suffixes: [1],
+      port: 8090,
+      discoveryTimeoutMs: 1000,
+      fetchImpl,
+      piAgentClientFor: (hostname) => new PiAgentClient({ hostname, port: 8090, fetchImpl }),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.devices).toHaveLength(1);
+    expect(result.devices[0].connected).toBe(true);
+    // missionStatus() degraded to the unreachable fallback for this one probe.
+    expect(result.devices[0].runtimeState).toBe("offline");
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.multi-device.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.multi-device.test.ts
@@ -1,0 +1,132 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { buildServer as buildPiAgentServer } from "@pennair/pi-agent";
+import { buildServer as buildOrchestratorServer } from "./index.js";
+
+/**
+ * Every existing fleet-board test (core and orchestrator) exercises exactly
+ * one discovered device. This exercises the real GET /api/fleet/board
+ * endpoint against *two* real local pi-agent instances on different ports,
+ * to check that the board genuinely aggregates multiple devices (not just
+ * fans a single-element array through, and doesn't conflate/overwrite rows)
+ * rather than just relying on synthetic single-device unit tests.
+ *
+ * Note: both real pi-agent instances run in this same Node test process and
+ * therefore share one `process.env` -- pi-agent's own deploy.ts reads
+ * DEPLOY_ROOT fresh per-request via `deployPaths()`, so two instances can't
+ * safely be given two *different* DEPLOY_ROOT values here without a request
+ * race (whichever value is current when each instance's request handler
+ * runs). Both instances are given the same DEPLOY_ROOT/installed release
+ * instead -- what this test is actually checking is aggregation-by-hostname
+ * correctness (two distinct rows, correct per-device connectivity, correct
+ * rolled-up summary counts), not per-device build-state divergence.
+ */
+describe("orchestrator fleet board endpoint against two real local pi-agent instances", () => {
+  let scratchRoot: string;
+  let piAgentA: ReturnType<typeof buildPiAgentServer>;
+  let piAgentB: ReturnType<typeof buildPiAgentServer>;
+  let portA: number;
+  let portB: number;
+  const originalDeployRoot = process.env.DEPLOY_ROOT;
+
+  beforeAll(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "fleet-board-multi-"));
+
+    const releaseDir = join(scratchRoot, "releases", "20260101-000000-test");
+    await mkdir(releaseDir, { recursive: true });
+    await writeFile(join(releaseDir, "RELEASE_METADATA.json"), JSON.stringify({ releaseId: "rel-shared" }), "utf-8");
+    await symlink(releaseDir, join(scratchRoot, "current"));
+    process.env.DEPLOY_ROOT = scratchRoot;
+
+    piAgentA = buildPiAgentServer();
+    await piAgentA.listen({ port: 0, host: "127.0.0.1" });
+    const addressA = piAgentA.server.address();
+    if (typeof addressA === "string" || addressA === null) {
+      throw new Error("expected pi-agent A to listen on a TCP port");
+    }
+    portA = addressA.port;
+
+    piAgentB = buildPiAgentServer();
+    await piAgentB.listen({ port: 0, host: "127.0.0.1" });
+    const addressB = piAgentB.server.address();
+    if (typeof addressB === "string" || addressB === null) {
+      throw new Error("expected pi-agent B to listen on a TCP port");
+    }
+    portB = addressB.port;
+  });
+
+  afterAll(async () => {
+    await piAgentA.close();
+    await piAgentB.close();
+    process.env.DEPLOY_ROOT = originalDeployRoot;
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("aggregates both devices into one board with a correct rolled-up summary", async () => {
+    const hostnameToPort: Record<string, number> = {
+      "air-01.local": portA,
+      "air-02.local": portB,
+    };
+    // Capture the real fetch before stubbing the global -- routedFetch must
+    // call through to it, not recurse into the stub it's about to become.
+    const realFetch = fetch;
+    const routedFetch = (async (url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const original = new URL(String(url));
+      const port = hostnameToPort[original.hostname];
+      if (port === undefined) throw new Error(`no route for ${original.hostname}`);
+      const target = new URL(`${original.pathname}${original.search}`, `http://127.0.0.1:${port}`);
+      return realFetch(target, init);
+    }) as typeof fetch;
+
+    process.env.DISCOVERY_PREFIXES = "air";
+    process.env.DISCOVERY_SUFFIX_MAX = "2";
+    process.env.PI_AGENT_PORT = "8090"; // irrelevant to routing; routedFetch ignores the literal port
+
+    vi.stubGlobal("fetch", routedFetch);
+    try {
+      const orchestrator = buildOrchestratorServer();
+      const response = await orchestrator.inject({ method: "GET", url: "/api/fleet/board" });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.success).toBe(true);
+      expect(body.devices).toHaveLength(2);
+
+      const hostnames = (body.devices as Array<{ hostname: string }>).map((d) => d.hostname).sort();
+      expect(hostnames).toEqual(["air-01.local", "air-02.local"]);
+
+      for (const device of body.devices as Array<{
+        connected: boolean;
+        buildInstalled: boolean;
+        releaseId?: string;
+      }>) {
+        expect(device.connected).toBe(true);
+        expect(device.buildInstalled).toBe(true);
+        expect(device.releaseId).toBe("20260101-000000-test");
+      }
+
+      // Real graceful failure expected: no real systemd/sudo on this dev
+      // machine, so missionStatus() reports state:"error" for both real
+      // pi-agent instances -- neither device is "ready", but both got there
+      // via a genuinely independent round trip, not a value copied across
+      // rows.
+      expect(body.summary).toEqual({
+        totalDevices: 2,
+        connectedDevices: 2,
+        buildInstalledDevices: 2,
+        runningDevices: 0,
+        readyDevices: 0,
+      });
+    } finally {
+      delete process.env.DISCOVERY_PREFIXES;
+      delete process.env.DISCOVERY_SUFFIX_MAX;
+      delete process.env.PI_AGENT_PORT;
+    }
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.test.ts
@@ -119,4 +119,28 @@ describe("fetchFleetBoard", () => {
     expect(result.devices[0].ready).toBe(false);
     expect(result.devices[0].notes).toEqual(["No installed build"]);
   });
+
+  it("forwards fetchImpl into the default per-Pi client when piAgentClientFor isn't supplied", async () => {
+    // Regression test: the default `clientFor` used to construct a bare
+    // `new PiAgentClient({ hostname, port })` with no fetchImpl, so a caller
+    // supplying only fetchImpl (discovery gets faked) would silently fall
+    // through to the real global fetch for the per-Pi probes.
+    const fetchImpl = (async (url: Parameters<typeof fetch>[0]) => {
+      const u = String(url);
+      if (u === "http://air-01.local:8090/health") return jsonResponse({ status: "ok" });
+      if (u.startsWith("http://air-01.local:8090/api/mission/status")) {
+        return jsonResponse({ success: true, running: false, state: "stopped" });
+      }
+      if (u.startsWith("http://air-01.local:8090/api/deploy/current")) {
+        return jsonResponse({ success: true, installed: true, info: "Build 42", releaseId: "rel-1" });
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as typeof fetch;
+
+    // No piAgentClientFor supplied -- exercises the default clientFor path.
+    const result = await fetchFleetBoard({ prefixes: ["air"], suffixes: [1], port: 8090, discoveryTimeoutMs: 1000, fetchImpl });
+
+    expect(result.devices).toHaveLength(1);
+    expect(result.devices[0]).toMatchObject({ connected: true, buildInstalled: true, releaseId: "rel-1" });
+  });
 });

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.test.ts
@@ -120,6 +120,44 @@ describe("fetchFleetBoard", () => {
     expect(result.devices[0].notes).toEqual(["No installed build"]);
   });
 
+  it("dedupes a hostname that discovery returns more than once, rather than double-counting it", async () => {
+    // A duplicated prefix (e.g. misconfigured DISCOVERY_PREFIXES) makes
+    // discoverPis's own candidate cross-product probe and return the same
+    // hostname twice -- fetchFleetBoard must not fan out (or count) it twice.
+    let probeCount = 0;
+    const fetchImpl = (async (url: Parameters<typeof fetch>[0]) => {
+      const u = String(url);
+      if (u === "http://air-01.local:8090/health") {
+        probeCount += 1;
+        return jsonResponse({ status: "ok" });
+      }
+      if (u.startsWith("http://air-01.local:8090/api/mission/status")) {
+        return jsonResponse({ success: true, running: false, state: "stopped" });
+      }
+      if (u.startsWith("http://air-01.local:8090/api/deploy/current")) {
+        return jsonResponse({ success: true, installed: true });
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as typeof fetch;
+
+    const result = await fetchFleetBoard({
+      prefixes: ["air", "air"], // duplicated on purpose
+      suffixes: [1],
+      port: 8090,
+      discoveryTimeoutMs: 1000,
+      fetchImpl,
+      piAgentClientFor: (hostname) => new PiAgentClient({ hostname, port: 8090, fetchImpl }),
+    });
+
+    expect(result.devices).toHaveLength(1);
+    expect(result.summary.totalDevices).toBe(1);
+    // 2 discovery /health probes (one per duplicated candidate -- discovery
+    // itself isn't deduped) + 1 more from fetchFleetBoard's own isHealthy()
+    // fan-out for the single deduped device -- not 2 fan-out calls, which
+    // would mean the board fanned out to the same Pi twice.
+    expect(probeCount).toBe(3);
+  });
+
   it("forwards fetchImpl into the default per-Pi client when piAgentClientFor isn't supplied", async () => {
     // Regression test: the default `clientFor` used to construct a bare
     // `new PiAgentClient({ hostname, port })` with no fetchImpl, so a caller

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { PiAgentClient } from "./pi-agent-client.js";
+import { fetchFleetBoard } from "./fleet-board.js";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+describe("fetchFleetBoard", () => {
+  it("discovers Pis and fans out health/mission/build probes into a board with a summary", async () => {
+    const fetchImpl = (async (url: Parameters<typeof fetch>[0]) => {
+      const u = String(url);
+      if (u === "http://air-01.local:8090/health") return jsonResponse({ status: "ok" });
+      if (u === "http://air-02.local:8090/health") throw new Error("unreachable");
+      if (u.startsWith("http://air-01.local:8090/api/mission/status")) {
+        return jsonResponse({ success: true, running: false, state: "stopped" });
+      }
+      if (u.startsWith("http://air-01.local:8090/api/deploy/current")) {
+        return jsonResponse({ success: true, installed: true, info: "Build 42", releaseId: "rel-1" });
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as typeof fetch;
+
+    const result = await fetchFleetBoard({
+      prefixes: ["air"],
+      suffixes: [1, 2],
+      port: 8090,
+      discoveryTimeoutMs: 1000,
+      fetchImpl,
+      piAgentClientFor: (hostname) => new PiAgentClient({ hostname, port: 8090, fetchImpl }),
+    });
+
+    expect(result.success).toBe(true);
+    // Only air-01 is discovered -- air-02's /health probe throws.
+    expect(result.devices).toHaveLength(1);
+    expect(result.devices[0]).toMatchObject({
+      hostname: "air-01.local",
+      connected: true,
+      buildInstalled: true,
+      releaseId: "rel-1",
+      buildInfo: "Build 42",
+      runtimeState: "stopped",
+      runtimeRunning: false,
+      ready: true,
+      notes: [],
+    });
+    expect(result.summary).toEqual({
+      totalDevices: 1,
+      connectedDevices: 1,
+      buildInstalledDevices: 1,
+      runningDevices: 0,
+      readyDevices: 1,
+    });
+  });
+
+  it("returns an empty board when nothing is discovered", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("unreachable");
+    }) as typeof fetch;
+
+    const result = await fetchFleetBoard({ prefixes: ["air"], suffixes: [1], port: 8090, discoveryTimeoutMs: 1000, fetchImpl });
+
+    expect(result).toEqual({
+      success: true,
+      devices: [],
+      summary: { totalDevices: 0, connectedDevices: 0, buildInstalledDevices: 0, runningDevices: 0, readyDevices: 0 },
+    });
+  });
+
+  it("includes a discovered-but-since-unreachable Pi as a not-ready row rather than failing the whole board", async () => {
+    const discoveryFetch = (async (url: Parameters<typeof fetch>[0]) => {
+      if (String(url) === "http://air-01.local:8090/health") return jsonResponse({ status: "ok" });
+      throw new Error("unreachable");
+    }) as typeof fetch;
+    const piAgentFetch = (async () => {
+      throw new Error("connection refused");
+    }) as typeof fetch;
+
+    const result = await fetchFleetBoard({
+      prefixes: ["air"],
+      suffixes: [1],
+      port: 8090,
+      discoveryTimeoutMs: 1000,
+      fetchImpl: discoveryFetch,
+      piAgentClientFor: (hostname) => new PiAgentClient({ hostname, port: 8090, fetchImpl: piAgentFetch }),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.devices).toHaveLength(1);
+    expect(result.devices[0].connected).toBe(false);
+    expect(result.devices[0].ready).toBe(false);
+    expect(result.devices[0].notes).toContain("Pi unreachable");
+  });
+
+  it("marks a connected Pi with no installed build as not ready, with a clear note", async () => {
+    const fetchImpl = (async (url: Parameters<typeof fetch>[0]) => {
+      const u = String(url);
+      if (u === "http://air-01.local:8090/health") return jsonResponse({ status: "ok" });
+      if (u.startsWith("http://air-01.local:8090/api/mission/status")) {
+        return jsonResponse({ success: true, running: false, state: "not_prepared" });
+      }
+      if (u.startsWith("http://air-01.local:8090/api/deploy/current")) {
+        return jsonResponse({ success: true, installed: false });
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as typeof fetch;
+
+    const result = await fetchFleetBoard({
+      prefixes: ["air"],
+      suffixes: [1],
+      port: 8090,
+      discoveryTimeoutMs: 1000,
+      fetchImpl,
+      piAgentClientFor: (hostname) => new PiAgentClient({ hostname, port: 8090, fetchImpl }),
+    });
+
+    expect(result.devices[0].connected).toBe(true);
+    expect(result.devices[0].buildInstalled).toBe(false);
+    expect(result.devices[0].ready).toBe(false);
+    expect(result.devices[0].notes).toEqual(["No installed build"]);
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.ts
@@ -1,0 +1,75 @@
+import { computeFleetReadiness, discoverPis, summarizeFleetBoard, type FleetBoardDevice, type FleetBoardResult } from "@pennair/integration-core";
+import { PiAgentClient } from "./pi-agent-client.js";
+
+export interface FetchFleetBoardOptions {
+  prefixes: string[];
+  suffixes: number[];
+  port: number;
+  discoveryTimeoutMs: number;
+  fetchImpl?: typeof fetch;
+  piAgentClientFor?: (hostname: string) => PiAgentClient;
+}
+
+/**
+ * Mirrors the old dashboard's `fleet.py`'s `get_board()` -- discovers every
+ * reachable Pi, then fans out a 3-way probe per Pi (health/mission-status/
+ * current-build) in parallel, same shape as the old board's per-device
+ * `_summarize_device` (health check + `launch_status` + `current_build`).
+ * A single unreachable Pi can't fail the whole board: PiAgentClient's own
+ * methods already degrade to a graceful `{success:false, ...}` shape on
+ * failure/timeout rather than throwing, so `Promise.all` per device is safe
+ * without needing `allSettled` -- matches the old board's "per-row failure
+ * doesn't fail the board" behavior for free.
+ *
+ * Deliberately excludes wifi status (unlike a natural "show everything"
+ * urge might suggest): wifi's worst-case relay timeout is up to 35s, and
+ * fanning that out across a whole fleet on every board refresh would make
+ * one unreachable/slow Pi visibly stall the board -- a bad tradeoff against
+ * this project's explicit low-latency priority. Also excludes fleet-YAML
+ * vehicle-assignment cross-referencing (the old board's `vehicle_assigned`
+ * readiness criterion) -- that needs a parsed fleet-vehicle-preview layer
+ * that doesn't exist yet in this rewrite; scoped out of Phase 5, not
+ * silently dropped.
+ */
+export async function fetchFleetBoard(options: FetchFleetBoardOptions): Promise<FleetBoardResult> {
+  const pis = await discoverPis({
+    prefixes: options.prefixes,
+    suffixes: options.suffixes,
+    port: options.port,
+    timeoutMs: options.discoveryTimeoutMs,
+    fetchImpl: options.fetchImpl,
+  });
+
+  const clientFor = options.piAgentClientFor ?? ((hostname: string) => new PiAgentClient({ hostname, port: options.port }));
+
+  const devices: FleetBoardDevice[] = await Promise.all(
+    pis.map(async (pi) => {
+      const client = clientFor(pi.hostname);
+      const [connected, missionStatus, currentBuild] = await Promise.all([
+        client.isHealthy(),
+        client.missionStatus(),
+        client.currentBuild(),
+      ]);
+
+      const readiness = computeFleetReadiness({
+        connected,
+        buildInstalled: currentBuild.installed,
+        runtimeState: missionStatus.state,
+      });
+
+      return {
+        hostname: pi.hostname,
+        connected,
+        buildInstalled: currentBuild.installed,
+        releaseId: currentBuild.releaseId,
+        buildInfo: currentBuild.info,
+        runtimeState: missionStatus.state,
+        runtimeRunning: missionStatus.running,
+        ready: readiness.ready,
+        notes: readiness.notes,
+      };
+    }),
+  );
+
+  return { success: true, devices, summary: summarizeFleetBoard(devices) };
+}

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.ts
@@ -32,12 +32,22 @@ export interface FetchFleetBoardOptions {
  * silently dropped.
  */
 export async function fetchFleetBoard(options: FetchFleetBoardOptions): Promise<FleetBoardResult> {
-  const pis = await discoverPis({
+  const discovered = await discoverPis({
     prefixes: options.prefixes,
     suffixes: options.suffixes,
     port: options.port,
     timeoutMs: options.discoveryTimeoutMs,
     fetchImpl: options.fetchImpl,
+  });
+  // Defense in depth against a duplicate hostname reaching the board (e.g. a
+  // misconfigured DISCOVERY_PREFIXES) -- summarizeFleetBoard has no
+  // uniqueness safeguard of its own (it just counts whatever it's given), so
+  // dedupe at the source, which also avoids probing the same Pi twice.
+  const seen = new Set<string>();
+  const pis = discovered.filter((pi) => {
+    if (seen.has(pi.hostname)) return false;
+    seen.add(pi.hostname);
+    return true;
   });
 
   // Forward fetchImpl into the default client too -- a caller supplying

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-board.ts
@@ -40,7 +40,13 @@ export async function fetchFleetBoard(options: FetchFleetBoardOptions): Promise<
     fetchImpl: options.fetchImpl,
   });
 
-  const clientFor = options.piAgentClientFor ?? ((hostname: string) => new PiAgentClient({ hostname, port: options.port }));
+  // Forward fetchImpl into the default client too -- a caller supplying
+  // only fetchImpl (without also supplying piAgentClientFor) would
+  // otherwise get discovery faked but the per-Pi probes silently falling
+  // through to the real global fetch.
+  const clientFor =
+    options.piAgentClientFor ??
+    ((hostname: string) => new PiAgentClient({ hostname, port: options.port, fetchImpl: options.fetchImpl }));
 
   const devices: FleetBoardDevice[] = await Promise.all(
     pis.map(async (pi) => {

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-catalog-cache-staleness.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-catalog-cache-staleness.test.ts
@@ -1,0 +1,79 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as tar from "tar";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { BuildSourceRecord } from "./build-source-store.js";
+import { resolveFleetCatalog } from "./fleet-catalog.js";
+
+async function buildArtifactWithFleet(dir: string, artifactPath: string, fleetName: string, marker: string) {
+  const stagingDir = join(dir, `staging-${marker}`);
+  await mkdir(join(stagingDir, "uav", "fleets"), { recursive: true });
+  await writeFile(join(stagingDir, "uav", "fleets", fleetName), `marker: ${marker}`, "utf-8");
+  await tar.c({ file: artifactPath, cwd: stagingDir, gzip: true }, ["uav"]);
+}
+
+/**
+ * Regression test for a stale on-disk extraction cache in
+ * resolveFleetCatalog (packages/orchestrator/src/fleet-catalog.ts).
+ *
+ * `catalogCacheKey` for a `local_artifact` record is derived only from
+ * `record.localArtifactPath` -- the on-disk path the orchestrator saved the
+ * uploaded file to. But that path is stable across repeated uploads of a
+ * file with the same name: `POST /api/deploy/source/local-artifact`
+ * (packages/orchestrator/src/index.ts) always saves to
+ * `join(artifactDir, part.filename)` and overwrites whatever was already
+ * there. Re-uploading a *different* local build under an unchanged filename
+ * (an extremely normal workflow -- operators iterating locally tend to keep
+ * re-exporting "build.tar.gz") used to reuse the exact same cache key and
+ * extractDir, treated as still valid purely because the directory existed on
+ * disk, regardless of whether the archive backing it had since changed.
+ * Fixed by fingerprinting the artifact file (size+mtime) and re-extracting
+ * whenever it no longer matches the fingerprint recorded at extraction time.
+ */
+describe("resolveFleetCatalog extraction cache for local_artifact", () => {
+  let scratchDir: string;
+  let cacheRoot: string;
+  let artifactDir: string;
+
+  beforeEach(async () => {
+    scratchDir = await mkdtemp(join(tmpdir(), "fleet-catalog-stale-cache-test-"));
+    cacheRoot = join(scratchDir, "cache");
+    artifactDir = join(scratchDir, "local-artifacts");
+    await mkdir(artifactDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(scratchDir, { recursive: true, force: true });
+  });
+
+  it("keeps serving the first upload's fleet catalog after a same-named re-upload replaces the archive on disk", async () => {
+    // Mirrors the real upload flow: the orchestrator always writes to
+    // artifactDir/<filename>, overwriting on a repeat upload of the same name.
+    const artifactPath = join(artifactDir, "build.tar.gz");
+
+    await buildArtifactWithFleet(scratchDir, artifactPath, "example_fleet.yaml", "v1");
+    const record: BuildSourceRecord = {
+      kind: "local_artifact",
+      artifactName: "build.tar.gz",
+      localArtifactPath: artifactPath,
+    };
+
+    const first = await resolveFleetCatalog({ record, cacheRoot });
+    expect(first.error).toBeNull();
+    const firstFleetPath = first.catalog["example_fleet.yaml"];
+    expect(firstFleetPath).toBeTruthy();
+    const { readFile } = await import("node:fs/promises");
+    expect(await readFile(firstFleetPath, "utf-8")).toContain("v1");
+
+    // Operator re-uploads a DIFFERENT build under the SAME filename -- the
+    // real endpoint overwrites artifactPath in place, same as here.
+    await buildArtifactWithFleet(scratchDir, artifactPath, "example_fleet.yaml", "v2-DIFFERENT-BUILD");
+
+    const second = await resolveFleetCatalog({ record, cacheRoot });
+    const secondFleetPath = second.catalog["example_fleet.yaml"];
+    const secondContent = await readFile(secondFleetPath, "utf-8");
+
+    expect(secondContent).toContain("v2-DIFFERENT-BUILD");
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-catalog.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-catalog.test.ts
@@ -1,0 +1,154 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as tar from "tar";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { BuildSourceRecord } from "./build-source-store.js";
+import { catalogYamlPaths, fleetCatalogLookupFromPaths, resolveFleetCatalog } from "./fleet-catalog.js";
+
+describe("catalogYamlPaths / fleetCatalogLookupFromPaths", () => {
+  let scratchDir: string;
+
+  beforeEach(async () => {
+    scratchDir = await mkdtemp(join(tmpdir(), "fleet-catalog-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(scratchDir, { recursive: true, force: true });
+  });
+
+  it("finds yaml files only under a 'fleets' path segment", async () => {
+    await mkdir(join(scratchDir, "uav", "fleets"), { recursive: true });
+    await mkdir(join(scratchDir, "uav", "missions"), { recursive: true });
+    await writeFile(join(scratchDir, "uav", "fleets", "example_fleet.yaml"), "vehicles: []", "utf-8");
+    await writeFile(join(scratchDir, "uav", "missions", "not_a_fleet.yaml"), "steps: []", "utf-8");
+
+    const paths = await catalogYamlPaths(scratchDir);
+    expect(paths).toHaveLength(1);
+    expect(paths[0]).toMatch(/example_fleet\.yaml$/);
+  });
+
+  it("prefers the installed install/uav/share/uav/fleets copy over a bare uav/fleets copy", async () => {
+    await mkdir(join(scratchDir, "install", "uav", "share", "uav", "fleets"), { recursive: true });
+    await mkdir(join(scratchDir, "uav", "fleets"), { recursive: true });
+    await writeFile(join(scratchDir, "install", "uav", "share", "uav", "fleets", "example_fleet.yaml"), "installed", "utf-8");
+    await writeFile(join(scratchDir, "uav", "fleets", "example_fleet.yaml"), "bare", "utf-8");
+
+    const paths = await catalogYamlPaths(scratchDir);
+    const catalog = fleetCatalogLookupFromPaths(paths);
+    expect(Object.keys(catalog)).toEqual(["example_fleet.yaml"]);
+    expect(catalog["example_fleet.yaml"]).toContain(join("install", "uav", "share", "uav", "fleets"));
+  });
+
+  it("prefers src/uav/uav/fleets over a bare uav/fleets copy", async () => {
+    await mkdir(join(scratchDir, "src", "uav", "uav", "fleets"), { recursive: true });
+    await mkdir(join(scratchDir, "uav", "fleets"), { recursive: true });
+    await writeFile(join(scratchDir, "src", "uav", "uav", "fleets", "example_fleet.yaml"), "src copy", "utf-8");
+    await writeFile(join(scratchDir, "uav", "fleets", "example_fleet.yaml"), "bare copy", "utf-8");
+
+    const catalog = fleetCatalogLookupFromPaths(await catalogYamlPaths(scratchDir));
+    expect(catalog["example_fleet.yaml"]).toContain(join("src", "uav", "uav", "fleets"));
+  });
+});
+
+describe("resolveFleetCatalog", () => {
+  let scratchDir: string;
+  let cacheRoot: string;
+
+  beforeEach(async () => {
+    scratchDir = await mkdtemp(join(tmpdir(), "fleet-catalog-resolve-test-"));
+    cacheRoot = join(scratchDir, "cache");
+  });
+
+  afterEach(async () => {
+    await rm(scratchDir, { recursive: true, force: true });
+  });
+
+  it("returns an empty catalog for kind:none", async () => {
+    const result = await resolveFleetCatalog({ record: { kind: "none" }, cacheRoot });
+    expect(result).toEqual({ catalog: {}, source: null, error: null });
+  });
+
+  it("reads directly from disk for kind:local_codebase", async () => {
+    const codebaseRoot = join(scratchDir, "repo");
+    await mkdir(join(codebaseRoot, "src", "uav", "uav", "fleets"), { recursive: true });
+    await writeFile(join(codebaseRoot, "src", "uav", "uav", "fleets", "example_fleet.yaml"), "vehicles: []", "utf-8");
+
+    const record: BuildSourceRecord = { kind: "local_codebase", codebaseRoot };
+    const result = await resolveFleetCatalog({ record, cacheRoot });
+    expect(result.error).toBeNull();
+    expect(Object.keys(result.catalog)).toEqual(["example_fleet.yaml"]);
+  });
+
+  it("extracts a local .tar.gz artifact and caches the extraction on disk", async () => {
+    const stagingDir = join(scratchDir, "staging");
+    await mkdir(join(stagingDir, "install", "uav", "share", "uav", "fleets"), { recursive: true });
+    await writeFile(join(stagingDir, "install", "uav", "share", "uav", "fleets", "example_fleet.yaml"), "vehicles: []", "utf-8");
+    await writeFile(join(stagingDir, "install", "README.txt"), "not yaml", "utf-8");
+    const artifactPath = join(scratchDir, "artifact.tar.gz");
+    await tar.c({ file: artifactPath, cwd: stagingDir, gzip: true }, ["install"]);
+
+    const record: BuildSourceRecord = { kind: "local_artifact", artifactName: "artifact.tar.gz", localArtifactPath: artifactPath };
+    const first = await resolveFleetCatalog({ record, cacheRoot });
+    expect(first.error).toBeNull();
+    expect(Object.keys(first.catalog)).toEqual(["example_fleet.yaml"]);
+
+    // Second call should reuse the already-extracted cache dir rather than re-extracting.
+    const second = await resolveFleetCatalog({ record, cacheRoot });
+    expect(second).toEqual(first);
+  });
+
+  it("reports a clear error when the selected local artifact no longer exists", async () => {
+    const record: BuildSourceRecord = {
+      kind: "local_artifact",
+      artifactName: "gone.tar.gz",
+      localArtifactPath: join(scratchDir, "gone.tar.gz"),
+    };
+    const result = await resolveFleetCatalog({ record, cacheRoot });
+    expect(result.catalog).toEqual({});
+    expect(result.error).toMatch(/no longer exists/);
+  });
+
+  it("downloads and extracts a github release archive via the injected fetch", async () => {
+    const stagingDir = join(scratchDir, "staging");
+    await mkdir(join(stagingDir, "uav", "fleets"), { recursive: true });
+    await writeFile(join(stagingDir, "uav", "fleets", "example_fleet.yaml"), "vehicles: []", "utf-8");
+    const artifactPath = join(scratchDir, "release.tar.gz");
+    await tar.c({ file: artifactPath, cwd: stagingDir, gzip: true }, ["uav"]);
+    const archiveBytes = await import("node:fs/promises").then((fs) => fs.readFile(artifactPath));
+
+    let fetchCalls = 0;
+    const fetchImpl = (async () => {
+      fetchCalls += 1;
+      return new Response(archiveBytes);
+    }) as typeof fetch;
+
+    const record: BuildSourceRecord = {
+      kind: "github",
+      githubSource: "release",
+      tag: "build-7",
+      downloadUrl: "https://example.com/build-7.tar.gz",
+    };
+    const result = await resolveFleetCatalog({ record, cacheRoot, fetchImpl });
+    expect(result.error).toBeNull();
+    expect(Object.keys(result.catalog)).toEqual(["example_fleet.yaml"]);
+    expect(fetchCalls).toBe(1);
+
+    await resolveFleetCatalog({ record, cacheRoot, fetchImpl });
+    expect(fetchCalls).toBe(1); // second call reused the on-disk extract cache
+  });
+
+  it("explicitly refuses .zip github actions artifacts rather than silently returning empty", async () => {
+    const record: BuildSourceRecord = { kind: "github", githubSource: "actions", artifactId: "55" };
+    const result = await resolveFleetCatalog({ record, cacheRoot });
+    expect(result.catalog).toEqual({});
+    expect(result.error).toMatch(/aren't supported/);
+  });
+
+  it("errors when a github release source has no download URL", async () => {
+    const record: BuildSourceRecord = { kind: "github", githubSource: "release", tag: "build-8" };
+    const result = await resolveFleetCatalog({ record, cacheRoot });
+    expect(result.catalog).toEqual({});
+    expect(result.error).toMatch(/does not expose a download URL/);
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-catalog.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-catalog.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile } from "node:fs/promises";
+import { access, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { createWriteStream } from "node:fs";
 import { pipeline } from "node:stream/promises";
 import { Readable } from "node:stream";
@@ -32,12 +32,17 @@ export interface ResolveFleetCatalogOptions {
 
 async function pathExists(path: string): Promise<boolean> {
   try {
-    await readFile(path);
+    await access(path);
     return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "EISDIR") return true;
+  } catch {
     return false;
   }
+}
+
+/** size+mtime fingerprint, cheap to compute, good enough to detect a re-upload replacing the file at the same path. */
+async function archiveFingerprint(path: string): Promise<string> {
+  const stats = await stat(path);
+  return `${stats.size}-${stats.mtimeMs}`;
 }
 
 function isFleetYamlMember(memberName: string): boolean {
@@ -174,10 +179,22 @@ export async function resolveFleetCatalog(options: ResolveFleetCatalogOptions): 
     if (!(await pathExists(artifactPath))) {
       return { catalog: {}, source: artifactPath, error: "Selected local artifact no longer exists." };
     }
-    const extractDir = join(options.cacheRoot, catalogCacheKey(record), "extract");
+    const catalogDir = join(options.cacheRoot, catalogCacheKey(record));
+    const extractDir = join(catalogDir, "extract");
+    const fingerprintPath = join(catalogDir, "source.fingerprint");
     try {
-      if (!(await pathExists(extractDir))) {
+      // The cache key is the saved artifact's path, which stays the same
+      // across repeat uploads of a same-named file (a very normal workflow
+      // when iterating locally) -- an existing extractDir alone isn't proof
+      // it still matches the *current* file on disk, so re-extract whenever
+      // the file's size/mtime has changed since the cached extraction.
+      const currentFingerprint = await archiveFingerprint(artifactPath);
+      const previousFingerprint = await readFile(fingerprintPath, "utf-8").catch(() => null);
+      if (previousFingerprint !== currentFingerprint) {
+        await rm(extractDir, { recursive: true, force: true });
         await extractFleetYamlFromTarGz(artifactPath, extractDir);
+        await mkdir(catalogDir, { recursive: true });
+        await writeFile(fingerprintPath, currentFingerprint, "utf-8");
       }
       const paths = await catalogYamlPaths(extractDir);
       return { catalog: fleetCatalogLookupFromPaths(paths), source: artifactPath, error: null };

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-catalog.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/fleet-catalog.ts
@@ -1,0 +1,225 @@
+import { mkdir, readdir, readFile } from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+import { join, resolve as resolvePath, sep } from "node:path";
+import * as tar from "tar";
+import type { BuildSourceRecord } from "./build-source-store.js";
+
+export interface FleetCatalogResult {
+  catalog: Record<string, string>;
+  source: string | null;
+  error: string | null;
+}
+
+export interface ResolveFleetCatalogOptions {
+  record: BuildSourceRecord;
+  cacheRoot: string;
+  githubToken?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Fleet-catalog resolution here is intentionally scoped down from the old
+ * dashboard's `deploy.py`: only .tar.gz bundles (GitHub release assets,
+ * uploaded local artifacts) are extracted -- GitHub Actions artifacts are
+ * .zip and aren't supported for catalog resolution (or for pi-agent deploy,
+ * which also only extracts .tar.gz), and archive-nested-inside-archive
+ * recursion isn't implemented. Both are uncommon paths in practice (day-to-day
+ * deploys use release builds); a release build source is what should be used
+ * for source bundles containing nested archives.
+ */
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await readFile(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EISDIR") return true;
+    return false;
+  }
+}
+
+function isFleetYamlMember(memberName: string): boolean {
+  const normalized = memberName.replace(/\\/g, "/").toLowerCase();
+  return normalized.includes("/fleets/") && (normalized.endsWith(".yaml") || normalized.endsWith(".yml"));
+}
+
+async function walkYamlFiles(root: string): Promise<string[]> {
+  const results: string[] = [];
+  async function walk(dir: string): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile() && (entry.name.endsWith(".yaml") || entry.name.endsWith(".yml"))) {
+        results.push(full);
+      }
+    }
+  }
+  await walk(root);
+  return results;
+}
+
+/** Mirrors `_catalog_yaml_paths`: yaml files anywhere under a path segment named "fleets" (case-insensitive). */
+export async function catalogYamlPaths(root: string): Promise<string[]> {
+  const allYaml = await walkYamlFiles(root);
+  return allYaml
+    .filter((path) => path.split(sep).some((part) => part.toLowerCase() === "fleets"))
+    .map((path) => resolvePath(path))
+    .sort();
+}
+
+function pathEndsWithParts(path: string, suffixParts: string[]): boolean {
+  const parts = path.split(sep).map((p) => p.toLowerCase());
+  if (parts.length < suffixParts.length) return false;
+  const tail = parts.slice(parts.length - suffixParts.length);
+  return tail.every((part, i) => part === suffixParts[i]);
+}
+
+/** Mirrors `_fleet_catalog_candidate_key`: prefer the installed share/ copy over src/ over a bare fleets/ dir. */
+function fleetCatalogCandidateKey(path: string): [number, number, number, string] {
+  const fleetFile = path.split(sep).pop()!.toLowerCase();
+  let rank: number;
+  if (pathEndsWithParts(path, ["install", "uav", "share", "uav", "fleets", fleetFile])) {
+    rank = 0;
+  } else if (pathEndsWithParts(path, ["src", "uav", "uav", "fleets", fleetFile])) {
+    rank = 1;
+  } else if (pathEndsWithParts(path, ["uav", "fleets", fleetFile])) {
+    rank = 2;
+  } else {
+    rank = 3;
+  }
+  return [rank, path.split(sep).length, path.length, path];
+}
+
+function compareCandidateKeys(a: [number, number, number, string], b: [number, number, number, string]): number {
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] < b[i]) return -1;
+    if (a[i] > b[i]) return 1;
+  }
+  return 0;
+}
+
+/** Mirrors `_fleet_catalog_lookup_from_paths`: collapse duplicate copies of the same filename to the best-ranked one. */
+export function fleetCatalogLookupFromPaths(paths: string[]): Record<string, string> {
+  const candidates = new Map<string, Set<string>>();
+  for (const path of paths) {
+    const fleetFile = path.split(sep).pop()?.trim();
+    if (!fleetFile) continue;
+    const resolved = resolvePath(path);
+    if (!candidates.has(fleetFile)) candidates.set(fleetFile, new Set());
+    candidates.get(fleetFile)!.add(resolved);
+  }
+  const catalog: Record<string, string> = {};
+  for (const [fleetFile, fleetPaths] of candidates) {
+    const best = [...fleetPaths].sort((a, b) => compareCandidateKeys(fleetCatalogCandidateKey(a), fleetCatalogCandidateKey(b)))[0];
+    catalog[fleetFile] = best;
+  }
+  return Object.fromEntries(Object.entries(catalog).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+}
+
+async function extractFleetYamlFromTarGz(archivePath: string, extractDir: string): Promise<void> {
+  await mkdir(extractDir, { recursive: true });
+  await tar.x({
+    file: archivePath,
+    cwd: extractDir,
+    filter: (entryPath) => isFleetYamlMember(entryPath),
+  });
+}
+
+function catalogCacheKey(record: BuildSourceRecord): string {
+  if (record.kind === "github") {
+    return `github-${record.githubSource}-${record.tag ?? record.runId ?? record.artifactId ?? "unknown"}`;
+  }
+  if (record.kind === "local_artifact") {
+    return `local-artifact-${record.localArtifactPath ?? "unknown"}`;
+  }
+  return record.kind;
+}
+
+/**
+ * Resolves the set of fleet YAML files available from whichever build source
+ * is currently selected. Persists extracted archives under `cacheRoot` keyed
+ * by source identity, so repeated calls for the same selected build don't
+ * re-download/re-extract (a simpler, disk-based analog of the old
+ * dashboard's in-memory TTL+stale-fallback cache).
+ */
+export async function resolveFleetCatalog(options: ResolveFleetCatalogOptions): Promise<FleetCatalogResult> {
+  const { record } = options;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  if (record.kind === "none") {
+    return { catalog: {}, source: null, error: null };
+  }
+
+  if (record.kind === "local_codebase") {
+    const root = join(record.codebaseRoot ?? "", "src", "uav", "uav", "fleets");
+    try {
+      const paths = await catalogYamlPaths(root);
+      return { catalog: fleetCatalogLookupFromPaths(paths), source: root, error: null };
+    } catch (error) {
+      return { catalog: {}, source: root, error: (error as Error).message };
+    }
+  }
+
+  if (record.kind === "local_artifact") {
+    const artifactPath = record.localArtifactPath ?? "";
+    if (!(await pathExists(artifactPath))) {
+      return { catalog: {}, source: artifactPath, error: "Selected local artifact no longer exists." };
+    }
+    const extractDir = join(options.cacheRoot, catalogCacheKey(record), "extract");
+    try {
+      if (!(await pathExists(extractDir))) {
+        await extractFleetYamlFromTarGz(artifactPath, extractDir);
+      }
+      const paths = await catalogYamlPaths(extractDir);
+      return { catalog: fleetCatalogLookupFromPaths(paths), source: artifactPath, error: null };
+    } catch (error) {
+      return { catalog: {}, source: artifactPath, error: (error as Error).message };
+    }
+  }
+
+  // record.kind === "github"
+  if (record.githubSource === "actions") {
+    return {
+      catalog: {},
+      source: "github",
+      error: "GitHub Actions artifacts are .zip and aren't supported for fleet catalog resolution -- select a GitHub release build instead.",
+    };
+  }
+  if (!record.downloadUrl) {
+    return { catalog: {}, source: "github", error: "Selected GitHub build source does not expose a download URL." };
+  }
+
+  const catalogDir = join(options.cacheRoot, catalogCacheKey(record));
+  const archivePath = join(catalogDir, "archive.tar.gz");
+  const extractDir = join(catalogDir, "extract");
+  try {
+    if (!(await pathExists(extractDir))) {
+      await mkdir(catalogDir, { recursive: true });
+      const headers: Record<string, string> = { Accept: "application/octet-stream" };
+      if (options.githubToken) headers.Authorization = `Bearer ${options.githubToken}`;
+      await ensureDownloadedFile(record.downloadUrl, archivePath, headers, fetchImpl);
+      await extractFleetYamlFromTarGz(archivePath, extractDir);
+    }
+    const paths = await catalogYamlPaths(extractDir);
+    return { catalog: fleetCatalogLookupFromPaths(paths), source: record.downloadUrl, error: null };
+  } catch (error) {
+    return { catalog: {}, source: record.downloadUrl, error: (error as Error).message };
+  }
+}
+
+async function ensureDownloadedFile(url: string, destination: string, headers: Record<string, string>, fetchImpl: typeof fetch): Promise<void> {
+  const response = await fetchImpl(url, { headers });
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download build archive: ${response.status}`);
+  }
+  await pipeline(Readable.fromWeb(response.body as never), createWriteStream(destination));
+}

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/github-builds-pagination.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/github-builds-pagination.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { listBuilds } from "./github-builds.js";
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function artifact(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    name: "ros2-build-uav",
+    size_in_bytes: 2_000_000,
+    updated_at: "2026-01-02T00:00:00Z",
+    archive_download_url: "https://example.com/artifact.zip",
+    workflow_run: { id: 10, head_sha: "deadbeef", head_branch: "main" },
+    ...overrides,
+  };
+}
+
+/** Same fake-fetch shape as github-builds.test.ts, but tracks how many times
+ *  each artifacts page was actually requested, to make the pagination bug
+ *  observable. */
+function fakeFetchTrackingPages(artifactPages: Record<string, unknown>[][]) {
+  const requestedPages: number[] = [];
+  const fetchImpl = (async (input: Parameters<typeof fetch>[0]) => {
+    const url = String(input);
+    if (url.includes("/actions/artifacts")) {
+      const page = Number(new URL(url).searchParams.get("page") ?? "1");
+      requestedPages.push(page);
+      return jsonResponse({ artifacts: artifactPages[page - 1] ?? [] });
+    }
+    if (url.includes("/releases")) return jsonResponse([]);
+    const runMatch = url.match(/\/actions\/runs\/([^/?]+)$/);
+    if (runMatch) return jsonResponse({ id: Number(runMatch[1]), name: "ARM Artifact", event: "push", head_branch: "main", head_sha: "irrelevant" });
+    const commitMatch = url.match(/\/commits\/([^/?]+)$/);
+    if (commitMatch) return jsonResponse({ commit: { message: "irrelevant commit" } });
+    throw new Error(`fakeFetch: unhandled url ${url}`);
+  }) as typeof fetch;
+  return { fetchImpl, requestedPages };
+}
+
+/**
+ * Regression test for a pagination bug in listBuilds/collectArtifacts
+ * (packages/orchestrator/src/github-builds.ts, surfaced through
+ * GET /api/deploy/builds in packages/orchestrator/src/index.ts).
+ *
+ * `collectArtifacts` used to always start at page=1 and accumulate every page
+ * from 1 through the requested page into one `rows` array, so a client
+ * requesting artifactPage=2 got page 1's items concatenated with page 2's --
+ * not just page 2, despite the response shape (artifactPage/artifactPageSize/
+ * artifactHasMore) implying single-page-cursor semantics. Fixed: an
+ * unfiltered request now fetches exactly the requested page (one GitHub
+ * call); a filtered request still has to walk pages looking for matches
+ * (there's no GitHub-side filter to page against), bounded by
+ * MAX_FILTERED_ARTIFACT_PAGES.
+ */
+describe("listBuilds artifact pagination", () => {
+  it("requesting artifactPage 2 returns only page 2's items, not page 1 concatenated with page 2", async () => {
+    const page1 = [artifact({ id: 101, workflow_run: { id: 1001, head_sha: "aaa0001", head_branch: "main" } })];
+    const page2 = [artifact({ id: 102, workflow_run: { id: 1002, head_sha: "aaa0002", head_branch: "main" } })];
+    const { fetchImpl } = fakeFetchTrackingPages([page1, page2]);
+
+    const result = await listBuilds({
+      githubRepo: "acme/repo-pagebug",
+      artifactPage: 2,
+      artifactPageSize: 1,
+      fetchImpl,
+    });
+
+    expect(result.success).toBe(true);
+    const idsReturned = result.artifacts.map((a) => a.artifactId);
+    expect(idsReturned).toEqual(["102"]);
+  });
+
+  it("fetching a given page costs exactly one GitHub request for that page, not a re-fetch of every earlier page", async () => {
+    const page1 = [artifact({ id: 201, workflow_run: { id: 2001, head_sha: "bbb0001", head_branch: "main" } })];
+    const page2 = [artifact({ id: 202, workflow_run: { id: 2002, head_sha: "bbb0002", head_branch: "main" } })];
+    const page3 = [artifact({ id: 203, workflow_run: { id: 2003, head_sha: "bbb0003", head_branch: "main" } })];
+    const { fetchImpl, requestedPages } = fakeFetchTrackingPages([page1, page2, page3]);
+
+    await listBuilds({ githubRepo: "acme/repo-refetch", artifactPage: 3, artifactPageSize: 1, fetchImpl });
+
+    expect(requestedPages).toEqual([3]);
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/github-builds.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/github-builds.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import { listBuilds } from "./github-builds.js";
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function release(overrides: Record<string, unknown> = {}) {
+  return {
+    tag_name: "build-1",
+    name: "Build one",
+    published_at: "2026-01-01T00:00:00Z",
+    body: "",
+    assets: [{ browser_download_url: "https://example.com/a.tar.gz", size: 5_000_000 }],
+    ...overrides,
+  };
+}
+
+function artifact(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    name: "ros2-build-uav",
+    size_in_bytes: 2_000_000,
+    updated_at: "2026-01-02T00:00:00Z",
+    archive_download_url: "https://example.com/artifact.zip",
+    workflow_run: { id: 10, head_sha: "deadbeef", head_branch: "main" },
+    ...overrides,
+  };
+}
+
+/** Builds a fake fetch that dispatches on URL shape, matching the real GitHub REST endpoints this module calls. */
+function fakeFetch(routes: {
+  releases?: Record<string, unknown>[][];
+  artifacts?: Record<string, unknown>[][];
+  commits?: Record<string, string | null>;
+  runs?: Record<string, Record<string, unknown>>;
+  onRequest?: (url: string) => Response | undefined;
+}): typeof fetch {
+  const releasePages = routes.releases ?? [[]];
+  const artifactPages = routes.artifacts ?? [[]];
+
+  return (async (input: Parameters<typeof fetch>[0]) => {
+    const url = String(input);
+    const override = routes.onRequest?.(url);
+    if (override) return override;
+
+    if (url.includes("/releases")) {
+      const page = Number(new URL(url).searchParams.get("page") ?? "1");
+      return jsonResponse(releasePages[page - 1] ?? []);
+    }
+    if (url.includes("/actions/artifacts")) {
+      const page = Number(new URL(url).searchParams.get("page") ?? "1");
+      return jsonResponse({ artifacts: artifactPages[page - 1] ?? [] });
+    }
+    const commitMatch = url.match(/\/commits\/([^/?]+)$/);
+    if (commitMatch) {
+      const sha = commitMatch[1];
+      const subject = routes.commits?.[sha];
+      if (subject === undefined) return jsonResponse({}, { status: 404 });
+      return jsonResponse({ commit: { message: `${subject}\n\nmore detail` } });
+    }
+    const runMatch = url.match(/\/actions\/runs\/([^/?]+)$/);
+    if (runMatch) {
+      const run = routes.runs?.[runMatch[1]];
+      if (!run) return jsonResponse({}, { status: 404 });
+      return jsonResponse(run);
+    }
+    throw new Error(`fakeFetch: unhandled url ${url}`);
+  }) as typeof fetch;
+}
+
+describe("listBuilds", () => {
+  it("reports an error when no repo is configured", async () => {
+    const result = await listBuilds({ githubRepo: "", fetchImpl: fakeFetch({}) });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not configured/);
+  });
+
+  it("only includes releases whose tag starts with build-", async () => {
+    const result = await listBuilds({
+      githubRepo: "acme/repo-tagfilter",
+      fetchImpl: fakeFetch({
+        releases: [[release({ tag_name: "build-9", name: "Nine" }), release({ tag_name: "v1.0.0", name: "Not a build" })]],
+        commits: { "9": "commit nine" },
+      }),
+    });
+    expect(result.success).toBe(true);
+    expect(result.releases).toHaveLength(1);
+    expect(result.releases[0].tag).toBe("build-9");
+  });
+
+  it("filters actions artifacts to deployable ones and excludes fallback by default", async () => {
+    const result = await listBuilds({
+      githubRepo: "acme/repo-artifacts",
+      fetchImpl: fakeFetch({
+        artifacts: [
+          [
+            artifact({ id: 101, name: "ros2-build-uav", workflow_run: { id: 201, head_sha: "aaa1111", head_branch: "main" } }),
+            artifact({ id: 102, name: "ros2-build-fallback-uav", workflow_run: { id: 202, head_sha: "bbb2222", head_branch: "main" } }),
+            artifact({ id: 103, name: "unrelated-artifact", workflow_run: { id: 203, head_sha: "ccc3333", head_branch: "main" } }),
+          ],
+        ],
+        runs: {
+          "201": { id: 201, name: "ARM Artifact", event: "push", conclusion: "success", head_branch: "main", head_sha: "aaa1111" },
+          "202": { id: 202, name: "ARM Fallback", event: "push", conclusion: "success", head_branch: "main", head_sha: "bbb2222" },
+        },
+        commits: { aaa1111: "good commit", bbb2222: "fallback commit" },
+      }),
+    });
+    expect(result.success).toBe(true);
+    expect(result.artifacts.map((a) => a.artifactId)).toEqual(["101"]);
+    expect(result.artifacts[0].fallback).toBe(false);
+  });
+
+  it("includes fallback artifacts when includeFallback is set", async () => {
+    const result = await listBuilds({
+      githubRepo: "acme/repo-includefallback",
+      includeFallback: true,
+      fetchImpl: fakeFetch({
+        artifacts: [
+          [artifact({ id: 201, name: "ros2-build-fallback-uav", workflow_run: { id: 301, head_sha: "fff9999", head_branch: "main" } })],
+        ],
+        runs: { "301": { id: 301, name: "ARM Fallback", event: "push", head_branch: "main", head_sha: "fff9999" } },
+        commits: { fff9999: "fallback build" },
+      }),
+    });
+    expect(result.success).toBe(true);
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.artifacts[0].fallback).toBe(true);
+  });
+
+  it("paginates releases across multiple pages of 100", async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) => release({ tag_name: `build-${i}`, name: `Build ${i}` }));
+    const secondPage = [release({ tag_name: "build-100", name: "Build 100" })];
+    const result = await listBuilds({
+      githubRepo: "acme/repo-paginate",
+      fetchImpl: fakeFetch({
+        releases: [fullPage, secondPage],
+        commits: Object.fromEntries(Array.from({ length: 101 }, (_, i) => [`${i}`, `commit ${i}`])),
+      }),
+    });
+    expect(result.success).toBe(true);
+    expect(result.releases).toHaveLength(101);
+  });
+
+  it("filters combined results by q substring across name/tag/branch", async () => {
+    const result = await listBuilds({
+      githubRepo: "acme/repo-qfilter",
+      q: "special",
+      fetchImpl: fakeFetch({
+        releases: [[release({ tag_name: "build-special", name: "Special build" }), release({ tag_name: "build-plain", name: "Plain build" })]],
+        commits: { special: "special commit", plain: "plain commit" },
+      }),
+    });
+    expect(result.success).toBe(true);
+    expect(result.releases).toHaveLength(1);
+    expect(result.releases[0].tag).toBe("build-special");
+  });
+
+  it("surfaces a rate-limit-specific error message with retry hint on 403", async () => {
+    const result = await listBuilds({
+      githubRepo: "acme/repo-ratelimited",
+      fetchImpl: fakeFetch({
+        onRequest: (url) => {
+          if (url.includes("/releases")) {
+            return new Response(JSON.stringify({ message: "API rate limit exceeded for xxx." }), {
+              status: 403,
+              headers: { "retry-after": "42" },
+            });
+          }
+          return undefined;
+        },
+      }),
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/rate limit/i);
+    expect(result.error).toMatch(/42 seconds/);
+  });
+
+  it("falls back to a stale cached result when the cache has expired and a refresh is rate-limited", async () => {
+    let clock = 0;
+    const now = () => clock;
+
+    const first = await listBuilds({
+      githubRepo: "acme/repo-stalecache",
+      now,
+      fetchImpl: fakeFetch({
+        releases: [[release({ tag_name: "build-stale", name: "Stale build" })]],
+        commits: { stale: "stale commit" },
+      }),
+    });
+    expect(first.success).toBe(true);
+
+    clock += 61_000; // past the 60s TTL, forcing a real refresh attempt
+    const rateLimited = await listBuilds({
+      githubRepo: "acme/repo-stalecache",
+      now,
+      fetchImpl: fakeFetch({
+        onRequest: (url) => {
+          if (url.includes("/releases")) {
+            return new Response(JSON.stringify({ message: "API rate limit exceeded for xxx." }), { status: 403 });
+          }
+          return undefined;
+        },
+      }),
+    });
+    expect(rateLimited.success).toBe(true);
+    expect(rateLimited.error).toMatch(/cached build list/);
+    expect(rateLimited.releases[0].tag).toBe("build-stale");
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/github-builds.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/github-builds.ts
@@ -159,6 +159,39 @@ async function collectReleases(repo: string, headers: Record<string, string>, fe
   return releases;
 }
 
+// A filtered query has no native GitHub-side filter to page against, so it
+// has to walk multiple raw pages looking for matches -- bounded so a plain
+// search-box query can't walk a whole artifact history and exhaust the rate
+// limit on one request.
+const MAX_FILTERED_ARTIFACT_PAGES = 20;
+
+async function fetchArtifactPage(
+  repo: string,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+  artifactPageSize: number,
+  page: number,
+): Promise<Record<string, unknown>[]> {
+  const response = await fetchImpl(
+    `https://api.github.com/repos/${repo}/actions/artifacts?per_page=${artifactPageSize}&page=${page}`,
+    { headers },
+  );
+  if (!response.ok) {
+    throw Object.assign(new Error(`GitHub artifacts request failed: ${response.status}`), { response });
+  }
+  const payload = (await response.json()) as { artifacts?: Record<string, unknown>[] };
+  return payload.artifacts ?? [];
+}
+
+/**
+ * Unfiltered: returns exactly the requested page's raw rows (one GitHub
+ * request), matching normal page-cursor semantics -- a client asking for page
+ * 2 gets page 2, not page 1 concatenated with page 2.
+ *
+ * Filtered: there's no GitHub-side filter to page against, so this walks
+ * pages from the start looking for matches, capped at
+ * MAX_FILTERED_ARTIFACT_PAGES raw pages.
+ */
 async function collectArtifacts(
   repo: string,
   headers: Record<string, string>,
@@ -166,23 +199,19 @@ async function collectArtifacts(
   artifactPageSize: number,
   artifactPage: number,
   filtersActive: boolean,
-) {
-  const rows: Record<string, unknown>[] = [];
-  for (let page = 1; ; page++) {
-    const response = await fetchImpl(
-      `https://api.github.com/repos/${repo}/actions/artifacts?per_page=${artifactPageSize}&page=${page}`,
-      { headers },
-    );
-    if (!response.ok) {
-      throw Object.assign(new Error(`GitHub artifacts request failed: ${response.status}`), { response });
-    }
-    const payload = (await response.json()) as { artifacts?: Record<string, unknown>[] };
-    const pageRows = payload.artifacts ?? [];
-    rows.push(...pageRows);
-    if (pageRows.length === 0 || pageRows.length < artifactPageSize) break;
-    if (!filtersActive && page >= artifactPage) break;
+): Promise<{ rows: Record<string, unknown>[]; hasMore: boolean }> {
+  if (!filtersActive) {
+    const rows = await fetchArtifactPage(repo, headers, fetchImpl, artifactPageSize, artifactPage);
+    return { rows, hasMore: rows.length >= artifactPageSize };
   }
-  return rows;
+
+  const rows: Record<string, unknown>[] = [];
+  for (let page = 1; page <= MAX_FILTERED_ARTIFACT_PAGES; page++) {
+    const pageRows = await fetchArtifactPage(repo, headers, fetchImpl, artifactPageSize, page);
+    rows.push(...pageRows);
+    if (pageRows.length < artifactPageSize) return { rows, hasMore: false };
+  }
+  return { rows, hasMore: true };
 }
 
 async function commitSubjectFor(
@@ -288,10 +317,11 @@ export async function listBuilds(options: ListBuildsOptions): Promise<ListBuilds
   const headers = githubHeaders(options.githubToken);
 
   try {
-    const [rawReleases, rawArtifacts] = await Promise.all([
+    const [rawReleases, artifactPageResult] = await Promise.all([
       collectReleases(options.githubRepo, headers, fetchImpl),
       collectArtifacts(options.githubRepo, headers, fetchImpl, artifactPageSize, artifactPage, filtersActive),
     ]);
+    const { rows: rawArtifacts, hasMore: artifactHasMore } = artifactPageResult;
 
     const releaseRows = rawReleases.filter((r) => String(r.tag_name ?? "").startsWith("build-"));
     const deployableArtifactRows = rawArtifacts.filter(
@@ -374,7 +404,7 @@ export async function listBuilds(options: ListBuildsOptions): Promise<ListBuilds
       artifacts: artifactBuilds,
       artifactPage: filtersActive ? 1 : artifactPage,
       artifactPageSize,
-      artifactHasMore: filtersActive ? false : deployableArtifactRows.length >= artifactPageSize,
+      artifactHasMore,
       error: commitLookupState.message,
     };
     buildListCache.set(key, { at: now(), payload: result });

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/github-builds.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/github-builds.ts
@@ -1,0 +1,403 @@
+export interface BuildListItem {
+  source: "release" | "actions";
+  tag: string;
+  sha: string;
+  commitSha?: string;
+  commitSubject?: string;
+  name: string;
+  date: string;
+  downloadUrl?: string;
+  sizeMb?: number;
+  runId?: string;
+  artifactId?: string;
+  artifactName?: string;
+  branch?: string;
+  workflowName?: string;
+  workflowEvent?: string;
+  workflowConclusion?: string;
+  deployable: boolean;
+  fallback: boolean;
+}
+
+export interface ListBuildsOptions {
+  githubRepo: string;
+  githubToken?: string;
+  artifactPage?: number;
+  artifactPageSize?: number;
+  q?: string;
+  sha?: string;
+  commitSubject?: string;
+  branch?: string;
+  includeFallback?: boolean;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}
+
+export interface ListBuildsResult {
+  success: boolean;
+  builds: BuildListItem[];
+  releases: BuildListItem[];
+  artifacts: BuildListItem[];
+  artifactPage: number;
+  artifactPageSize: number;
+  artifactHasMore: boolean;
+  error?: string;
+}
+
+// -- Caches, matching the old dashboard's module-level TTL caches (this is a
+// single orchestrator process serving one operator, so module-level state is
+// the same shape the old backend used, not a multi-tenant concern). --------
+const BUILD_LIST_CACHE_TTL_MS = 60_000;
+const LOOKUP_CACHE_TTL_MS = 1_800_000; // 30 min
+
+const buildListCache = new Map<string, { at: number; payload: ListBuildsResult }>();
+const commitSubjectCache = new Map<string, { at: number; subject: string | null }>();
+const workflowRunCache = new Map<string, { at: number; payload: Record<string, unknown> | null }>();
+
+function cacheKey(options: ListBuildsOptions): string {
+  return JSON.stringify({
+    repo: options.githubRepo,
+    page: options.artifactPage ?? 1,
+    size: options.artifactPageSize ?? 20,
+    q: (options.q ?? "").trim(),
+    sha: (options.sha ?? "").trim(),
+    commitSubject: (options.commitSubject ?? "").trim(),
+    branch: (options.branch ?? "").trim(),
+    includeFallback: !!options.includeFallback,
+  });
+}
+
+function githubHeaders(token?: string): Record<string, string> {
+  const headers: Record<string, string> = { Accept: "application/vnd.github+json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+/**
+ * Only 403-with-"rate limit" gets special handling (retry-hint parsing,
+ * stale-cache fallback) -- matches the old dashboard exactly: 404/401/5xx/
+ * network errors all just surface as a plain generic failure message.
+ */
+async function githubRateLimitMessage(
+  response: Response,
+  tokenConfigured: boolean,
+  context: "builds" | "commit-lookup" | "cached",
+): Promise<string | null> {
+  if (response.status !== 403) return null;
+  let message = "";
+  try {
+    const payload = (await response.clone().json()) as { message?: string };
+    message = (payload.message ?? "").trim();
+  } catch {
+    message = (await response.clone().text()).trim();
+  }
+  if (!message.toLowerCase().includes("rate limit")) return null;
+
+  let retryHint = "";
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter && /^\d+$/.test(retryAfter)) {
+    retryHint = ` Retry after about ${retryAfter} seconds.`;
+  } else {
+    const resetAt = response.headers.get("x-ratelimit-reset");
+    if (resetAt && /^\d+$/.test(resetAt)) {
+      const resetTime = new Date(Number(resetAt) * 1000).toISOString().replace("T", " ").slice(0, 19);
+      retryHint = ` GitHub resets at ${resetTime} UTC.`;
+    }
+  }
+  const authHint = tokenConfigured
+    ? ""
+    : " Configure a GitHub token for higher limits.";
+
+  if (context === "commit-lookup") {
+    return `GitHub commit-title lookups were rate-limited. Showing available builds with fallback titles.${retryHint}${authHint}`;
+  }
+  if (context === "cached") {
+    return `GitHub API rate limit exceeded. Showing a cached build list.${retryHint}${authHint}`;
+  }
+  return `GitHub API rate limit exceeded while loading deployable builds.${retryHint}${authHint}`;
+}
+
+function isDeployableArtifact(artifact: Record<string, unknown>): boolean {
+  const name = String(artifact.name ?? "").toLowerCase();
+  const workflowRun = (artifact.workflow_run ?? {}) as Record<string, unknown>;
+  const workflowName = String(workflowRun.name ?? "").toLowerCase();
+  return name.startsWith("ros2-build-") || workflowName === "arm artifact" || workflowName === "arm fallback";
+}
+
+function isFallbackArtifact(artifact: Record<string, unknown>): boolean {
+  const name = String(artifact.name ?? "").toLowerCase();
+  const workflowRun = (artifact.workflow_run ?? {}) as Record<string, unknown>;
+  const workflowName = String(workflowRun.name ?? "").toLowerCase();
+  return name.includes("fallback") || workflowName.includes("fallback");
+}
+
+function releaseBodyValue(release: Record<string, unknown>, label: string): string | null {
+  const body = String(release.body ?? "");
+  for (const line of body.split("\n")) {
+    const prefix = `${label}:`;
+    if (line.trim().startsWith(prefix)) {
+      return line.trim().slice(prefix.length).trim();
+    }
+  }
+  return null;
+}
+
+async function collectReleases(repo: string, headers: Record<string, string>, fetchImpl: typeof fetch) {
+  const releases: Record<string, unknown>[] = [];
+  for (let page = 1; ; page++) {
+    const response = await fetchImpl(
+      `https://api.github.com/repos/${repo}/releases?per_page=100&page=${page}`,
+      { headers },
+    );
+    if (!response.ok) {
+      throw Object.assign(new Error(`GitHub releases request failed: ${response.status}`), { response });
+    }
+    const rows = (await response.json()) as Record<string, unknown>[];
+    releases.push(...rows);
+    if (rows.length < 100) break;
+  }
+  return releases;
+}
+
+async function collectArtifacts(
+  repo: string,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+  artifactPageSize: number,
+  artifactPage: number,
+  filtersActive: boolean,
+) {
+  const rows: Record<string, unknown>[] = [];
+  for (let page = 1; ; page++) {
+    const response = await fetchImpl(
+      `https://api.github.com/repos/${repo}/actions/artifacts?per_page=${artifactPageSize}&page=${page}`,
+      { headers },
+    );
+    if (!response.ok) {
+      throw Object.assign(new Error(`GitHub artifacts request failed: ${response.status}`), { response });
+    }
+    const payload = (await response.json()) as { artifacts?: Record<string, unknown>[] };
+    const pageRows = payload.artifacts ?? [];
+    rows.push(...pageRows);
+    if (pageRows.length === 0 || pageRows.length < artifactPageSize) break;
+    if (!filtersActive && page >= artifactPage) break;
+  }
+  return rows;
+}
+
+async function commitSubjectFor(
+  repo: string,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+  sha: string,
+  rateLimited: { hit: boolean; message?: string },
+  now: () => number,
+): Promise<string | null> {
+  if (!sha) return null;
+  const cached = commitSubjectCache.get(sha);
+  if (cached && now() - cached.at < LOOKUP_CACHE_TTL_MS) return cached.subject;
+  if (rateLimited.hit) return null;
+
+  try {
+    const response = await fetchImpl(`https://api.github.com/repos/${repo}/commits/${sha}`, { headers });
+    if (!response.ok) {
+      const message = await githubRateLimitMessage(response, !!headers.Authorization, "commit-lookup");
+      if (message) {
+        rateLimited.hit = true;
+        rateLimited.message = message;
+      }
+      commitSubjectCache.set(sha, { at: now(), subject: null });
+      return null;
+    }
+    const payload = (await response.json()) as { commit?: { message?: string } };
+    const subject = (payload.commit?.message ?? "").split("\n")[0]?.trim() || null;
+    commitSubjectCache.set(sha, { at: now(), subject });
+    return subject;
+  } catch {
+    commitSubjectCache.set(sha, { at: now(), subject: null });
+    return null;
+  }
+}
+
+async function workflowRunFor(
+  repo: string,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+  runId: string,
+  now: () => number,
+): Promise<Record<string, unknown> | null> {
+  const cached = workflowRunCache.get(runId);
+  if (cached && now() - cached.at < LOOKUP_CACHE_TTL_MS) return cached.payload;
+
+  try {
+    const response = await fetchImpl(`https://api.github.com/repos/${repo}/actions/runs/${runId}`, { headers });
+    const payload = response.ok ? ((await response.json()) as Record<string, unknown>) : null;
+    workflowRunCache.set(runId, { at: now(), payload });
+    return payload;
+  } catch {
+    workflowRunCache.set(runId, { at: now(), payload: null });
+    return null;
+  }
+}
+
+function matchesFilters(item: BuildListItem, options: ListBuildsOptions): boolean {
+  if (!options.includeFallback && item.fallback) return false;
+  const lower = (v: string | undefined) => (v ?? "").toLowerCase();
+  if (options.sha && !`${item.sha} ${item.commitSha ?? ""}`.toLowerCase().includes(options.sha.toLowerCase())) {
+    return false;
+  }
+  if (options.commitSubject && !lower(item.commitSubject).includes(options.commitSubject.toLowerCase())) {
+    return false;
+  }
+  if (options.branch && !lower(item.branch).includes(options.branch.toLowerCase())) return false;
+  if (options.q) {
+    const haystack = [item.sha, item.commitSha, item.commitSubject, item.name, item.tag, item.branch, item.workflowName]
+      .map(lower)
+      .join(" ");
+    if (!haystack.includes(options.q.toLowerCase())) return false;
+  }
+  return true;
+}
+
+export async function listBuilds(options: ListBuildsOptions): Promise<ListBuildsResult> {
+  const artifactPage = Math.max(Math.trunc(options.artifactPage ?? 1), 1);
+  const artifactPageSize = Math.max(1, Math.min(Math.trunc(options.artifactPageSize ?? 20), 50));
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? (() => Date.now());
+  const key = cacheKey({ ...options, artifactPage, artifactPageSize });
+
+  if (!options.githubRepo) {
+    return {
+      success: false,
+      error: "GITHUB_REPO not configured",
+      builds: [],
+      releases: [],
+      artifacts: [],
+      artifactPage,
+      artifactPageSize,
+      artifactHasMore: false,
+    };
+  }
+
+  const cached = buildListCache.get(key);
+  if (cached && now() - cached.at < BUILD_LIST_CACHE_TTL_MS) {
+    return cached.payload;
+  }
+
+  const filtersActive = !!(options.includeFallback || options.q || options.sha || options.commitSubject || options.branch);
+  const headers = githubHeaders(options.githubToken);
+
+  try {
+    const [rawReleases, rawArtifacts] = await Promise.all([
+      collectReleases(options.githubRepo, headers, fetchImpl),
+      collectArtifacts(options.githubRepo, headers, fetchImpl, artifactPageSize, artifactPage, filtersActive),
+    ]);
+
+    const releaseRows = rawReleases.filter((r) => String(r.tag_name ?? "").startsWith("build-"));
+    const deployableArtifactRows = rawArtifacts.filter(
+      (a) => isDeployableArtifact(a) && (options.includeFallback || !isFallbackArtifact(a)),
+    );
+
+    const runIds = [...new Set(deployableArtifactRows.map((a) => (a.workflow_run as { id?: unknown })?.id).filter(Boolean))].map(String);
+    const workflowRunLookup = new Map<string, Record<string, unknown>>();
+    for (const runId of runIds) {
+      const run = await workflowRunFor(options.githubRepo, headers, fetchImpl, runId, now);
+      if (run) workflowRunLookup.set(runId, run);
+    }
+
+    const commitLookupState: { hit: boolean; message?: string } = { hit: false };
+    const shortSha = (sha: string) => (sha.length > 7 ? sha.slice(0, 7) : sha);
+
+    const releaseBuilds: BuildListItem[] = [];
+    for (const release of releaseRows) {
+      const assets = (release.assets as Record<string, unknown>[]) ?? [];
+      const asset = assets[0] ?? {};
+      const commitSha = releaseBodyValue(release, "Commit") ?? String(release.tag_name ?? "").replace(/^build-/, "");
+      const commitSubject = await commitSubjectFor(options.githubRepo, headers, fetchImpl, commitSha, commitLookupState, now);
+      const item: BuildListItem = {
+        source: "release",
+        tag: String(release.tag_name ?? ""),
+        sha: shortSha(commitSha),
+        commitSha: commitSha || undefined,
+        commitSubject: commitSubject ?? undefined,
+        name: commitSubject || String(release.name ?? release.tag_name ?? ""),
+        date: releaseBodyValue(release, "Built") ?? String(release.published_at ?? ""),
+        downloadUrl: asset.browser_download_url as string | undefined,
+        sizeMb: assets.length ? Math.round((Number(asset.size ?? 0) / 1_000_000) * 10) / 10 : undefined,
+        branch: releaseBodyValue(release, "Branch") ?? undefined,
+        workflowName: "ARM Artifact Release",
+        workflowEvent: "release",
+        deployable: true,
+        fallback: false,
+      };
+      if (matchesFilters(item, options)) releaseBuilds.push(item);
+    }
+
+    const artifactBuilds: BuildListItem[] = [];
+    for (const artifact of deployableArtifactRows) {
+      const embeddedRun = (artifact.workflow_run ?? {}) as Record<string, unknown>;
+      const runId = String(embeddedRun.id ?? "");
+      const resolvedRun = workflowRunLookup.get(runId) ?? embeddedRun;
+      const commitSha = String(resolvedRun.head_sha ?? embeddedRun.head_sha ?? "");
+      const commitSubject = await commitSubjectFor(options.githubRepo, headers, fetchImpl, commitSha, commitLookupState, now);
+      const item: BuildListItem = {
+        source: "actions",
+        tag: `run-${resolvedRun.id ?? artifact.id}`,
+        sha: shortSha(commitSha),
+        commitSha: commitSha || undefined,
+        commitSubject: commitSubject ?? undefined,
+        name: commitSubject || String(artifact.name ?? `artifact-${artifact.id}`),
+        date: String(artifact.updated_at ?? "").trim(),
+        downloadUrl:
+          (artifact.archive_download_url as string | undefined) ??
+          `https://api.github.com/repos/${options.githubRepo}/actions/artifacts/${artifact.id}/zip`,
+        sizeMb: Math.round((Number(artifact.size_in_bytes ?? 0) / 1_000_000) * 10) / 10,
+        runId: runId || undefined,
+        artifactId: String(artifact.id ?? "") || undefined,
+        artifactName: artifact.name as string | undefined,
+        branch: resolvedRun.head_branch as string | undefined,
+        workflowName: resolvedRun.name as string | undefined,
+        workflowEvent: resolvedRun.event as string | undefined,
+        workflowConclusion: resolvedRun.conclusion as string | undefined,
+        deployable: isDeployableArtifact(artifact),
+        fallback: isFallbackArtifact(artifact),
+      };
+      if (matchesFilters(item, options)) artifactBuilds.push(item);
+    }
+
+    const combined = [...releaseBuilds, ...artifactBuilds].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+
+    const result: ListBuildsResult = {
+      success: true,
+      builds: combined,
+      releases: releaseBuilds,
+      artifacts: artifactBuilds,
+      artifactPage: filtersActive ? 1 : artifactPage,
+      artifactPageSize,
+      artifactHasMore: filtersActive ? false : deployableArtifactRows.length >= artifactPageSize,
+      error: commitLookupState.message,
+    };
+    buildListCache.set(key, { at: now(), payload: result });
+    return result;
+  } catch (error) {
+    const response = (error as { response?: Response }).response;
+    const staleCached = buildListCache.get(key);
+    const rateLimitMessage = response
+      ? await githubRateLimitMessage(response, !!options.githubToken, staleCached ? "cached" : "builds")
+      : null;
+
+    if (staleCached && rateLimitMessage) {
+      return { ...staleCached.payload, error: rateLimitMessage };
+    }
+    return {
+      success: false,
+      error: rateLimitMessage || (error as Error).message,
+      builds: [],
+      releases: [],
+      artifacts: [],
+      artifactPage,
+      artifactPageSize,
+      artifactHasMore: false,
+    };
+  }
+}

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/heartbeat.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/heartbeat.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { attachHeartbeat, type HeartbeatSocket } from "./heartbeat.js";
+
+function fakeSocket() {
+  const listeners: Record<string, Array<() => void>> = {};
+  const socket: HeartbeatSocket = {
+    ping: vi.fn(),
+    terminate: vi.fn(),
+    on: (event, listener) => {
+      (listeners[event] ??= []).push(listener);
+    },
+  };
+  return { socket, emitPong: () => listeners.pong?.forEach((l) => l()), emitClose: () => listeners.close?.forEach((l) => l()) };
+}
+
+describe("attachHeartbeat", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("pings on each interval as long as a pong keeps arriving", () => {
+    const { socket, emitPong } = fakeSocket();
+    attachHeartbeat(socket, 1000);
+
+    vi.advanceTimersByTime(1000);
+    expect(socket.ping).toHaveBeenCalledTimes(1);
+    emitPong();
+
+    vi.advanceTimersByTime(1000);
+    expect(socket.ping).toHaveBeenCalledTimes(2);
+    expect(socket.terminate).not.toHaveBeenCalled();
+  });
+
+  it("terminates the connection if no pong arrives before the next interval", () => {
+    const { socket } = fakeSocket();
+    attachHeartbeat(socket, 1000);
+
+    vi.advanceTimersByTime(1000); // sends first ping, no pong follows
+    vi.advanceTimersByTime(1000); // next tick: still no pong -> terminate
+
+    expect(socket.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops the interval once the socket closes", () => {
+    const { socket, emitClose } = fakeSocket();
+    attachHeartbeat(socket, 1000);
+
+    emitClose();
+    vi.advanceTimersByTime(10_000);
+
+    expect(socket.ping).not.toHaveBeenCalled();
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/heartbeat.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/heartbeat.ts
@@ -1,0 +1,31 @@
+export interface HeartbeatSocket {
+  ping(): void;
+  terminate(): void;
+  on(event: "pong" | "close", listener: () => void): void;
+}
+
+/**
+ * Detects a client that vanished without a clean close handshake (WiFi
+ * drop, app killed, laptop sleep) -- without this, the server only notices
+ * via the OS's own (often very slow, sometimes effectively unbounded) TCP
+ * dead-peer detection, leaving whatever the connection was holding open
+ * (here: the outbound relay connection to pi-agent) running longer than
+ * necessary.
+ */
+export function attachHeartbeat(socket: HeartbeatSocket, intervalMs = 30_000): void {
+  let alive = true;
+  socket.on("pong", () => {
+    alive = true;
+  });
+
+  const timer = setInterval(() => {
+    if (!alive) {
+      socket.terminate();
+      return;
+    }
+    alive = false;
+    socket.ping();
+  }, intervalMs);
+
+  socket.on("close", () => clearInterval(timer));
+}

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.test.ts
@@ -91,6 +91,58 @@ describe("orchestrator discovery endpoint", () => {
   });
 });
 
+describe("orchestrator fleet board endpoint", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("discovers a Pi and fans out into a board response with a readiness summary", async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const u = url.toString();
+      if (u === "http://air-01.local:8090/health") {
+        return new Response(JSON.stringify({ status: "ok" }), { status: 200 });
+      }
+      if (u.startsWith("http://air-01.local:8090/api/mission/status")) {
+        return new Response(JSON.stringify({ success: true, running: false, state: "stopped" }), { status: 200 });
+      }
+      if (u.startsWith("http://air-01.local:8090/api/deploy/current")) {
+        return new Response(JSON.stringify({ success: true, installed: true, info: "Build 42", releaseId: "rel-1" }), {
+          status: 200,
+        });
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.DISCOVERY_PREFIXES = "air";
+    process.env.DISCOVERY_SUFFIX_MAX = "1";
+    process.env.PI_AGENT_PORT = "8090";
+
+    const orchestrator = buildOrchestratorServer();
+    const response = await orchestrator.inject({ method: "GET", url: "/api/fleet/board" });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.devices).toEqual([
+      {
+        hostname: "air-01.local",
+        connected: true,
+        buildInstalled: true,
+        releaseId: "rel-1",
+        buildInfo: "Build 42",
+        runtimeState: "stopped",
+        runtimeRunning: false,
+        ready: true,
+        notes: [],
+      },
+    ]);
+    expect(body.summary.readyDevices).toBe(1);
+
+    delete process.env.DISCOVERY_PREFIXES;
+    delete process.env.DISCOVERY_SUFFIX_MAX;
+    delete process.env.PI_AGENT_PORT;
+  });
+});
+
 describe("orchestrator build-source selection endpoints", () => {
   let stateDir: string;
   const originalStateDir = process.env.ORCHESTRATOR_STATE_DIR;

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.test.ts
@@ -1,4 +1,9 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as tar from "tar";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildServer as buildPiAgentServer } from "@pennair/pi-agent";
 import { buildServer as buildOrchestratorServer } from "./index.js";
 
@@ -83,5 +88,198 @@ describe("orchestrator discovery endpoint", () => {
     delete process.env.DISCOVERY_PREFIXES;
     delete process.env.DISCOVERY_SUFFIX_MAX;
     delete process.env.PI_AGENT_PORT;
+  });
+});
+
+describe("orchestrator build-source selection endpoints", () => {
+  let stateDir: string;
+  const originalStateDir = process.env.ORCHESTRATOR_STATE_DIR;
+
+  beforeEach(async () => {
+    stateDir = await mkdtemp(join(tmpdir(), "orchestrator-state-test-"));
+    process.env.ORCHESTRATOR_STATE_DIR = stateDir;
+  });
+
+  afterEach(async () => {
+    process.env.ORCHESTRATOR_STATE_DIR = originalStateDir;
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("defaults to kind:none", async () => {
+    const orchestrator = buildOrchestratorServer();
+    const response = await orchestrator.inject({ method: "GET", url: "/api/deploy/source" });
+    expect(response.json()).toMatchObject({ kind: "none" });
+  });
+
+  it("selects a github release source, persists it, and resolves its fleet catalog error when there's no download url", async () => {
+    const orchestrator = buildOrchestratorServer();
+    const select = await orchestrator.inject({
+      method: "POST",
+      url: "/api/deploy/source/github",
+      payload: { githubSource: "release", tag: "build-42", name: "Build 42" },
+    });
+    expect(select.json()).toMatchObject({ kind: "github", tag: "build-42" });
+
+    const reread = await orchestrator.inject({ method: "GET", url: "/api/deploy/source" });
+    expect(reread.json()).toMatchObject({ kind: "github", tag: "build-42" });
+
+    const catalog = await orchestrator.inject({ method: "GET", url: "/api/deploy/fleet-catalog" });
+    expect(catalog.json()).toMatchObject({ catalog: {}, error: expect.stringContaining("download URL") });
+  });
+
+  it("selects a local codebase source and resolves fleet yaml files directly from disk", async () => {
+    const codebaseRoot = join(stateDir, "repo");
+    await mkdir(join(codebaseRoot, "src", "uav", "uav", "fleets"), { recursive: true });
+    await writeFile(join(codebaseRoot, "src", "uav", "uav", "fleets", "example_fleet.yaml"), "vehicles: []", "utf-8");
+
+    const orchestrator = buildOrchestratorServer();
+    await orchestrator.inject({
+      method: "POST",
+      url: "/api/deploy/source/local-codebase",
+      payload: { codebaseRoot },
+    });
+
+    const catalog = await orchestrator.inject({ method: "GET", url: "/api/deploy/fleet-catalog" });
+    expect(catalog.json()).toMatchObject({ catalog: { "example_fleet.yaml": expect.any(String) }, error: null });
+  });
+
+  it("clear() resets to kind:none", async () => {
+    const orchestrator = buildOrchestratorServer();
+    await orchestrator.inject({
+      method: "POST",
+      url: "/api/deploy/source/github",
+      payload: { githubSource: "release", tag: "build-42" },
+    });
+    const cleared = await orchestrator.inject({ method: "POST", url: "/api/deploy/source/clear" });
+    expect(cleared.json()).toMatchObject({ kind: "none" });
+  });
+
+  it("reports the GITHUB_REPO-not-configured error from /api/deploy/builds", async () => {
+    const orchestrator = buildOrchestratorServer();
+    const response = await orchestrator.inject({ method: "GET", url: "/api/deploy/builds" });
+    expect(response.json()).toMatchObject({ success: false, error: expect.stringContaining("not configured") });
+  });
+
+  it("accepts a real multipart local-artifact upload and selects it as the build source", async () => {
+    const stagingDir = join(stateDir, "staging");
+    await mkdir(join(stagingDir, "uav", "fleets"), { recursive: true });
+    await writeFile(join(stagingDir, "uav", "fleets", "example_fleet.yaml"), "vehicles: []", "utf-8");
+    const artifactPath = join(stateDir, "local-build.tar.gz");
+    await tar.c({ file: artifactPath, cwd: stagingDir, gzip: true }, ["uav"]);
+
+    const orchestrator = buildOrchestratorServer();
+    await orchestrator.listen({ port: 0, host: "127.0.0.1" });
+    const address = orchestrator.server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected orchestrator to listen on a TCP port");
+    }
+
+    const form = new FormData();
+    const fileBuffer = await import("node:fs/promises").then((fs) => fs.readFile(artifactPath));
+    form.set("file", new Blob([fileBuffer]), "local-build.tar.gz");
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/deploy/source/local-artifact`, {
+      method: "POST",
+      body: form,
+    });
+    const body = (await response.json()) as { kind: string; artifactName: string };
+    expect(body).toMatchObject({ kind: "local_artifact", artifactName: "local-build.tar.gz" });
+
+    const catalog = await orchestrator.inject({ method: "GET", url: "/api/deploy/fleet-catalog" });
+    expect(catalog.json()).toMatchObject({ catalog: { "example_fleet.yaml": expect.any(String) } });
+
+    await orchestrator.close();
+  });
+});
+
+describe("orchestrator deploy relay to a real local pi-agent instance", () => {
+  let scratchRoot: string;
+  let piAgent: ReturnType<typeof buildPiAgentServer>;
+  let piAgentPort: number;
+  const originalPiAgentPortEnv = process.env.PI_AGENT_PORT;
+  const originalDeployRoot = process.env.DEPLOY_ROOT;
+
+  beforeAll(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "orchestrator-deploy-relay-test-"));
+    process.env.DEPLOY_ROOT = scratchRoot;
+    piAgent = buildPiAgentServer();
+    await piAgent.listen({ port: 0, host: "127.0.0.1" });
+    const address = piAgent.server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected pi-agent to listen on a TCP port");
+    }
+    piAgentPort = address.port;
+    process.env.PI_AGENT_PORT = String(piAgentPort);
+  });
+
+  afterAll(async () => {
+    await piAgent.close();
+    process.env.PI_AGENT_PORT = originalPiAgentPortEnv;
+    process.env.DEPLOY_ROOT = originalDeployRoot;
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    await rm(`${scratchRoot}/releases`, { recursive: true, force: true });
+    await rm(`${scratchRoot}/current`, { force: true });
+    await rm(`${scratchRoot}/previous`, { force: true });
+  });
+
+  it("relays /api/deploy/current to the real pi-agent", async () => {
+    const orchestrator = buildOrchestratorServer();
+    const response = await orchestrator.inject({ method: "GET", url: "/api/deploy/current?hostname=127.0.0.1" });
+    expect(response.json()).toMatchObject({ installed: false });
+  });
+
+  it("relays a real multipart upload end-to-end: client -> orchestrator -> real pi-agent, which genuinely extracts it", async () => {
+    const stagingDir = join(scratchRoot, "staging");
+    await mkdir(join(stagingDir, "install"), { recursive: true });
+    await writeFile(join(stagingDir, "install", "marker.txt"), "v1", "utf-8");
+    const artifactPath = join(scratchRoot, "upload-test.tar.gz");
+    await tar.c({ file: artifactPath, cwd: stagingDir, gzip: true }, ["install"]);
+
+    const orchestrator = buildOrchestratorServer();
+    await orchestrator.listen({ port: 0, host: "127.0.0.1" });
+    const address = orchestrator.server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected orchestrator to listen on a TCP port");
+    }
+
+    const form = new FormData();
+    form.set("hostname", "127.0.0.1");
+    form.set("sourceType", "github");
+    form.set("sourceLabel", "build-42");
+    form.set("vehicleName", "air-01");
+    const fileBuffer = await import("node:fs/promises").then((fs) => fs.readFile(artifactPath));
+    form.set("file", new Blob([fileBuffer]), "upload-test.tar.gz");
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/deploy/upload`, {
+      method: "POST",
+      body: form,
+    });
+    const body = (await response.json()) as { success: boolean; releaseId?: string };
+
+    // Real graceful failure expected: no real systemd/sudo on this dev machine.
+    expect(body.success).toBe(false);
+    expect(body.releaseId).toBeTruthy();
+    expect(existsSync(`${scratchRoot}/current/install/marker.txt`)).toBe(true);
+
+    await orchestrator.close();
+  });
+
+  it("returns 400 when no hostname is provided to the upload endpoint", async () => {
+    const orchestrator = buildOrchestratorServer();
+    await orchestrator.listen({ port: 0, host: "127.0.0.1" });
+    const address = orchestrator.server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected orchestrator to listen on a TCP port");
+    }
+    const form = new FormData();
+    form.set("file", new Blob([Buffer.from("test")]), "artifact.tar.gz");
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/deploy/upload`, {
+      method: "POST",
+      body: form,
+    });
+    expect(response.status).toBe(400);
+    await orchestrator.close();
   });
 });

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.test.ts
@@ -283,3 +283,112 @@ describe("orchestrator deploy relay to a real local pi-agent instance", () => {
     await orchestrator.close();
   });
 });
+
+describe("orchestrator mission/fleet-file/schema relay to a real local pi-agent instance", () => {
+  let scratchRoot: string;
+  let piAgent: ReturnType<typeof buildPiAgentServer>;
+  let piAgentPort: number;
+  const originalPiAgentPortEnv = process.env.PI_AGENT_PORT;
+  const originalDeployRoot = process.env.DEPLOY_ROOT;
+
+  beforeAll(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "orchestrator-mission-fleet-relay-test-"));
+    process.env.DEPLOY_ROOT = scratchRoot;
+
+    const releaseDir = join(scratchRoot, "releases", "20260101-000000-test");
+    await mkdir(join(releaseDir, "install", "uav", "share", "uav", "missions"), { recursive: true });
+    await mkdir(join(releaseDir, "install", "uav", "share", "uav", "fleets"), { recursive: true });
+    await writeFile(
+      join(releaseDir, "install", "uav", "share", "uav", "missions", "patrol.yaml"),
+      "modes:\n  start:\n    mode: uav.LandingMode\n",
+      "utf-8",
+    );
+    await writeFile(
+      join(releaseDir, "install", "uav", "share", "uav", "fleets", "example_fleet.yaml"),
+      "backend:\n  kind: hardware\nvehicles: []\n",
+      "utf-8",
+    );
+    const { symlink } = await import("node:fs/promises");
+    await symlink(releaseDir, join(scratchRoot, "current"));
+
+    piAgent = buildPiAgentServer();
+    await piAgent.listen({ port: 0, host: "127.0.0.1" });
+    const address = piAgent.server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected pi-agent to listen on a TCP port");
+    }
+    piAgentPort = address.port;
+    process.env.PI_AGENT_PORT = String(piAgentPort);
+  });
+
+  afterAll(async () => {
+    await piAgent.close();
+    process.env.PI_AGENT_PORT = originalPiAgentPortEnv;
+    process.env.DEPLOY_ROOT = originalDeployRoot;
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  it("relays /api/mission/mission-names to the real pi-agent", async () => {
+    const orchestrator = buildOrchestratorServer();
+    const response = await orchestrator.inject({ method: "GET", url: "/api/mission/mission-names?hostname=127.0.0.1" });
+    expect(response.json()).toEqual({ success: true, missions: ["patrol"] });
+  });
+
+  it("returns 400 when hostname is missing from mission-names", async () => {
+    const orchestrator = buildOrchestratorServer();
+    const response = await orchestrator.inject({ method: "GET", url: "/api/mission/mission-names" });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("relays mission file read/write round trips through to the real pi-agent", async () => {
+    const orchestrator = buildOrchestratorServer();
+    const read = await orchestrator.inject({
+      method: "GET",
+      url: "/api/mission/mission-file?hostname=127.0.0.1&name=patrol",
+    });
+    expect(read.json().content).toContain("uav.LandingMode");
+
+    const write = await orchestrator.inject({
+      method: "POST",
+      url: "/api/mission/mission-file",
+      payload: { hostname: "127.0.0.1", name: "patrol", content: "modes:\n  start:\n    mode: uav.NavGPSMode\n" },
+    });
+    expect(write.json()).toEqual({ success: true });
+
+    const reread = await orchestrator.inject({
+      method: "GET",
+      url: "/api/mission/mission-file?hostname=127.0.0.1&name=patrol",
+    });
+    expect(reread.json().content).toContain("uav.NavGPSMode");
+  });
+
+  it("relays fleet file read/write round trips through to the real pi-agent", async () => {
+    const orchestrator = buildOrchestratorServer();
+    const read = await orchestrator.inject({
+      method: "GET",
+      url: "/api/fleet/fleet-file?hostname=127.0.0.1&name=example_fleet",
+    });
+    expect(read.json().content).toContain("hardware");
+
+    const write = await orchestrator.inject({
+      method: "POST",
+      url: "/api/fleet/fleet-file",
+      payload: { hostname: "127.0.0.1", name: "example_fleet", content: "backend:\n  kind: hardware\nvehicles:\n  - name: air-01\n" },
+    });
+    expect(write.json()).toEqual({ success: true });
+
+    const reread = await orchestrator.inject({
+      method: "GET",
+      url: "/api/fleet/fleet-file?hostname=127.0.0.1&name=example_fleet",
+    });
+    expect(reread.json().content).toContain("air-01");
+  });
+
+  it("relays /api/schema, which genuinely fails without a real ROS2 environment on this dev machine", async () => {
+    const orchestrator = buildOrchestratorServer();
+    const response = await orchestrator.inject({ method: "GET", url: "/api/schema?hostname=127.0.0.1" });
+    const body = response.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBeTruthy();
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { buildServer as buildPiAgentServer } from "@pennair/pi-agent";
+import { buildServer as buildOrchestratorServer } from "./index.js";
+
+describe("orchestrator wifi relay, against a real local pi-agent instance", () => {
+  const piAgent = buildPiAgentServer();
+  let piAgentPort: number;
+  const originalPiAgentPortEnv = process.env.PI_AGENT_PORT;
+
+  beforeAll(async () => {
+    await piAgent.listen({ port: 0, host: "127.0.0.1" });
+    const address = piAgent.server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected pi-agent to listen on a TCP port");
+    }
+    piAgentPort = address.port;
+    process.env.PI_AGENT_PORT = String(piAgentPort);
+  });
+
+  afterAll(async () => {
+    await piAgent.close();
+    process.env.PI_AGENT_PORT = originalPiAgentPortEnv;
+  });
+
+  it("relays /api/wifi/status to the real pi-agent (nmcli absent in this environment, so a graceful failure is the correct real response)", async () => {
+    const orchestrator = buildOrchestratorServer();
+    const response = await orchestrator.inject({
+      method: "GET",
+      url: "/api/wifi/status?hostname=127.0.0.1",
+    });
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    // We're not asserting success:true here -- there's no real nmcli on this
+    // dev machine. The point is that the orchestrator actually reached the
+    // real pi-agent process over HTTP and relayed back whatever it said,
+    // rather than the request failing to even reach it.
+    expect(body).toHaveProperty("success");
+    expect(body).toHaveProperty("connections");
+  });
+
+  it("returns 400 when hostname is missing", async () => {
+    const orchestrator = buildOrchestratorServer();
+    const response = await orchestrator.inject({ method: "GET", url: "/api/wifi/status" });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("relays /api/wifi/connect POST bodies through to pi-agent", async () => {
+    const orchestrator = buildOrchestratorServer();
+    const response = await orchestrator.inject({
+      method: "POST",
+      url: "/api/wifi/connect",
+      payload: { hostname: "127.0.0.1", ssid: "some_network", password: "hunter2" },
+    });
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    // Again: no real nmcli here, so success:false is expected and correct --
+    // what matters is the request actually reached pi-agent's real handler.
+    expect(body).toHaveProperty("success", false);
+  });
+});
+
+describe("orchestrator discovery endpoint", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("wires discoverPis with the configured prefixes/port and returns its result", async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const reachable = url.toString() === "http://air-01.local:8090/health";
+      return { ok: reachable } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.DISCOVERY_PREFIXES = "air";
+    process.env.DISCOVERY_SUFFIX_MAX = "2";
+    process.env.PI_AGENT_PORT = "8090";
+
+    const orchestrator = buildOrchestratorServer();
+    const response = await orchestrator.inject({ method: "GET", url: "/api/discovery" });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ pis: [{ hostname: "air-01.local" }] });
+
+    delete process.env.DISCOVERY_PREFIXES;
+    delete process.env.DISCOVERY_SUFFIX_MAX;
+    delete process.env.PI_AGENT_PORT;
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.test.ts
@@ -89,6 +89,26 @@ describe("orchestrator discovery endpoint", () => {
     delete process.env.DISCOVERY_SUFFIX_MAX;
     delete process.env.PI_AGENT_PORT;
   });
+
+  it("trims whitespace and de-dupes a repeated/malformed DISCOVERY_PREFIXES value, avoiding a double-counted Pi", async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const reachable = url.toString() === "http://air-01.local:8090/health";
+      return { ok: reachable } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.DISCOVERY_PREFIXES = "air, air,  ,air";
+    process.env.DISCOVERY_SUFFIX_MAX = "1";
+    process.env.PI_AGENT_PORT = "8090";
+
+    const orchestrator = buildOrchestratorServer();
+    const response = await orchestrator.inject({ method: "GET", url: "/api/discovery" });
+
+    expect(response.json()).toEqual({ pis: [{ hostname: "air-01.local" }] });
+
+    delete process.env.DISCOVERY_PREFIXES;
+    delete process.env.DISCOVERY_SUFFIX_MAX;
+    delete process.env.PI_AGENT_PORT;
+  });
 });
 
 describe("orchestrator fleet board endpoint", () => {

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
@@ -1,9 +1,72 @@
 import Fastify from "fastify";
+import { discoverPis } from "@pennair/integration-core";
+import { PiAgentClient } from "./pi-agent-client.js";
+
+function piAgentPort(): number {
+  return Number(process.env.PI_AGENT_PORT ?? 8090);
+}
+
+function piAgentClientFor(hostname: string): PiAgentClient {
+  return new PiAgentClient({ hostname, port: piAgentPort() });
+}
 
 export function buildServer() {
   const app = Fastify();
 
   app.get("/health", async () => ({ status: "ok" }));
+
+  app.get("/api/discovery", async () => {
+    const prefixes = (process.env.DISCOVERY_PREFIXES ?? "air,payload").split(",");
+    const suffixMax = Number(process.env.DISCOVERY_SUFFIX_MAX ?? 20);
+    const timeoutMs = Number(process.env.DISCOVERY_TIMEOUT_MS ?? 1000);
+    const suffixes = Array.from({ length: suffixMax }, (_, i) => i + 1);
+    const pis = await discoverPis({
+      prefixes,
+      suffixes,
+      port: piAgentPort(),
+      timeoutMs,
+    });
+    return { pis };
+  });
+
+  app.get<{ Querystring: { hostname?: string } }>("/api/wifi/status", async (request, reply) => {
+    const { hostname } = request.query;
+    if (!hostname) {
+      reply.code(400);
+      return { success: false, connections: [], error: "hostname is required" };
+    }
+    return piAgentClientFor(hostname).wifiStatus();
+  });
+
+  app.get<{ Querystring: { hostname?: string } }>("/api/wifi/scan", async (request, reply) => {
+    const { hostname } = request.query;
+    if (!hostname) {
+      reply.code(400);
+      return { success: false, networks: [], error: "hostname is required" };
+    }
+    return piAgentClientFor(hostname).wifiScan();
+  });
+
+  app.post<{ Body: { hostname?: string; ssid: string; password?: string } }>(
+    "/api/wifi/connect",
+    async (request, reply) => {
+      const { hostname, ssid, password } = request.body;
+      if (!hostname || !ssid) {
+        reply.code(400);
+        return { success: false, error: "hostname and ssid are required" };
+      }
+      return piAgentClientFor(hostname).wifiConnect(ssid, password ?? "");
+    },
+  );
+
+  app.post<{ Body: { hostname?: string } }>("/api/wifi/hotspot", async (request, reply) => {
+    const { hostname } = request.body;
+    if (!hostname) {
+      reply.code(400);
+      return { success: false, error: "hostname is required" };
+    }
+    return piAgentClientFor(hostname).wifiHotspot();
+  });
 
   return app;
 }

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
@@ -325,6 +325,70 @@ export function buildServer() {
     return { success: false, error: "No file uploaded" };
   });
 
+  // -- Mission/fleet YAML editors -- relayed to pi-agent, which reads/writes
+  // files inside the currently-deployed release on that specific Pi (and
+  // runs schema_export.py there, since the Pi is guaranteed to have a real
+  // ROS2 + vehicle_common environment, unlike the orchestrator).
+  app.get<{ Querystring: { hostname?: string } }>("/api/schema", async (request, reply) => {
+    const { hostname } = request.query;
+    if (!hostname) {
+      reply.code(400);
+      return { success: false, error: "hostname is required" };
+    }
+    return piAgentClientFor(hostname).schema();
+  });
+
+  app.get<{ Querystring: { hostname?: string } }>("/api/mission/mission-names", async (request, reply) => {
+    const { hostname } = request.query;
+    if (!hostname) {
+      reply.code(400);
+      return { success: false, missions: [], error: "hostname is required" };
+    }
+    return piAgentClientFor(hostname).missionNames();
+  });
+
+  app.get<{ Querystring: { hostname?: string; name?: string } }>("/api/mission/mission-file", async (request, reply) => {
+    const { hostname, name } = request.query;
+    if (!hostname || !name) {
+      reply.code(400);
+      return { success: false, error: "hostname and name are required" };
+    }
+    return piAgentClientFor(hostname).readMissionFile(name);
+  });
+
+  app.post<{ Body: { hostname?: string; name?: string; content?: string } }>(
+    "/api/mission/mission-file",
+    async (request, reply) => {
+      const { hostname, name, content } = request.body;
+      if (!hostname || !name) {
+        reply.code(400);
+        return { success: false, error: "hostname and name are required" };
+      }
+      return piAgentClientFor(hostname).writeMissionFile(name, content ?? "");
+    },
+  );
+
+  app.get<{ Querystring: { hostname?: string; name?: string } }>("/api/fleet/fleet-file", async (request, reply) => {
+    const { hostname, name } = request.query;
+    if (!hostname || !name) {
+      reply.code(400);
+      return { success: false, error: "hostname and name are required" };
+    }
+    return piAgentClientFor(hostname).readFleetFile(name);
+  });
+
+  app.post<{ Body: { hostname?: string; name?: string; content?: string } }>(
+    "/api/fleet/fleet-file",
+    async (request, reply) => {
+      const { hostname, name, content } = request.body;
+      if (!hostname || !name) {
+        reply.code(400);
+        return { success: false, error: "hostname and name are required" };
+      }
+      return piAgentClientFor(hostname).writeFleetFile(name, content ?? "");
+    },
+  );
+
   // Real-time log relay: client <-> orchestrator <-> pi-agent, all real
   // WebSocket streaming, no polling anywhere in the chain.
   app.register(async (instance) => {

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
@@ -80,8 +80,6 @@ export function buildServer() {
     return { pis };
   });
 
-  // Fleet board: fans discovery out into a per-Pi health/mission/build probe
-  // and rolls the results into a fleet-wide readiness summary.
   app.get("/api/fleet/board", async () => {
     const { prefixes, suffixes, timeoutMs } = discoveryParams();
     return fetchFleetBoard({ prefixes, suffixes, port: piAgentPort(), discoveryTimeoutMs: timeoutMs });

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
@@ -57,7 +57,12 @@ export function buildServer() {
   app.get("/health", async () => ({ status: "ok" }));
 
   function discoveryParams() {
-    const prefixes = (process.env.DISCOVERY_PREFIXES ?? "air,payload").split(",");
+    // Trimmed + deduped: a stray space or a copy-paste duplicate in the env
+    // var (e.g. "air, air") would otherwise make discoverPis() probe and
+    // return the same hostname twice, double-counting one physical Pi in
+    // every fleet-board summary bucket and giving React a duplicate list key.
+    const rawPrefixes = (process.env.DISCOVERY_PREFIXES ?? "air,payload").split(",").map((p) => p.trim());
+    const prefixes = [...new Set(rawPrefixes.filter(Boolean))];
     const suffixMax = Number(process.env.DISCOVERY_SUFFIX_MAX ?? 20);
     const timeoutMs = Number(process.env.DISCOVERY_TIMEOUT_MS ?? 1000);
     const suffixes = Array.from({ length: suffixMax }, (_, i) => i + 1);

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
@@ -1,10 +1,19 @@
+import { createWriteStream } from "node:fs";
+import { mkdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { pipeline } from "node:stream/promises";
 import Fastify from "fastify";
 import websocketPlugin from "@fastify/websocket";
+import multipartPlugin from "@fastify/multipart";
 import WebSocket from "ws";
 import { discoverPis } from "@pennair/integration-core";
 import { PiAgentClient } from "./pi-agent-client.js";
 import { startMission, triggerFailsafe } from "./mission.js";
 import { attachHeartbeat } from "./heartbeat.js";
+import { BuildSourceStore } from "./build-source-store.js";
+import { listBuilds } from "./github-builds.js";
+import { resolveFleetCatalog } from "./fleet-catalog.js";
 
 function piAgentPort(): number {
   return Number(process.env.PI_AGENT_PORT ?? 8090);
@@ -14,9 +23,35 @@ function piAgentClientFor(hostname: string): PiAgentClient {
   return new PiAgentClient({ hostname, port: piAgentPort() });
 }
 
+function orchestratorStateDir(): string {
+  return process.env.ORCHESTRATOR_STATE_DIR ?? join(homedir(), ".pennair-orchestrator");
+}
+
+function githubRepo(): string {
+  return process.env.GITHUB_REPO ?? "";
+}
+
+function githubToken(): string | undefined {
+  return process.env.GITHUB_TOKEN || undefined;
+}
+
+function truthyQueryParam(value: unknown): boolean {
+  return value === "true" || value === "1";
+}
+
 export function buildServer() {
   const app = Fastify();
   app.register(websocketPlugin);
+  app.register(multipartPlugin, {
+    limits: { fileSize: 2 * 1024 * 1024 * 1024 }, // 2GB -- ROS2 build artifacts can be large
+  });
+
+  const buildSourceStore = new BuildSourceStore(join(orchestratorStateDir(), "build-source.json"));
+  let storeLoaded: Promise<void> | null = null;
+  function ensureStoreLoaded(): Promise<void> {
+    if (!storeLoaded) storeLoaded = buildSourceStore.load();
+    return storeLoaded;
+  }
 
   app.get("/health", async () => ({ status: "ok" }));
 
@@ -120,6 +155,174 @@ export function buildServer() {
       return { success: false, error: "vehicleName is required" };
     }
     return triggerFailsafe(vehicleName);
+  });
+
+  // -- Build source selection & GitHub build listing -----------------------
+  app.get<{
+    Querystring: {
+      artifactPage?: string;
+      artifactPageSize?: string;
+      q?: string;
+      sha?: string;
+      commitSubject?: string;
+      branch?: string;
+      includeFallback?: string;
+    };
+  }>("/api/deploy/builds", async (request) => {
+    const query = request.query;
+    return listBuilds({
+      githubRepo: githubRepo(),
+      githubToken: githubToken(),
+      artifactPage: query.artifactPage ? Number(query.artifactPage) : undefined,
+      artifactPageSize: query.artifactPageSize ? Number(query.artifactPageSize) : undefined,
+      q: query.q,
+      sha: query.sha,
+      commitSubject: query.commitSubject,
+      branch: query.branch,
+      includeFallback: truthyQueryParam(query.includeFallback),
+    });
+  });
+
+  app.get("/api/deploy/source", async () => {
+    await ensureStoreLoaded();
+    return buildSourceStore.get();
+  });
+
+  app.post<{ Body: Record<string, unknown> }>("/api/deploy/source/github", async (request) => {
+    await ensureStoreLoaded();
+    const body = request.body;
+    await buildSourceStore.setGithub({
+      githubSource: body.githubSource as "release" | "actions",
+      tag: body.tag as string | undefined,
+      artifactId: body.artifactId as string | undefined,
+      runId: body.runId as string | undefined,
+      sha: body.sha as string | undefined,
+      commitSubject: body.commitSubject as string | undefined,
+      name: body.name as string | undefined,
+      date: body.date as string | undefined,
+      downloadUrl: body.downloadUrl as string | undefined,
+      sizeMb: body.sizeMb as number | undefined,
+      branch: body.branch as string | undefined,
+      artifactName: body.artifactName as string | undefined,
+      workflowName: body.workflowName as string | undefined,
+      workflowEvent: body.workflowEvent as string | undefined,
+      workflowConclusion: body.workflowConclusion as string | undefined,
+    });
+    return buildSourceStore.get();
+  });
+
+  app.post<{ Body: { codebaseRoot?: string } }>("/api/deploy/source/local-codebase", async (request, reply) => {
+    await ensureStoreLoaded();
+    const { codebaseRoot } = request.body;
+    if (!codebaseRoot) {
+      reply.code(400);
+      return { success: false, error: "codebaseRoot is required" };
+    }
+    await buildSourceStore.setLocalCodebase(codebaseRoot);
+    return buildSourceStore.get();
+  });
+
+  app.post<{ Body: { fleetFile?: string } }>("/api/deploy/source/fleet-file", async (request, reply) => {
+    await ensureStoreLoaded();
+    const { fleetFile } = request.body;
+    if (!fleetFile) {
+      reply.code(400);
+      return { success: false, error: "fleetFile is required" };
+    }
+    await buildSourceStore.setFleetFile(fleetFile);
+    return buildSourceStore.get();
+  });
+
+  app.post("/api/deploy/source/clear", async () => {
+    await ensureStoreLoaded();
+    await buildSourceStore.clear();
+    return buildSourceStore.get();
+  });
+
+  // Local artifact: the operator uploads a build tarball to the orchestrator
+  // itself (not to a specific Pi yet) so it becomes the selected build
+  // source, the same two-step flow as the old dashboard (select a source,
+  // then deploy it to whichever Pi later).
+  app.post("/api/deploy/source/local-artifact", async (request, reply) => {
+    await ensureStoreLoaded();
+    const artifactDir = join(orchestratorStateDir(), "local-artifacts");
+    await mkdir(artifactDir, { recursive: true });
+
+    let savedPath: string | undefined;
+    let artifactName: string | undefined;
+    for await (const part of request.parts()) {
+      if (part.type === "file") {
+        artifactName = part.filename;
+        savedPath = join(artifactDir, part.filename);
+        await pipeline(part.file, createWriteStream(savedPath));
+      }
+    }
+
+    if (!savedPath || !artifactName) {
+      reply.code(400);
+      return { success: false, error: "No file uploaded" };
+    }
+
+    const stats = await stat(savedPath);
+    await buildSourceStore.setLocalArtifact(artifactName, savedPath, stats.size);
+    return buildSourceStore.get();
+  });
+
+  app.get("/api/deploy/fleet-catalog", async () => {
+    await ensureStoreLoaded();
+    return resolveFleetCatalog({
+      record: buildSourceStore.get(),
+      cacheRoot: join(orchestratorStateDir(), "fleet-catalog-cache"),
+      githubToken: githubToken(),
+    });
+  });
+
+  // -- Per-Pi deploy relay ---------------------------------------------------
+  app.get<{ Querystring: { hostname?: string } }>("/api/deploy/current", async (request, reply) => {
+    const { hostname } = request.query;
+    if (!hostname) {
+      reply.code(400);
+      return { installed: false, error: "hostname is required" };
+    }
+    return piAgentClientFor(hostname).currentBuild();
+  });
+
+  app.post<{ Body: { hostname?: string } }>("/api/deploy/rollback", async (request, reply) => {
+    const { hostname } = request.body;
+    if (!hostname) {
+      reply.code(400);
+      return { success: false, error: "hostname is required" };
+    }
+    return piAgentClientFor(hostname).rollbackDeploy();
+  });
+
+  app.post("/api/deploy/upload", async (request, reply) => {
+    await ensureStoreLoaded();
+    let hostname: string | undefined;
+    let sourceType: string | undefined;
+    let sourceLabel: string | undefined;
+    let vehicleName: string | undefined;
+    let fleetFile: string | undefined;
+
+    for await (const part of request.parts()) {
+      if (part.type === "file") {
+        if (!hostname) {
+          reply.code(400);
+          return { success: false, error: "hostname is required" };
+        }
+        const client = piAgentClientFor(hostname);
+        return client.uploadDeploy(part.filename, part.file, { sourceType, sourceLabel, vehicleName, fleetFile });
+      }
+      const value = String(part.value ?? "");
+      if (part.fieldname === "hostname") hostname = value || undefined;
+      else if (part.fieldname === "sourceType") sourceType = value || undefined;
+      else if (part.fieldname === "sourceLabel") sourceLabel = value || undefined;
+      else if (part.fieldname === "vehicleName") vehicleName = value || undefined;
+      else if (part.fieldname === "fleetFile") fleetFile = value || undefined;
+    }
+
+    reply.code(400);
+    return { success: false, error: "No file uploaded" };
   });
 
   // Real-time log relay: client <-> orchestrator <-> pi-agent, all real

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
@@ -1,0 +1,18 @@
+import Fastify from "fastify";
+
+export function buildServer() {
+  const app = Fastify();
+
+  app.get("/health", async () => ({ status: "ok" }));
+
+  return app;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const port = Number(process.env.PORT ?? 8080);
+  const app = buildServer();
+  app.listen({ port, host: "0.0.0.0" }).catch((error) => {
+    app.log.error(error);
+    process.exit(1);
+  });
+}

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
@@ -4,6 +4,7 @@ import WebSocket from "ws";
 import { discoverPis } from "@pennair/integration-core";
 import { PiAgentClient } from "./pi-agent-client.js";
 import { startMission, triggerFailsafe } from "./mission.js";
+import { attachHeartbeat } from "./heartbeat.js";
 
 function piAgentPort(): number {
   return Number(process.env.PI_AGENT_PORT ?? 8090);
@@ -135,6 +136,7 @@ export function buildServer() {
           return;
         }
 
+        attachHeartbeat(clientSocket);
         const upstream = new WebSocket(`ws://${hostname}:${piAgentPort()}/ws/mission/logs`);
 
         upstream.on("message", (data) => {

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
@@ -14,6 +14,7 @@ import { attachHeartbeat } from "./heartbeat.js";
 import { BuildSourceStore } from "./build-source-store.js";
 import { listBuilds } from "./github-builds.js";
 import { resolveFleetCatalog } from "./fleet-catalog.js";
+import { fetchFleetBoard } from "./fleet-board.js";
 
 function piAgentPort(): number {
   return Number(process.env.PI_AGENT_PORT ?? 8090);
@@ -55,11 +56,16 @@ export function buildServer() {
 
   app.get("/health", async () => ({ status: "ok" }));
 
-  app.get("/api/discovery", async () => {
+  function discoveryParams() {
     const prefixes = (process.env.DISCOVERY_PREFIXES ?? "air,payload").split(",");
     const suffixMax = Number(process.env.DISCOVERY_SUFFIX_MAX ?? 20);
     const timeoutMs = Number(process.env.DISCOVERY_TIMEOUT_MS ?? 1000);
     const suffixes = Array.from({ length: suffixMax }, (_, i) => i + 1);
+    return { prefixes, suffixes, timeoutMs };
+  }
+
+  app.get("/api/discovery", async () => {
+    const { prefixes, suffixes, timeoutMs } = discoveryParams();
     const pis = await discoverPis({
       prefixes,
       suffixes,
@@ -67,6 +73,13 @@ export function buildServer() {
       timeoutMs,
     });
     return { pis };
+  });
+
+  // Fleet board: fans discovery out into a per-Pi health/mission/build probe
+  // and rolls the results into a fleet-wide readiness summary.
+  app.get("/api/fleet/board", async () => {
+    const { prefixes, suffixes, timeoutMs } = discoveryParams();
+    return fetchFleetBoard({ prefixes, suffixes, port: piAgentPort(), discoveryTimeoutMs: timeoutMs });
   });
 
   app.get<{ Querystring: { hostname?: string } }>("/api/wifi/status", async (request, reply) => {

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/index.ts
@@ -1,6 +1,9 @@
 import Fastify from "fastify";
+import websocketPlugin from "@fastify/websocket";
+import WebSocket from "ws";
 import { discoverPis } from "@pennair/integration-core";
 import { PiAgentClient } from "./pi-agent-client.js";
+import { startMission, triggerFailsafe } from "./mission.js";
 
 function piAgentPort(): number {
   return Number(process.env.PI_AGENT_PORT ?? 8090);
@@ -12,6 +15,7 @@ function piAgentClientFor(hostname: string): PiAgentClient {
 
 export function buildServer() {
   const app = Fastify();
+  app.register(websocketPlugin);
 
   app.get("/health", async () => ({ status: "ok" }));
 
@@ -66,6 +70,85 @@ export function buildServer() {
       return { success: false, error: "hostname is required" };
     }
     return piAgentClientFor(hostname).wifiHotspot();
+  });
+
+  // Process lifecycle -- relayed to pi-agent, which runs systemctl locally.
+  app.get<{ Querystring: { hostname?: string } }>("/api/mission/status", async (request, reply) => {
+    const { hostname } = request.query;
+    if (!hostname) {
+      reply.code(400);
+      return { success: false, running: false, state: "error", error: "hostname is required" };
+    }
+    return piAgentClientFor(hostname).missionStatus();
+  });
+
+  app.post<{ Body: { hostname?: string } }>("/api/mission/prepare", async (request, reply) => {
+    const { hostname } = request.body;
+    if (!hostname) {
+      reply.code(400);
+      return { success: false, error: "hostname is required" };
+    }
+    return piAgentClientFor(hostname).prepareMission();
+  });
+
+  app.post<{ Body: { hostname?: string } }>("/api/mission/stop", async (request, reply) => {
+    const { hostname } = request.body;
+    if (!hostname) {
+      reply.code(400);
+      return { success: false, error: "hostname is required" };
+    }
+    return piAgentClientFor(hostname).stopMission();
+  });
+
+  // In-graph mission RPC -- the orchestrator is itself a ROS2 participant
+  // (see ros/trigger-service-client.ts), so these reach the vehicle's
+  // mode_manager node directly over the network, not through pi-agent.
+  app.post<{ Body: { vehicleName?: string } }>("/api/mission/start", async (request, reply) => {
+    const { vehicleName } = request.body;
+    if (!vehicleName) {
+      reply.code(400);
+      return { success: false, error: "vehicleName is required" };
+    }
+    return startMission(vehicleName);
+  });
+
+  app.post<{ Body: { vehicleName?: string } }>("/api/mission/failsafe", async (request, reply) => {
+    const { vehicleName } = request.body;
+    if (!vehicleName) {
+      reply.code(400);
+      return { success: false, error: "vehicleName is required" };
+    }
+    return triggerFailsafe(vehicleName);
+  });
+
+  // Real-time log relay: client <-> orchestrator <-> pi-agent, all real
+  // WebSocket streaming, no polling anywhere in the chain.
+  app.register(async (instance) => {
+    instance.get<{ Querystring: { hostname?: string } }>(
+      "/ws/mission/logs",
+      { websocket: true },
+      (clientSocket, request) => {
+        const { hostname } = request.query;
+        if (!hostname) {
+          clientSocket.send(JSON.stringify({ type: "error", message: "hostname is required" }));
+          clientSocket.close();
+          return;
+        }
+
+        const upstream = new WebSocket(`ws://${hostname}:${piAgentPort()}/ws/mission/logs`);
+
+        upstream.on("message", (data) => {
+          clientSocket.send(data.toString());
+        });
+        upstream.on("error", (error) => {
+          clientSocket.send(JSON.stringify({ type: "error", message: error.message }));
+          clientSocket.close();
+        });
+        upstream.on("close", () => clientSocket.close());
+
+        clientSocket.on("close", () => upstream.close());
+      },
+    );
   });
 
   return app;

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/mission.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/mission.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { TriggerServiceCaller } from "./ros/trigger-service-client.js";
+import { startMission, triggerFailsafe } from "./mission.js";
+
+describe("startMission", () => {
+  it("calls the vehicle's mode_manager/start_mission service", async () => {
+    const caller: TriggerServiceCaller = async (serviceName) => {
+      expect(serviceName).toBe("/air-01/mode_manager/start_mission");
+      return { success: true, message: "Mission runtime running" };
+    };
+
+    expect(await startMission("air-01", caller)).toEqual({
+      success: true,
+      output: "Mission runtime running",
+    });
+  });
+
+  it("reports failure when the service call itself throws", async () => {
+    const caller: TriggerServiceCaller = async () => {
+      throw new Error("Service /air-01/mode_manager/start_mission is not available");
+    };
+
+    const result = await startMission("air-01", caller);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not available");
+  });
+
+  it("reports failure when the service responds success:false", async () => {
+    const caller: TriggerServiceCaller = async () => ({ success: false, message: "already running" });
+    expect(await startMission("air-01", caller)).toEqual({ success: false, error: "already running" });
+  });
+});
+
+describe("triggerFailsafe", () => {
+  it("calls the vehicle's mode_manager/failsafe service", async () => {
+    const caller: TriggerServiceCaller = async (serviceName) => {
+      expect(serviceName).toBe("/air-01/mode_manager/failsafe");
+      return { success: true, message: "failsafe triggered" };
+    };
+
+    expect(await triggerFailsafe("air-01", caller)).toEqual({
+      success: true,
+      output: "failsafe triggered",
+    });
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/mission.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/mission.ts
@@ -1,0 +1,47 @@
+import { rclnodejsTriggerServiceCaller, type TriggerServiceCaller } from "./ros/trigger-service-client.js";
+
+interface SimpleResult {
+  success: boolean;
+  output?: string;
+  error?: string;
+}
+
+/**
+ * Calls a vehicle's mode_manager Trigger service directly over the ROS2
+ * graph -- the orchestrator is a real ROS2 participant (see
+ * ros/trigger-service-client.ts), so this reaches any Pi's mode_manager
+ * node with no new node or process required on that Pi.
+ */
+async function callModeManagerTrigger(
+  vehicleName: string,
+  serviceName: string,
+  caller: TriggerServiceCaller,
+): Promise<SimpleResult> {
+  try {
+    const result = await caller(`/${vehicleName}/mode_manager/${serviceName}`);
+    if (!result.success) {
+      return { success: false, error: result.message || `${serviceName} failed` };
+    }
+    return { success: true, output: result.message || `${serviceName} called` };
+  } catch (error) {
+    return { success: false, error: (error as Error).message };
+  }
+}
+
+export async function startMission(
+  vehicleName: string,
+  caller: TriggerServiceCaller = rclnodejsTriggerServiceCaller,
+): Promise<SimpleResult> {
+  return callModeManagerTrigger(vehicleName, "start_mission", caller);
+}
+
+// UAV-specific -- payload targets don't define this service (mirrors the
+// old dashboard's target-kind branching); calling it against a payload
+// vehicle will just fail with "service not available", which is acceptable
+// for this phase since fleet/vehicle-kind metadata isn't wired up yet.
+export async function triggerFailsafe(
+  vehicleName: string,
+  caller: TriggerServiceCaller = rclnodejsTriggerServiceCaller,
+): Promise<SimpleResult> {
+  return callModeManagerTrigger(vehicleName, "failsafe", caller);
+}

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.test.ts
@@ -1,0 +1,31 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildServer as buildPiAgentServer } from "@pennair/pi-agent";
+import { PiAgentClient } from "./pi-agent-client.js";
+
+describe("PiAgentClient against a real local pi-agent instance", () => {
+  const piAgent = buildPiAgentServer();
+  let port: number;
+
+  beforeAll(async () => {
+    await piAgent.listen({ port: 0, host: "127.0.0.1" });
+    const address = piAgent.server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected pi-agent to listen on a TCP port");
+    }
+    port = address.port;
+  });
+
+  afterAll(async () => {
+    await piAgent.close();
+  });
+
+  it("reports healthy when pi-agent is reachable", async () => {
+    const client = new PiAgentClient({ hostname: "127.0.0.1", port });
+    expect(await client.isHealthy()).toBe(true);
+  });
+
+  it("reports unhealthy when nothing is listening on the port", async () => {
+    const client = new PiAgentClient({ hostname: "127.0.0.1", port: 1 });
+    expect(await client.isHealthy()).toBe(false);
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.test.ts
@@ -1,4 +1,9 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createReadStream, existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as tar from "tar";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { buildServer as buildPiAgentServer } from "@pennair/pi-agent";
 import { PiAgentClient } from "./pi-agent-client.js";
 
@@ -37,5 +42,63 @@ describe("PiAgentClient against a real local pi-agent instance", () => {
     // and got a real (non-hung, non-crashed) response back.
     expect(status).toHaveProperty("success");
     expect(status).toHaveProperty("state");
+  });
+});
+
+describe("PiAgentClient deploy relay, against a real local pi-agent instance with a scratch DEPLOY_ROOT", () => {
+  let scratchRoot: string;
+  let piAgent: ReturnType<typeof buildPiAgentServer>;
+  let port: number;
+  const originalDeployRoot = process.env.DEPLOY_ROOT;
+
+  beforeAll(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "pi-agent-client-deploy-test-"));
+    process.env.DEPLOY_ROOT = scratchRoot;
+    piAgent = buildPiAgentServer();
+    await piAgent.listen({ port: 0, host: "127.0.0.1" });
+    const address = piAgent.server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected pi-agent to listen on a TCP port");
+    }
+    port = address.port;
+  });
+
+  afterAll(async () => {
+    await piAgent.close();
+    process.env.DEPLOY_ROOT = originalDeployRoot;
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    await rm(`${scratchRoot}/releases`, { recursive: true, force: true });
+    await rm(`${scratchRoot}/current`, { force: true });
+    await rm(`${scratchRoot}/previous`, { force: true });
+  });
+
+  it("relays currentBuild when nothing has been deployed yet", async () => {
+    const client = new PiAgentClient({ hostname: "127.0.0.1", port });
+    const result = await client.currentBuild();
+    expect(result.installed).toBe(false);
+  });
+
+  it("relays a real streamed multipart upload through to pi-agent, which genuinely extracts it", async () => {
+    const stagingDir = join(scratchRoot, "staging");
+    await mkdir(join(stagingDir, "install"), { recursive: true });
+    await writeFile(join(stagingDir, "install", "marker.txt"), "v1", "utf-8");
+    const artifactPath = join(scratchRoot, "relay-test.tar.gz");
+    await tar.c({ file: artifactPath, cwd: stagingDir, gzip: true }, ["install"]);
+
+    const client = new PiAgentClient({ hostname: "127.0.0.1", port });
+    const result = await client.uploadDeploy("relay-test.tar.gz", createReadStream(artifactPath), {
+      sourceType: "github",
+      sourceLabel: "build-99",
+      vehicleName: "air-01",
+    });
+
+    // Real graceful failure expected: no real systemd/sudo on this dev machine.
+    expect(result.success).toBe(false);
+    expect(result.releaseId).toBeTruthy();
+
+    expect(existsSync(`${scratchRoot}/current/install/marker.txt`)).toBe(true);
   });
 });

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.test.ts
@@ -28,4 +28,14 @@ describe("PiAgentClient against a real local pi-agent instance", () => {
     const client = new PiAgentClient({ hostname: "127.0.0.1", port: 1 });
     expect(await client.isHealthy()).toBe(false);
   });
+
+  it("relays missionStatus to the real pi-agent (no systemctl on this dev machine, so a graceful error is the correct real response)", async () => {
+    const client = new PiAgentClient({ hostname: "127.0.0.1", port });
+    const status = await client.missionStatus();
+    // As with wifi: not asserting success:true, there's no real systemd here.
+    // What matters is the request actually reached pi-agent's real handler
+    // and got a real (non-hung, non-crashed) response back.
+    expect(status).toHaveProperty("success");
+    expect(status).toHaveProperty("state");
+  });
 });

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.test.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.test.ts
@@ -102,3 +102,88 @@ describe("PiAgentClient deploy relay, against a real local pi-agent instance wit
     expect(existsSync(`${scratchRoot}/current/install/marker.txt`)).toBe(true);
   });
 });
+
+describe("PiAgentClient schema/mission-file/fleet-file relay, against a real local pi-agent instance with a fake deployed release", () => {
+  let scratchRoot: string;
+  let piAgent: ReturnType<typeof buildPiAgentServer>;
+  let port: number;
+  const originalDeployRoot = process.env.DEPLOY_ROOT;
+
+  beforeAll(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "pi-agent-client-schema-test-"));
+    process.env.DEPLOY_ROOT = scratchRoot;
+
+    const releaseDir = join(scratchRoot, "releases", "20260101-000000-test");
+    await mkdir(join(releaseDir, "install", "uav", "share", "uav", "missions"), { recursive: true });
+    await mkdir(join(releaseDir, "install", "uav", "share", "uav", "fleets"), { recursive: true });
+    await writeFile(
+      join(releaseDir, "install", "uav", "share", "uav", "missions", "patrol.yaml"),
+      "modes:\n  start:\n    mode: uav.LandingMode\n",
+      "utf-8",
+    );
+    await writeFile(
+      join(releaseDir, "install", "uav", "share", "uav", "fleets", "example_fleet.yaml"),
+      "backend:\n  kind: hardware\nvehicles: []\n",
+      "utf-8",
+    );
+    const { symlink } = await import("node:fs/promises");
+    await symlink(releaseDir, join(scratchRoot, "current"));
+
+    piAgent = buildPiAgentServer();
+    await piAgent.listen({ port: 0, host: "127.0.0.1" });
+    const address = piAgent.server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected pi-agent to listen on a TCP port");
+    }
+    port = address.port;
+  });
+
+  afterAll(async () => {
+    await piAgent.close();
+    process.env.DEPLOY_ROOT = originalDeployRoot;
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  it("relays missionNames to the real pi-agent, listing the fake release's mission files", async () => {
+    const client = new PiAgentClient({ hostname: "127.0.0.1", port });
+    const result = await client.missionNames();
+    expect(result).toEqual({ success: true, missions: ["patrol"] });
+  });
+
+  it("relays mission file read/write round-trip through to the real pi-agent", async () => {
+    const client = new PiAgentClient({ hostname: "127.0.0.1", port });
+    const read = await client.readMissionFile("patrol");
+    expect(read.success).toBe(true);
+    expect(read.content).toContain("uav.LandingMode");
+
+    const write = await client.writeMissionFile("patrol", "modes:\n  start:\n    mode: uav.NavGPSMode\n");
+    expect(write).toEqual({ success: true });
+
+    const reread = await client.readMissionFile("patrol");
+    expect(reread.content).toContain("uav.NavGPSMode");
+  });
+
+  it("relays fleet file read/write round-trip through to the real pi-agent", async () => {
+    const client = new PiAgentClient({ hostname: "127.0.0.1", port });
+    const read = await client.readFleetFile("example_fleet");
+    expect(read.success).toBe(true);
+    expect(read.content).toContain("hardware");
+
+    const write = await client.writeFleetFile("example_fleet", "backend:\n  kind: hardware\nvehicles:\n  - name: air-01\n");
+    expect(write).toEqual({ success: true });
+
+    const reread = await client.readFleetFile("example_fleet");
+    expect(reread.content).toContain("air-01");
+  });
+
+  it("relays schema, which genuinely fails without a real ROS2 environment on this dev machine", async () => {
+    const client = new PiAgentClient({ hostname: "127.0.0.1", port });
+    const result = await client.schema();
+    // No real ROS2/vehicle_common environment here -- what matters is the
+    // request actually reached pi-agent's real handler (which itself tried
+    // to spawn `bash -c "... python3 schema_export.py ..."`) and got back a
+    // real, graceful { success: false } rather than hanging or a raw crash.
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
@@ -1,4 +1,4 @@
-import type { WifiScanResult, WifiStatus } from "@pennair/integration-core";
+import type { LaunchStatus, WifiScanResult, WifiStatus } from "@pennair/integration-core";
 
 export interface PiAgentClientOptions {
   hostname: string;
@@ -24,6 +24,9 @@ const WIFI_STATUS_TIMEOUT_MS = 35_000; // policyStatus(15s) + con show(15s)
 const WIFI_SCAN_TIMEOUT_MS = 25_000; // dev wifi list(20s)
 const WIFI_CONNECT_TIMEOUT_MS = 80_000; // policyStatus(15s) + con down(15s) + connect(30s) + rollback con up(15s)
 const WIFI_HOTSPOT_TIMEOUT_MS = 50_000; // policyStatus(15s) + disconnect(15s) + con up(15s)
+const MISSION_STATUS_TIMEOUT_MS = 20_000; // is-active(8s) + show MainPID(8s)
+const MISSION_PREPARE_TIMEOUT_MS = 30_000; // systemctl restart(25s)
+const MISSION_STOP_TIMEOUT_MS = 25_000; // systemctl stop(20s)
 
 /** Thin HTTP client the orchestrator uses to reach one Pi's pi-agent daemon. */
 export class PiAgentClient {
@@ -72,6 +75,22 @@ export class PiAgentClient {
 
   async wifiHotspot(): Promise<SimpleResult> {
     return this.postJson<SimpleResult>("/api/wifi/hotspot", {}, WIFI_HOTSPOT_TIMEOUT_MS);
+  }
+
+  async missionStatus(): Promise<LaunchStatus> {
+    return this.getJson<LaunchStatus>(
+      "/api/mission/status",
+      { success: false, running: false, state: "offline", error: "unreachable" },
+      MISSION_STATUS_TIMEOUT_MS,
+    );
+  }
+
+  async prepareMission(): Promise<SimpleResult> {
+    return this.postJson<SimpleResult>("/api/mission/prepare", {}, MISSION_PREPARE_TIMEOUT_MS);
+  }
+
+  async stopMission(): Promise<SimpleResult> {
+    return this.postJson<SimpleResult>("/api/mission/stop", {}, MISSION_STOP_TIMEOUT_MS);
   }
 
   private async getJson<T>(path: string, onUnreachable: T, timeoutMs: number): Promise<T> {

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from "node:crypto";
+import { Readable } from "node:stream";
 import type { LaunchStatus, WifiScanResult, WifiStatus } from "@pennair/integration-core";
 
 export interface PiAgentClientOptions {
@@ -27,6 +29,58 @@ const WIFI_HOTSPOT_TIMEOUT_MS = 50_000; // policyStatus(15s) + disconnect(15s) +
 const MISSION_STATUS_TIMEOUT_MS = 20_000; // is-active(8s) + show MainPID(8s)
 const MISSION_PREPARE_TIMEOUT_MS = 30_000; // systemctl restart(25s)
 const MISSION_STOP_TIMEOUT_MS = 25_000; // systemctl stop(20s)
+const DEPLOY_CURRENT_TIMEOUT_MS = 10_000;
+const DEPLOY_ROLLBACK_TIMEOUT_MS = 30_000; // matches pi-agent's own activate/health-check-rollback window (8s poll) plus margin
+// Large and variable by design -- artifact size isn't bounded, so this can't
+// be sized off a fixed pi-agent-side exec duration the way the other
+// timeouts above are. 10 minutes comfortably covers a multi-hundred-MB
+// transfer even on a slow travel-router link.
+const DEPLOY_UPLOAD_TIMEOUT_MS = 600_000;
+
+export interface DeployUploadFields {
+  sourceType?: string;
+  sourceLabel?: string;
+  vehicleName?: string;
+  fleetFile?: string;
+}
+
+export interface DeployUploadResult {
+  success: boolean;
+  error?: string;
+  releaseId?: string;
+}
+
+export interface CurrentBuildResult {
+  installed: boolean;
+  releaseId?: string;
+  extractedAt?: string;
+  sourceType?: string;
+  sourceLabel?: string;
+  error?: string;
+}
+
+/** Builds a multipart/form-data body as an async byte stream, so the incoming client upload can be relayed to pi-agent without ever buffering the whole artifact in memory. */
+async function* multipartBody(
+  fields: DeployUploadFields,
+  filename: string,
+  fileStream: AsyncIterable<Buffer>,
+  boundary: string,
+): AsyncGenerator<Buffer> {
+  const encoder = new TextEncoder();
+  for (const [key, value] of Object.entries(fields)) {
+    if (value === undefined) continue;
+    yield Buffer.from(encoder.encode(`--${boundary}\r\nContent-Disposition: form-data; name="${key}"\r\n\r\n${value}\r\n`));
+  }
+  yield Buffer.from(
+    encoder.encode(
+      `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\nContent-Type: application/octet-stream\r\n\r\n`,
+    ),
+  );
+  for await (const chunk of fileStream) {
+    yield chunk;
+  }
+  yield Buffer.from(encoder.encode(`\r\n--${boundary}--\r\n`));
+}
 
 /** Thin HTTP client the orchestrator uses to reach one Pi's pi-agent daemon. */
 export class PiAgentClient {
@@ -91,6 +145,39 @@ export class PiAgentClient {
 
   async stopMission(): Promise<SimpleResult> {
     return this.postJson<SimpleResult>("/api/mission/stop", {}, MISSION_STOP_TIMEOUT_MS);
+  }
+
+  async currentBuild(): Promise<CurrentBuildResult> {
+    return this.getJson<CurrentBuildResult>(
+      "/api/deploy/current",
+      { installed: false, error: "unreachable" },
+      DEPLOY_CURRENT_TIMEOUT_MS,
+    );
+  }
+
+  async rollbackDeploy(): Promise<SimpleResult> {
+    return this.postJson<SimpleResult>("/api/deploy/rollback", {}, DEPLOY_ROLLBACK_TIMEOUT_MS);
+  }
+
+  async uploadDeploy(
+    filename: string,
+    fileStream: AsyncIterable<Buffer>,
+    fields: DeployUploadFields,
+  ): Promise<DeployUploadResult> {
+    const boundary = `----pennair-relay-${randomBytes(8).toString("hex")}`;
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}/api/deploy/upload`, {
+        method: "POST",
+        headers: { "Content-Type": `multipart/form-data; boundary=${boundary}` },
+        body: Readable.from(multipartBody(fields, filename, fileStream, boundary)) as unknown as ReadableStream,
+        // Node's fetch (undici) requires this when the body is a stream.
+        duplex: "half",
+        signal: AbortSignal.timeout(DEPLOY_UPLOAD_TIMEOUT_MS),
+      } as RequestInit);
+      return (await response.json()) as DeployUploadResult;
+    } catch (error) {
+      return { success: false, error: (error as Error).message };
+    }
   }
 
   private async getJson<T>(path: string, onUnreachable: T, timeoutMs: number): Promise<T> {

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
@@ -12,6 +12,19 @@ interface SimpleResult {
   error?: string;
 }
 
+// Sized relative to pi-agent's own internal nmcli exec timeouts for the same
+// operation (policyStatus 15s + the operation's own nmcli calls), plus a
+// margin -- these must stay >= pi-agent's worst case, or the orchestrator
+// would abort a request pi-agent is still legitimately working on. Without
+// an explicit timeout here, a fetch has no default overall request timeout
+// once connected (only a connect-timeout), so a wedged pi-agent could hang
+// the orchestrator indefinitely.
+const HEALTH_TIMEOUT_MS = 5_000;
+const WIFI_STATUS_TIMEOUT_MS = 35_000; // policyStatus(15s) + con show(15s)
+const WIFI_SCAN_TIMEOUT_MS = 25_000; // dev wifi list(20s)
+const WIFI_CONNECT_TIMEOUT_MS = 80_000; // policyStatus(15s) + con down(15s) + connect(30s) + rollback con up(15s)
+const WIFI_HOTSPOT_TIMEOUT_MS = 50_000; // policyStatus(15s) + disconnect(15s) + con up(15s)
+
 /** Thin HTTP client the orchestrator uses to reach one Pi's pi-agent daemon. */
 export class PiAgentClient {
   private readonly baseUrl: string;
@@ -24,7 +37,9 @@ export class PiAgentClient {
 
   async isHealthy(): Promise<boolean> {
     try {
-      const response = await this.fetchImpl(`${this.baseUrl}/health`);
+      const response = await this.fetchImpl(`${this.baseUrl}/health`, {
+        signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+      });
       return response.ok;
     } catch {
       return false;
@@ -32,32 +47,38 @@ export class PiAgentClient {
   }
 
   async wifiStatus(): Promise<WifiStatus> {
-    return this.getJson<WifiStatus>("/api/wifi/status", {
-      success: false,
-      connections: [],
-      error: "unreachable",
-    });
+    return this.getJson<WifiStatus>(
+      "/api/wifi/status",
+      { success: false, connections: [], error: "unreachable" },
+      WIFI_STATUS_TIMEOUT_MS,
+    );
   }
 
   async wifiScan(): Promise<WifiScanResult> {
-    return this.getJson<WifiScanResult>("/api/wifi/scan", {
-      success: false,
-      networks: [],
-      error: "unreachable",
-    });
+    return this.getJson<WifiScanResult>(
+      "/api/wifi/scan",
+      { success: false, networks: [], error: "unreachable" },
+      WIFI_SCAN_TIMEOUT_MS,
+    );
   }
 
   async wifiConnect(ssid: string, password: string): Promise<SimpleResult> {
-    return this.postJson<SimpleResult>("/api/wifi/connect", { ssid, password });
+    return this.postJson<SimpleResult>(
+      "/api/wifi/connect",
+      { ssid, password },
+      WIFI_CONNECT_TIMEOUT_MS,
+    );
   }
 
   async wifiHotspot(): Promise<SimpleResult> {
-    return this.postJson<SimpleResult>("/api/wifi/hotspot", {});
+    return this.postJson<SimpleResult>("/api/wifi/hotspot", {}, WIFI_HOTSPOT_TIMEOUT_MS);
   }
 
-  private async getJson<T>(path: string, onUnreachable: T): Promise<T> {
+  private async getJson<T>(path: string, onUnreachable: T, timeoutMs: number): Promise<T> {
     try {
-      const response = await this.fetchImpl(`${this.baseUrl}${path}`);
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        signal: AbortSignal.timeout(timeoutMs),
+      });
       if (!response.ok) {
         return onUnreachable;
       }
@@ -70,12 +91,14 @@ export class PiAgentClient {
   private async postJson<T extends { success: boolean; error?: string }>(
     path: string,
     body: unknown,
+    timeoutMs: number,
   ): Promise<T> {
     try {
       const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
+        signal: AbortSignal.timeout(timeoutMs),
       });
       const parsed = (await response.json()) as T;
       if (!response.ok && parsed.success === undefined) {

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
@@ -1,7 +1,15 @@
+import type { WifiScanResult, WifiStatus } from "@pennair/integration-core";
+
 export interface PiAgentClientOptions {
   hostname: string;
   port: number;
   fetchImpl?: typeof fetch;
+}
+
+interface SimpleResult {
+  success: boolean;
+  output?: string;
+  error?: string;
 }
 
 /** Thin HTTP client the orchestrator uses to reach one Pi's pi-agent daemon. */
@@ -20,6 +28,62 @@ export class PiAgentClient {
       return response.ok;
     } catch {
       return false;
+    }
+  }
+
+  async wifiStatus(): Promise<WifiStatus> {
+    return this.getJson<WifiStatus>("/api/wifi/status", {
+      success: false,
+      connections: [],
+      error: "unreachable",
+    });
+  }
+
+  async wifiScan(): Promise<WifiScanResult> {
+    return this.getJson<WifiScanResult>("/api/wifi/scan", {
+      success: false,
+      networks: [],
+      error: "unreachable",
+    });
+  }
+
+  async wifiConnect(ssid: string, password: string): Promise<SimpleResult> {
+    return this.postJson<SimpleResult>("/api/wifi/connect", { ssid, password });
+  }
+
+  async wifiHotspot(): Promise<SimpleResult> {
+    return this.postJson<SimpleResult>("/api/wifi/hotspot", {});
+  }
+
+  private async getJson<T>(path: string, onUnreachable: T): Promise<T> {
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`);
+      if (!response.ok) {
+        return onUnreachable;
+      }
+      return (await response.json()) as T;
+    } catch {
+      return onUnreachable;
+    }
+  }
+
+  private async postJson<T extends { success: boolean; error?: string }>(
+    path: string,
+    body: unknown,
+  ): Promise<T> {
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const parsed = (await response.json()) as T;
+      if (!response.ok && parsed.success === undefined) {
+        return { success: false, error: "unreachable" } as T;
+      }
+      return parsed;
+    } catch {
+      return { success: false, error: "unreachable" } as T;
     }
   }
 }

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
@@ -53,12 +53,16 @@ export interface DeployUploadResult {
   releaseId?: string;
 }
 
+// Matches pi-agent's real /api/deploy/current response (deploy.ts's
+// CurrentBuildStatus) -- this previously declared extractedAt/sourceType/
+// sourceLabel fields that don't exist on the wire and dropped the real
+// `info` field entirely, a mismatch that went unnoticed because nothing
+// read `info` from a currentBuild() call until the fleet board needed it.
 export interface CurrentBuildResult {
+  success: boolean;
   installed: boolean;
+  info?: string;
   releaseId?: string;
-  extractedAt?: string;
-  sourceType?: string;
-  sourceLabel?: string;
   error?: string;
 }
 
@@ -171,7 +175,7 @@ export class PiAgentClient {
   async currentBuild(): Promise<CurrentBuildResult> {
     return this.getJson<CurrentBuildResult>(
       "/api/deploy/current",
-      { installed: false, error: "unreachable" },
+      { success: false, installed: false, error: "unreachable" },
       DEPLOY_CURRENT_TIMEOUT_MS,
     );
   }

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
@@ -1,0 +1,25 @@
+export interface PiAgentClientOptions {
+  hostname: string;
+  port: number;
+  fetchImpl?: typeof fetch;
+}
+
+/** Thin HTTP client the orchestrator uses to reach one Pi's pi-agent daemon. */
+export class PiAgentClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: PiAgentClientOptions) {
+    this.baseUrl = `http://${options.hostname}:${options.port}`;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async isHealthy(): Promise<boolean> {
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}/health`);
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/pi-agent-client.ts
@@ -36,6 +36,9 @@ const DEPLOY_ROLLBACK_TIMEOUT_MS = 30_000; // matches pi-agent's own activate/he
 // timeouts above are. 10 minutes comfortably covers a multi-hundred-MB
 // transfer even on a slow travel-router link.
 const DEPLOY_UPLOAD_TIMEOUT_MS = 600_000;
+const SCHEMA_EXPORT_TIMEOUT_MS = 35_000; // pi-agent's own schema_export.py subprocess timeout (30s) plus margin
+const MISSION_NAMES_TIMEOUT_MS = 10_000;
+const FILE_READ_WRITE_TIMEOUT_MS = 10_000; // local fs read/write on the Pi, not a slow exec
 
 export interface DeployUploadFields {
   sourceType?: string;
@@ -56,6 +59,24 @@ export interface CurrentBuildResult {
   extractedAt?: string;
   sourceType?: string;
   sourceLabel?: string;
+  error?: string;
+}
+
+export interface SchemaExportResult {
+  success: boolean;
+  schema?: unknown;
+  error?: string;
+}
+
+export interface MissionNamesResult {
+  success: boolean;
+  missions: string[];
+  error?: string;
+}
+
+export interface FileResult {
+  success: boolean;
+  content?: string;
   error?: string;
 }
 
@@ -157,6 +178,42 @@ export class PiAgentClient {
 
   async rollbackDeploy(): Promise<SimpleResult> {
     return this.postJson<SimpleResult>("/api/deploy/rollback", {}, DEPLOY_ROLLBACK_TIMEOUT_MS);
+  }
+
+  async schema(): Promise<SchemaExportResult> {
+    return this.getJson<SchemaExportResult>("/api/schema", { success: false, error: "unreachable" }, SCHEMA_EXPORT_TIMEOUT_MS);
+  }
+
+  async missionNames(): Promise<MissionNamesResult> {
+    return this.getJson<MissionNamesResult>(
+      "/api/mission/mission-names",
+      { success: false, missions: [], error: "unreachable" },
+      MISSION_NAMES_TIMEOUT_MS,
+    );
+  }
+
+  async readMissionFile(name: string): Promise<FileResult> {
+    return this.getJson<FileResult>(
+      `/api/mission/mission-file?name=${encodeURIComponent(name)}`,
+      { success: false, error: "unreachable" },
+      FILE_READ_WRITE_TIMEOUT_MS,
+    );
+  }
+
+  async writeMissionFile(name: string, content: string): Promise<FileResult> {
+    return this.postJson<FileResult>("/api/mission/mission-file", { name, content }, FILE_READ_WRITE_TIMEOUT_MS);
+  }
+
+  async readFleetFile(name: string): Promise<FileResult> {
+    return this.getJson<FileResult>(
+      `/api/fleet/fleet-file?name=${encodeURIComponent(name)}`,
+      { success: false, error: "unreachable" },
+      FILE_READ_WRITE_TIMEOUT_MS,
+    );
+  }
+
+  async writeFleetFile(name: string, content: string): Promise<FileResult> {
+    return this.postJson<FileResult>("/api/fleet/fleet-file", { name, content }, FILE_READ_WRITE_TIMEOUT_MS);
   }
 
   async uploadDeploy(

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/ros/trigger-service-client.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/ros/trigger-service-client.ts
@@ -6,24 +6,34 @@ export interface TriggerResult {
 /** Calls a `std_srvs/srv/Trigger` ROS2 service and returns its response. */
 export type TriggerServiceCaller = (serviceName: string) => Promise<TriggerResult>;
 
+// Verified against the real published rclnodejs@2.1.1 type declarations
+// (downloaded via `npm pack`, since the package can't actually build/install
+// without a sourced ROS2 environment -- see loadRclnodejs below). Two things
+// were wrong in an earlier draft, caught by review rather than by tests
+// (nothing here can be exercised against the real package in this repo's
+// dev/CI environment): `sendRequest` is callback-based and returns nothing --
+// the promise API is `sendRequestAsync`. And `createClient`'s `typeClass`
+// argument must be the class object returned by `rclnodejs.require(...)`,
+// not a plain string.
 interface RclNodeJsModule {
   init(): Promise<void>;
   createNode(name: string): RclNode;
   shutdown(): void;
+  require(interfaceName: string): unknown;
 }
 
 interface RclNode {
-  createClient(type: string, name: string): RclServiceClient;
+  createClient(typeClass: unknown, name: string): RclServiceClient;
   spin(): void;
 }
 
 interface RclServiceClient {
   waitForService(timeoutMs: number): Promise<boolean>;
-  sendRequest(request: Record<string, never>): Promise<{ success: boolean; message: string }>;
+  sendRequestAsync(
+    request: Record<string, never>,
+    options?: { timeout?: number },
+  ): Promise<{ success: boolean; message: string }>;
 }
-
-let cachedNode: RclNode | null = null;
-const cachedClients = new Map<string, RclServiceClient>();
 
 async function loadRclnodejs(): Promise<RclNodeJsModule> {
   try {
@@ -31,7 +41,8 @@ async function loadRclnodejs(): Promise<RclNodeJsModule> {
     // that can only build/install inside a sourced ROS2 environment. This
     // import must never happen at module load time -- only when a mission-RPC
     // endpoint is actually called -- so the orchestrator still starts and
-    // serves every other endpoint fine on a machine without ROS2.
+    // serves every other endpoint fine on a machine without ROS2. Node's ESM
+    // loader caches dynamic imports, so calling this repeatedly is cheap.
     const rclnodejs = (await import("rclnodejs")) as unknown as RclNodeJsModule;
     return rclnodejs;
   } catch (error) {
@@ -43,22 +54,65 @@ async function loadRclnodejs(): Promise<RclNodeJsModule> {
   }
 }
 
-async function getNode(): Promise<RclNode> {
-  if (cachedNode) return cachedNode;
+async function initNode(): Promise<RclNode> {
   const rclnodejs = await loadRclnodejs();
   await rclnodejs.init();
-  cachedNode = rclnodejs.createNode("pennair_orchestrator");
-  cachedNode.spin();
-  return cachedNode;
+  const node = rclnodejs.createNode("pennair_orchestrator");
+  node.spin();
+  return node;
 }
 
-async function getClient(serviceName: string): Promise<RclServiceClient> {
-  const existing = cachedClients.get(serviceName);
+async function loadTriggerType(): Promise<unknown> {
+  const rclnodejs = await loadRclnodejs();
+  return rclnodejs.require("std_srvs/srv/Trigger");
+}
+
+// Cache the in-flight *promise*, not just the eventual value. This gives two
+// things a plain "cache the resolved value" approach doesn't:
+//  - single-flight: concurrent first calls (e.g. two simultaneous start-mission
+//    requests before anything is initialized) all await the same promise
+//    instead of racing to independently call rclnodejs.init()/createNode().
+//  - failure doesn't poison the cache forever: if initialization throws at any
+//    point, the cached promise is reset to null so the *next* call gets a
+//    fresh attempt, rather than permanently caching a broken result with no
+//    recovery short of a restart.
+let nodePromise: Promise<RclNode> | null = null;
+let triggerTypePromise: Promise<unknown> | null = null;
+
+function getNode(): Promise<RclNode> {
+  if (!nodePromise) {
+    nodePromise = initNode().catch((error: unknown) => {
+      nodePromise = null;
+      throw error;
+    });
+  }
+  return nodePromise;
+}
+
+function getTriggerType(): Promise<unknown> {
+  if (!triggerTypePromise) {
+    triggerTypePromise = loadTriggerType().catch((error: unknown) => {
+      triggerTypePromise = null;
+      throw error;
+    });
+  }
+  return triggerTypePromise;
+}
+
+const clientPromises = new Map<string, Promise<RclServiceClient>>();
+
+function getClient(serviceName: string): Promise<RclServiceClient> {
+  const existing = clientPromises.get(serviceName);
   if (existing) return existing;
-  const node = await getNode();
-  const client = node.createClient("std_srvs/srv/Trigger", serviceName);
-  cachedClients.set(serviceName, client);
-  return client;
+
+  const promise = Promise.all([getNode(), getTriggerType()])
+    .then(([node, triggerType]) => node.createClient(triggerType, serviceName))
+    .catch((error: unknown) => {
+      clientPromises.delete(serviceName);
+      throw error;
+    });
+  clientPromises.set(serviceName, promise);
+  return promise;
 }
 
 /** Real Trigger-service caller, backed by rclnodejs -- the default, unless a test injects a fake one. */
@@ -68,6 +122,6 @@ export const rclnodejsTriggerServiceCaller: TriggerServiceCaller = async (servic
   if (!available) {
     return { success: false, message: `Service ${serviceName} is not available` };
   }
-  const response = await client.sendRequest({});
+  const response = await client.sendRequestAsync({}, { timeout: 10_000 });
   return { success: response.success, message: response.message };
 };

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/ros/trigger-service-client.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/ros/trigger-service-client.ts
@@ -1,0 +1,73 @@
+export interface TriggerResult {
+  success: boolean;
+  message: string;
+}
+
+/** Calls a `std_srvs/srv/Trigger` ROS2 service and returns its response. */
+export type TriggerServiceCaller = (serviceName: string) => Promise<TriggerResult>;
+
+interface RclNodeJsModule {
+  init(): Promise<void>;
+  createNode(name: string): RclNode;
+  shutdown(): void;
+}
+
+interface RclNode {
+  createClient(type: string, name: string): RclServiceClient;
+  spin(): void;
+}
+
+interface RclServiceClient {
+  waitForService(timeoutMs: number): Promise<boolean>;
+  sendRequest(request: Record<string, never>): Promise<{ success: boolean; message: string }>;
+}
+
+let cachedNode: RclNode | null = null;
+const cachedClients = new Map<string, RclServiceClient>();
+
+async function loadRclnodejs(): Promise<RclNodeJsModule> {
+  try {
+    // Dynamic import: rclnodejs is an *optional* dependency (see package.json)
+    // that can only build/install inside a sourced ROS2 environment. This
+    // import must never happen at module load time -- only when a mission-RPC
+    // endpoint is actually called -- so the orchestrator still starts and
+    // serves every other endpoint fine on a machine without ROS2.
+    const rclnodejs = (await import("rclnodejs")) as unknown as RclNodeJsModule;
+    return rclnodejs;
+  } catch (error) {
+    throw new Error(
+      "rclnodejs is not available. Mission RPC (start mission / failsafe) requires " +
+        "running the orchestrator in a sourced ROS2 environment on the fleet's " +
+        `ROS_DOMAIN_ID. Underlying error: ${(error as Error).message}`,
+    );
+  }
+}
+
+async function getNode(): Promise<RclNode> {
+  if (cachedNode) return cachedNode;
+  const rclnodejs = await loadRclnodejs();
+  await rclnodejs.init();
+  cachedNode = rclnodejs.createNode("pennair_orchestrator");
+  cachedNode.spin();
+  return cachedNode;
+}
+
+async function getClient(serviceName: string): Promise<RclServiceClient> {
+  const existing = cachedClients.get(serviceName);
+  if (existing) return existing;
+  const node = await getNode();
+  const client = node.createClient("std_srvs/srv/Trigger", serviceName);
+  cachedClients.set(serviceName, client);
+  return client;
+}
+
+/** Real Trigger-service caller, backed by rclnodejs -- the default, unless a test injects a fake one. */
+export const rclnodejsTriggerServiceCaller: TriggerServiceCaller = async (serviceName) => {
+  const client = await getClient(serviceName);
+  const available = await client.waitForService(5_000);
+  if (!available) {
+    return { success: false, message: `Service ${serviceName} is not available` };
+  }
+  const response = await client.sendRequest({});
+  return { success: response.success, message: response.message };
+};

--- a/controls/sae_2025_ws/integration/packages/orchestrator/src/types/rclnodejs.d.ts
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/src/types/rclnodejs.d.ts
@@ -1,0 +1,6 @@
+// rclnodejs is an optional dependency (see package.json) that only builds in
+// a sourced ROS2 environment, so its own types aren't reliably available here.
+// This ambient declaration lets `import("rclnodejs")` typecheck regardless of
+// whether the real package is actually installed; trigger-service-client.ts
+// re-types its actual shape locally instead of trusting this blindly.
+declare module "rclnodejs";

--- a/controls/sae_2025_ws/integration/packages/orchestrator/tsconfig.build.json
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/controls/sae_2025_ws/integration/packages/orchestrator/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/tsconfig.json
@@ -2,10 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ES2022"],
-    "outDir": "dist",
-    "rootDir": "src"
+    "composite": false,
+    "noEmit": true
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"],
-  "references": [{ "path": "../core" }]
+  "include": ["src"]
 }

--- a/controls/sae_2025_ws/integration/packages/orchestrator/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../core" }]
+}

--- a/controls/sae_2025_ws/integration/packages/orchestrator/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/orchestrator/tsconfig.json
@@ -6,5 +6,6 @@
     "rootDir": "src"
   },
   "include": ["src"],
+  "exclude": ["src/**/*.test.ts"],
   "references": [{ "path": "../core" }]
 }

--- a/controls/sae_2025_ws/integration/packages/pi-agent/package.json
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/package.json
@@ -6,7 +6,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
     "start": "node dist/index.js",
     "test": "vitest run"
   },

--- a/controls/sae_2025_ws/integration/packages/pi-agent/package.json
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@pennair/integration-core": "*",
     "fastify": "^5.1.0"
   }
 }

--- a/controls/sae_2025_ws/integration/packages/pi-agent/package.json
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/package.json
@@ -12,8 +12,10 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@fastify/multipart": "^9.0.1",
     "@fastify/websocket": "^11.0.2",
     "@pennair/integration-core": "*",
-    "fastify": "^5.1.0"
+    "fastify": "^5.1.0",
+    "tar": "^7.4.3"
   }
 }

--- a/controls/sae_2025_ws/integration/packages/pi-agent/package.json
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@fastify/websocket": "^11.0.2",
     "@pennair/integration-core": "*",
     "fastify": "^5.1.0"
   }

--- a/controls/sae_2025_ws/integration/packages/pi-agent/package.json
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@pennair/pi-agent",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --build",
+    "start": "node dist/index.js",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "fastify": "^5.1.0"
+  }
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy-concurrency.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy-concurrency.test.ts
@@ -1,0 +1,116 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as tar from "tar";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deployPaths, type DeployPaths } from "./deploy-paths.js";
+import { pathExists, resolveSymlinkTarget } from "./deploy-fs.js";
+import { extractRelease } from "./deploy.js";
+
+/** Builds a real .tar.gz fixture, same helper shape as deploy.test.ts. */
+async function buildFixtureArtifact(dir: string, name: string, marker: string): Promise<string> {
+  const stagingDir = join(dir, `staging-${marker}`);
+  await mkdir(join(stagingDir, "install"), { recursive: true });
+  await writeFile(join(stagingDir, "install", "marker.txt"), marker, "utf-8");
+  const artifactPath = join(dir, name);
+  await tar.c({ file: artifactPath, cwd: stagingDir }, ["install"]);
+  return artifactPath;
+}
+
+/**
+ * Regression test for a concurrency bug that used to exist in extractRelease
+ * (packages/pi-agent/src/deploy.ts): nothing serialized overlapping deploy
+ * requests, so `symlinkForce`'s non-atomic rm-then-symlink and the
+ * independent-per-call "prune stale releases" pass could corrupt release
+ * state under concurrent calls (EEXIST crashes, a dangling `current` symlink,
+ * or losing a release directory entirely). Fixed by serializing
+ * extractRelease/activateRelease/rollbackRelease/deployArtifact through a
+ * single in-process mutex (`withDeployLock` in deploy.ts) -- a single pi-agent
+ * process only ever manages one deploy root, so this doesn't need to be a
+ * cross-process/file lock.
+ */
+describe("extractRelease concurrency (packages/pi-agent/src/deploy.ts, deploy-fs.ts)", () => {
+  let scratchRoot: string;
+  let paths: DeployPaths;
+
+  beforeEach(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "pi-agent-deploy-race-test-"));
+    paths = deployPaths(scratchRoot);
+  });
+
+  afterEach(async () => {
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  it("two concurrent first-time deploys never corrupt release state (no thrown EEXIST, no dangling current symlink, no lost release)", async () => {
+    // Run several trials with fresh scratch dirs -- before the deploy lock
+    // existed, this reproduced on effectively every attempt on a real
+    // filesystem (confirmed manually: 8/8 trials outside vitest). We only
+    // need one trial to show corruption for the test to fail.
+    let reproduced = false;
+    let lastDetail = "";
+
+    for (let trial = 0; trial < 5 && !reproduced; trial++) {
+      const trialRoot = await mkdtemp(join(tmpdir(), "pi-agent-deploy-race-trial-"));
+      const trialPaths = deployPaths(trialRoot);
+      const now = () => Date.now(); // both calls share "the same second"
+
+      const artifactA = await buildFixtureArtifact(trialRoot, "a.tar.gz", "A");
+      const artifactB = await buildFixtureArtifact(trialRoot, "b.tar.gz", "B");
+
+      const settled = await Promise.allSettled([
+        extractRelease(artifactA, "a.tar.gz", trialPaths, now),
+        extractRelease(artifactB, "b.tar.gz", trialPaths, now),
+      ]);
+
+      const rejected = settled.filter((s): s is PromiseRejectedResult => s.status === "rejected");
+      if (rejected.length > 0) {
+        reproduced = true;
+        lastDetail = `a concurrent extractRelease call threw: ${rejected[0].reason}`;
+      } else {
+        const fulfilled = settled as PromiseFulfilledResult<Awaited<ReturnType<typeof extractRelease>>>[];
+        const currentTarget = await resolveSymlinkTarget(trialPaths.currentLink);
+        const currentExists = currentTarget ? await pathExists(currentTarget) : false;
+        const releaseDirsStillExist = await Promise.all(fulfilled.map((f) => pathExists(f.value.releaseDir)));
+
+        if ((currentTarget && !currentExists) || releaseDirsStillExist.some((exists) => !exists)) {
+          reproduced = true;
+          lastDetail = `currentTarget=${currentTarget} currentExists=${currentExists} releaseDirsStillExist=${releaseDirsStillExist.join(",")}`;
+        }
+      }
+
+      await rm(trialRoot, { recursive: true, force: true });
+    }
+
+    expect(reproduced, `expected no corruption from concurrent deploys, but observed: ${lastDetail}`).toBe(false);
+  });
+
+  it("two sequential deploys within the same second, with the same artifact filename, get distinct releaseIds and a real previous release", async () => {
+    // releaseTimestamp() (deploy.ts:27-29) truncates to whole seconds, so two
+    // deploys of an identically-named artifact inside the same second (a very
+    // plausible double-submit, e.g. an operator double-clicking "Deploy", or a
+    // client retry after a slow-but-successful response) would collide on
+    // releaseId without a disambiguating suffix. extractRelease appends a
+    // random suffix specifically so this can't happen -- verified here rather
+    // than assumed.
+    const fixedNow = () => new Date("2026-01-15T10:00:00.000Z").getTime();
+
+    const artifactV1 = await buildFixtureArtifact(scratchRoot, "build.tar.gz", "v1");
+    const first = await extractRelease(artifactV1, "build.tar.gz", paths, fixedNow);
+
+    const artifactV2 = await buildFixtureArtifact(scratchRoot, "build.tar.gz", "v2");
+    const second = await extractRelease(artifactV2, "build.tar.gz", paths, fixedNow);
+
+    // Distinct releaseId/releaseDir despite the identical timestamp+filename.
+    expect(second.releaseId).not.toBe(first.releaseId);
+    expect(second.releaseDir).not.toBe(first.releaseDir);
+
+    // `previous` correctly points at the first release, not at the same
+    // directory as `current` -- rollbackRelease has a real release to revert to.
+    const currentTarget = await resolveSymlinkTarget(paths.currentLink);
+    const previousTarget = await resolveSymlinkTarget(paths.previousLink);
+    expect(currentTarget).toBe(second.releaseDir);
+    expect(previousTarget).toBe(first.releaseDir);
+    expect(previousTarget).not.toBe(currentTarget);
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy-fs.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy-fs.ts
@@ -1,0 +1,31 @@
+import { lstat, readlink, rm, symlink } from "node:fs/promises";
+
+export async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolves a symlink to an absolute target -- closer to `readlink -f` than
+ *  plain `fs.readlink` (which can return a relative target), but doesn't
+ *  require the target to actually exist (unlike `fs.realpath`), matching
+ *  the old bash's tolerance for a broken/dangling previous-release link. */
+export async function resolveSymlinkTarget(path: string): Promise<string> {
+  const stat = await lstat(path).catch(() => null);
+  if (!stat) return "";
+  if (stat.isDirectory()) return path;
+  if (!stat.isSymbolicLink()) return "";
+  const target = await readlink(path);
+  return target;
+}
+
+/** `ln -sfn target path` -- remove whatever's at `path` first (file, dir, or
+ *  stale symlink), then create a fresh symlink. Node's `fs.symlink` errors if
+ *  something already exists at the destination. */
+export async function symlinkForce(target: string, path: string): Promise<void> {
+  await rm(path, { force: true, recursive: true });
+  await symlink(target, path);
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy-malicious-archive.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy-malicious-archive.test.ts
@@ -1,0 +1,94 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deployPaths, type DeployPaths } from "./deploy-paths.js";
+import { pathExists } from "./deploy-fs.js";
+import { extractRelease } from "./deploy.js";
+
+describe("extractRelease with malformed/malicious archives (packages/pi-agent/src/deploy.ts)", () => {
+  let scratchRoot: string;
+  let paths: DeployPaths;
+
+  beforeEach(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "pi-agent-malicious-archive-test-"));
+    paths = deployPaths(scratchRoot);
+  });
+
+  afterEach(async () => {
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  /**
+   * Regression test: when `tar.x` throws (a non-gzip file, a
+   * truncated/corrupted download, garbage bytes), extractRelease now cleans
+   * up both the raw uploaded artifact and the just-created empty release
+   * directory before rethrowing, instead of leaking them on every
+   * failed/garbage upload -- a real disk-exhaustion risk on a
+   * storage-constrained Raspberry Pi given a flaky field WiFi link.
+   */
+  it("cleans up the incoming artifact file and the empty release dir when the archive is not a valid tar.gz", async () => {
+    const artifactPath = join(scratchRoot, "garbage.tar.gz");
+    await writeFile(artifactPath, randomBytes(4096)); // not a valid gzip/tar stream
+
+    await expect(extractRelease(artifactPath, "garbage.tar.gz", paths)).rejects.toThrow();
+
+    expect(await pathExists(artifactPath), "the raw uploaded artifact should not be left behind after a failed extraction").toBe(false);
+
+    const releasesEntries = await readdir(paths.releasesDir).catch(() => []);
+    expect(releasesEntries, "no empty/partial release directory should be left behind after a failed extraction").toEqual([]);
+  });
+
+  it("does not let a crafted archive with ../-escaping entry names write outside the release directory", async () => {
+    // node-tar (v7.x) sanitizes both absolute paths and ../ traversal by
+    // default -- this is a real check (not assumed), confirming the
+    // extraction path itself is safe against a classic path-traversal tar.
+    const outsideDir = join(scratchRoot, "outside-canary");
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(join(outsideDir, "canary.txt"), "ORIGINAL", "utf-8");
+
+    // Hand-build a minimal ustar archive with a ../-escaping entry, since
+    // the real `tar` package's own .c() sanitizes input paths on creation
+    // (we need to bypass that to build a genuinely malicious archive).
+    function ustarHeader(name: string, size: number): Buffer {
+      const buf = Buffer.alloc(512);
+      buf.write(name, 0, 100, "utf-8");
+      buf.write("0000777\0", 100, 8, "utf-8");
+      buf.write("0000000\0", 108, 8, "utf-8");
+      buf.write("0000000\0", 116, 8, "utf-8");
+      buf.write(size.toString(8).padStart(11, "0") + "\0", 124, 12, "utf-8");
+      buf.write("00000000000\0", 136, 12, "utf-8");
+      buf.write("        ", 148, 8, "utf-8");
+      buf.write("0", 156, 1, "utf-8");
+      buf.write("ustar\0", 257, 6, "utf-8");
+      buf.write("00", 263, 2, "utf-8");
+      let sum = 0;
+      for (let i = 0; i < 512; i++) sum += buf[i];
+      buf.write(sum.toString(8).padStart(6, "0") + "\0 ", 148, 8, "utf-8");
+      return buf;
+    }
+    function fileEntry(name: string, content: string): Buffer {
+      const data = Buffer.from(content, "utf-8");
+      const header = ustarHeader(name, data.length);
+      const padLen = (512 - (data.length % 512)) % 512;
+      return Buffer.concat([header, data, Buffer.alloc(padLen)]);
+    }
+
+    const zlib = await import("node:zlib");
+    const entries = Buffer.concat([
+      fileEntry("install/marker.txt", "v1"),
+      fileEntry("../../outside-canary/canary.txt", "OVERWRITTEN"),
+      Buffer.alloc(1024),
+    ]);
+    const archivePath = join(scratchRoot, "traversal.tar.gz");
+    await writeFile(archivePath, zlib.gzipSync(entries));
+
+    const result = await extractRelease(archivePath, "traversal.tar.gz", paths);
+    expect(await pathExists(`${result.releaseDir}/install/marker.txt`)).toBe(true);
+
+    const { readFile } = await import("node:fs/promises");
+    const canaryContent = await readFile(join(outsideDir, "canary.txt"), "utf-8");
+    expect(canaryContent).toBe("ORIGINAL"); // confirms the traversal entry did NOT escape releaseDir
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy-paths.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy-paths.ts
@@ -1,0 +1,38 @@
+export interface DeployPaths {
+  deployRoot: string;
+  incomingDir: string;
+  releasesDir: string;
+  currentLink: string;
+  previousLink: string;
+  configDir: string;
+  stateDir: string;
+  missionsDir: string;
+  runtimeFleet: string;
+  fleetFile: string;
+  overlayFile: string;
+  runnerScript: string;
+}
+
+function defaultDeployRoot(): string {
+  return (process.env.DEPLOY_ROOT ?? "/home/penn/pennair-deploy").replace(/\/$/, "");
+}
+
+// `root` is read lazily (not captured at module load) so tests can point
+// this at a scratch directory via the parameter without needing to set
+// process.env before this module is first imported.
+export function deployPaths(root: string = defaultDeployRoot()): DeployPaths {
+  return {
+    deployRoot: root,
+    incomingDir: `${root}/incoming`,
+    releasesDir: `${root}/releases`,
+    currentLink: `${root}/current`,
+    previousLink: `${root}/previous`,
+    configDir: `${root}/config`,
+    stateDir: `${root}/state`,
+    missionsDir: `${root}/config/missions`,
+    runtimeFleet: `${root}/config/runtime_fleet.yaml`,
+    fleetFile: `${root}/config/fleet.yaml`,
+    overlayFile: `${root}/config/overlay.yaml`,
+    runnerScript: `${root}/config/start-current.sh`,
+  };
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy-upload-abort.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy-upload-abort.test.ts
@@ -1,0 +1,83 @@
+import { randomBytes } from "node:crypto";
+import { Readable } from "node:stream";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { buildServer } from "./index.js";
+
+/**
+ * Regression test: pi-agent's /api/deploy/upload handler now wraps the
+ * `request.parts()` loop in a try/catch and removes the partial file it had
+ * already streamed into `incoming/` if the upload is interrupted (client
+ * disconnect, network blip, timeout) before finishing -- previously that
+ * partial file was left behind forever, since it's never referenced by
+ * extractRelease's own cleanup (which only runs for a fully-received artifact
+ * that actually made it to `deployArtifact`). Repeated interrupted uploads
+ * (very plausible on a flaky field WiFi link to a Pi) would otherwise
+ * accumulate orphaned multi-hundred-MB files in `incoming/`.
+ */
+describe("pi-agent /api/deploy/upload cleans up a partial file after an aborted upload", () => {
+  let scratchRoot: string;
+  let app: ReturnType<typeof buildServer>;
+  let port: number;
+  const originalDeployRoot = process.env.DEPLOY_ROOT;
+
+  beforeAll(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "pi-agent-abort-test-"));
+    process.env.DEPLOY_ROOT = scratchRoot;
+    app = buildServer();
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (typeof address === "string" || address === null) throw new Error("expected a TCP port");
+    port = address.port;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    process.env.DEPLOY_ROOT = originalDeployRoot;
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    await rm(`${scratchRoot}/incoming`, { recursive: true, force: true });
+  });
+
+  it("does not leave a partial file in incoming/ after the client aborts mid-upload", async () => {
+    const boundary = "----abort-test-boundary";
+    async function* slowChunks() {
+      for (let i = 0; i < 200; i++) {
+        yield randomBytes(256 * 1024);
+        await new Promise((resolve) => setTimeout(resolve, 15));
+      }
+    }
+    async function* body() {
+      const encoder = new TextEncoder();
+      yield Buffer.from(
+        encoder.encode(
+          `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="aborted.tar.gz"\r\nContent-Type: application/octet-stream\r\n\r\n`,
+        ),
+      );
+      for await (const chunk of slowChunks()) yield chunk;
+      yield Buffer.from(encoder.encode(`\r\n--${boundary}--\r\n`));
+    }
+
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 200);
+
+    await fetch(`http://127.0.0.1:${port}/api/deploy/upload`, {
+      method: "POST",
+      headers: { "Content-Type": `multipart/form-data; boundary=${boundary}` },
+      body: Readable.from(body()) as unknown as ReadableStream,
+      duplex: "half",
+      signal: controller.signal,
+    } as RequestInit).catch(() => {
+      // Expected: the client-side fetch itself rejects once aborted.
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 500)); // let the server settle post-abort
+
+    const incomingContents = await readdir(`${scratchRoot}/incoming`).catch(() => []);
+    expect(incomingContents).toEqual([]);
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy.test.ts
@@ -1,0 +1,311 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as tar from "tar";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CommandRunner, ExecResult } from "./exec.js";
+import { deployPaths, type DeployPaths } from "./deploy-paths.js";
+import { pathExists, resolveSymlinkTarget } from "./deploy-fs.js";
+import {
+  activateRelease,
+  currentBuild,
+  deployArtifact,
+  extractRelease,
+  rollbackRelease,
+  writeReleaseMetadata,
+} from "./deploy.js";
+
+function ok(stdout = ""): ExecResult {
+  return { code: 0, stdout, stderr: "" };
+}
+function fail(stderr: string): ExecResult {
+  return { code: 1, stdout: "", stderr };
+}
+const noWait = async () => {};
+
+/** Builds a real .tar.gz fixture (using the same `tar` package deploy.ts
+ *  uses to extract) containing an install/ dir, so extraction is exercised
+ *  against a real archive, not a mock. */
+async function buildFixtureArtifact(dir: string, name: string, marker: string): Promise<string> {
+  const stagingDir = join(dir, "staging");
+  await mkdir(join(stagingDir, "install"), { recursive: true });
+  await writeFile(join(stagingDir, "install", "marker.txt"), marker, "utf-8");
+  const artifactPath = join(dir, name);
+  await tar.c({ file: artifactPath, cwd: stagingDir }, ["install"]);
+  return artifactPath;
+}
+
+describe("deploy.ts (real filesystem, faked systemctl)", () => {
+  let scratchRoot: string;
+  let paths: DeployPaths;
+
+  beforeEach(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "pi-agent-deploy-test-"));
+    paths = deployPaths(scratchRoot);
+  });
+
+  afterEach(async () => {
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  describe("extractRelease", () => {
+    it("extracts a real tarball into a timestamped release dir and points current at it", async () => {
+      const artifactPath = await buildFixtureArtifact(scratchRoot, "build.tar.gz", "v1");
+      const now = () => new Date("2026-01-15T10:30:00Z").getTime();
+
+      const result = await extractRelease(artifactPath, "build.tar.gz", paths, now);
+
+      expect(result.releaseId).toBe("20260115-103000-build");
+      expect(await pathExists(`${result.releaseDir}/install/marker.txt`)).toBe(true);
+      expect(await resolveSymlinkTarget(paths.currentLink)).toBe(result.releaseDir);
+      expect(await pathExists(artifactPath)).toBe(false); // artifact cleaned up after extraction
+      expect(result.previousTarget).toBe(""); // nothing was current before
+    });
+
+    it("keeps the old current as previous, and prunes any other stale release dirs", async () => {
+      const firstArtifact = await buildFixtureArtifact(scratchRoot, "first.tar.gz", "v1");
+      const first = await extractRelease(firstArtifact, "first.tar.gz", paths, () =>
+        new Date("2026-01-15T10:00:00Z").getTime(),
+      );
+
+      const secondArtifact = await buildFixtureArtifact(scratchRoot, "second.tar.gz", "v2");
+      const second = await extractRelease(secondArtifact, "second.tar.gz", paths, () =>
+        new Date("2026-01-15T11:00:00Z").getTime(),
+      );
+
+      expect(second.previousTarget).toBe(first.releaseDir);
+      expect(await resolveSymlinkTarget(paths.currentLink)).toBe(second.releaseDir);
+      expect(await resolveSymlinkTarget(paths.previousLink)).toBe(first.releaseDir);
+
+      // A stray unrelated directory in releases/ should be pruned since it's
+      // neither the new current nor the retained previous.
+      const strayDir = `${paths.releasesDir}/some-stray-release`;
+      await mkdir(strayDir, { recursive: true });
+      const thirdArtifact = await buildFixtureArtifact(scratchRoot, "third.tar.gz", "v3");
+      await extractRelease(thirdArtifact, "third.tar.gz", paths, () => new Date("2026-01-15T12:00:00Z").getTime());
+      expect(await pathExists(strayDir)).toBe(false);
+      // the now-two-releases-back "first" should also have been pruned
+      expect(await pathExists(first.releaseDir)).toBe(false);
+    });
+
+    it("throws and cleans up if the archive has no install/ directory", async () => {
+      const stagingDir = join(scratchRoot, "bad-staging");
+      await mkdir(join(stagingDir, "not-install"), { recursive: true });
+      await writeFile(join(stagingDir, "not-install", "f.txt"), "x", "utf-8");
+      const artifactPath = join(scratchRoot, "bad.tar.gz");
+      await tar.c({ file: artifactPath, cwd: stagingDir }, ["not-install"]);
+
+      await expect(extractRelease(artifactPath, "bad.tar.gz", paths)).rejects.toThrow(/install/);
+    });
+  });
+
+  describe("activateRelease", () => {
+    it("succeeds once the service reports a stable active pid", async () => {
+      const releaseDir = `${paths.releasesDir}/rel-1`;
+      let call = 0;
+      const run: CommandRunner = async (command, args) => {
+        const key = [command, ...args].join(" ");
+        if (key === "sudo -n systemctl restart pennair-autonomy.service") return ok();
+        if (key.startsWith("sudo -n systemctl show")) {
+          call += 1;
+          return ok("active\nrunning\n4242\n0");
+        }
+        return fail(`unexpected: ${key}`);
+      };
+      let clock = 0;
+      const now = () => clock;
+      const wait = async () => {
+        clock += 1000;
+      };
+
+      const result = await activateRelease(releaseDir, "", run, wait, now, paths);
+      expect(result).toEqual({ success: true, output: "Release activated" });
+      expect(call).toBeGreaterThanOrEqual(2); // needs at least 2 stable readings
+    });
+
+    it("rolls back to the previous release if the restart itself fails", async () => {
+      const previousDir = join(scratchRoot, "releases", "prev-release");
+      await mkdir(previousDir, { recursive: true });
+      const failedDir = join(scratchRoot, "releases", "failed-release");
+      await mkdir(failedDir, { recursive: true });
+
+      const restartCalls: string[] = [];
+      const run: CommandRunner = async (command, args) => {
+        const key = [command, ...args].join(" ");
+        restartCalls.push(key);
+        if (key === "sudo -n systemctl restart pennair-autonomy.service") {
+          return fail("Unit pennair-autonomy.service not found.");
+        }
+        return ok();
+      };
+
+      const result = await activateRelease(failedDir, previousDir, run, noWait, Date.now, paths);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Reverted to the previous release");
+      expect(await resolveSymlinkTarget(paths.currentLink)).toBe(previousDir);
+      expect(await resolveSymlinkTarget(paths.previousLink)).toBe(failedDir);
+    });
+
+    it("rolls back if the service is unstable (pid keeps changing)", async () => {
+      const previousDir = join(scratchRoot, "releases", "prev-release");
+      await mkdir(previousDir, { recursive: true });
+      const newDir = join(scratchRoot, "releases", "new-release");
+      await mkdir(newDir, { recursive: true });
+
+      let showCall = 0;
+      const run: CommandRunner = async (command, args) => {
+        const key = [command, ...args].join(" ");
+        if (key === "sudo -n systemctl restart pennair-autonomy.service") return ok();
+        if (key.startsWith("sudo -n systemctl show")) {
+          showCall += 1;
+          // pid flips every call -> never stable
+          return ok(`active\nrunning\n${1000 + showCall}\n0`);
+        }
+        return ok();
+      };
+      let clock = 0;
+      const wait = async () => {
+        clock += 1000;
+      };
+
+      const result = await activateRelease(newDir, previousDir, run, wait, () => clock, paths);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("unstable");
+      expect(await resolveSymlinkTarget(paths.currentLink)).toBe(previousDir);
+    });
+
+    it("fails without rollback if there is no previous release available", async () => {
+      const releaseDir = join(scratchRoot, "releases", "only-release");
+      await mkdir(releaseDir, { recursive: true });
+      const run: CommandRunner = async () => fail("boom");
+
+      const result = await activateRelease(releaseDir, "", run, noWait, Date.now, paths);
+      expect(result).toEqual({ success: false, error: "boom" });
+    });
+  });
+
+  describe("rollbackRelease", () => {
+    it("swaps current/previous and reactivates", async () => {
+      const oldDir = join(scratchRoot, "releases", "old");
+      const newDir = join(scratchRoot, "releases", "new");
+      await mkdir(oldDir, { recursive: true });
+      await mkdir(newDir, { recursive: true });
+      await mkdir(paths.releasesDir, { recursive: true });
+      await symlink(newDir, paths.currentLink);
+      await symlink(oldDir, paths.previousLink);
+
+      const run: CommandRunner = async (command, args) => {
+        const key = [command, ...args].join(" ");
+        if (key === "sudo -n systemctl restart pennair-autonomy.service") return ok();
+        if (key.startsWith("sudo -n systemctl show")) return ok("active\nrunning\n999\n0");
+        return ok();
+      };
+      // activateRelease deliberately runs the full 8s polling window before
+      // declaring success (matches the old bash) -- use a fake clock so this
+      // test doesn't actually wait 8 real seconds.
+      let clock = 0;
+      const wait = async () => {
+        clock += 1000;
+      };
+
+      const result = await rollbackRelease(run, wait, () => clock, paths);
+      expect(result.success).toBe(true);
+      expect(await resolveSymlinkTarget(paths.currentLink)).toBe(oldDir);
+      expect(await resolveSymlinkTarget(paths.previousLink)).toBe(newDir);
+    });
+
+    it("reports an error when there is no previous release", async () => {
+      const result = await rollbackRelease(async () => ok(), noWait, Date.now, paths);
+      expect(result).toEqual({ success: false, error: "No previous release to roll back to" });
+    });
+  });
+
+  describe("currentBuild + writeReleaseMetadata", () => {
+    it("reports not installed when nothing has been deployed", async () => {
+      expect(await currentBuild(paths)).toEqual({ success: true, installed: false, info: "No build deployed" });
+    });
+
+    it("reports installed with a metadata summary once a release is current", async () => {
+      const releaseDir = join(scratchRoot, "releases", "rel-1");
+      await mkdir(releaseDir, { recursive: true });
+      await mkdir(paths.releasesDir, { recursive: true });
+      await symlink(releaseDir, paths.currentLink);
+      await writeReleaseMetadata(releaseDir, {
+        releaseId: "rel-1",
+        sourceType: "github",
+        sourceLabel: "build-42",
+        vehicleName: "air-01",
+        deployedAtUtc: "2026-01-15T10:00:00Z",
+      });
+
+      const status = await currentBuild(paths);
+      expect(status.success).toBe(true);
+      expect(status.installed).toBe(true);
+      expect(status.releaseId).toBe("rel-1");
+      expect(status.info).toContain("Vehicle: air-01");
+      expect(status.info).toContain("Source label: build-42");
+    });
+  });
+
+  describe("deployArtifact (full orchestration)", () => {
+    it("extracts, installs the service, writes metadata, and activates -- end to end", async () => {
+      const artifactPath = await buildFixtureArtifact(scratchRoot, "build.tar.gz", "v1");
+      const run: CommandRunner = async (command, args) => {
+        const key = [command, ...args].join(" ");
+        if (key === "sudo -n systemctl restart pennair-autonomy.service") return ok();
+        if (key.startsWith("sudo -n systemctl show")) return ok("active\nrunning\n123\n0");
+        return ok(); // install/daemon-reload/enable all succeed
+      };
+      let clock = 0;
+      const wait = async () => {
+        clock += 1000;
+      };
+
+      const result = await deployArtifact(
+        {
+          artifactPath,
+          artifactName: "build.tar.gz",
+          sourceType: "github",
+          sourceLabel: "build-42",
+          vehicleName: "air-01",
+        },
+        run,
+        wait,
+        () => clock,
+        paths,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.releaseId).toBeTruthy();
+
+      const status = await currentBuild(paths);
+      expect(status.installed).toBe(true);
+      expect(status.info).toContain("Vehicle: air-01");
+
+      // runner script + systemd unit were actually written to disk
+      expect(await pathExists(paths.runnerScript)).toBe(true);
+    });
+
+    it("stops before activating if the systemd unit install fails", async () => {
+      const artifactPath = await buildFixtureArtifact(scratchRoot, "build.tar.gz", "v1");
+      const run: CommandRunner = async (command, args) => {
+        const key = [command, ...args].join(" ");
+        if (key.startsWith("sudo -n install")) return fail("sudo: a password is required");
+        return ok();
+      };
+
+      const result = await deployArtifact(
+        { artifactPath, artifactName: "build.tar.gz", sourceType: "github", sourceLabel: "build-42" },
+        run,
+        noWait,
+        Date.now,
+        paths,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("password");
+      // the release was still extracted and made current, just never activated
+      expect(await pathExists(paths.currentLink)).toBe(true);
+    });
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy.test.ts
@@ -55,7 +55,9 @@ describe("deploy.ts (real filesystem, faked systemctl)", () => {
 
       const result = await extractRelease(artifactPath, "build.tar.gz", paths, now);
 
-      expect(result.releaseId).toBe("20260115-103000-build");
+      // A random suffix is appended so same-second, same-filename deploys
+      // never collide on releaseId (see deploy-concurrency.test.ts).
+      expect(result.releaseId).toMatch(/^20260115-103000-build-[0-9a-f]{6}$/);
       expect(await pathExists(`${result.releaseDir}/install/marker.txt`)).toBe(true);
       expect(await resolveSymlinkTarget(paths.currentLink)).toBe(result.releaseDir);
       expect(await pathExists(artifactPath)).toBe(false); // artifact cleaned up after extraction

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy.ts
@@ -1,0 +1,417 @@
+import { mkdir, readdir, readFile, rm, writeFile, chmod } from "node:fs/promises";
+import { basename } from "node:path";
+import * as tar from "tar";
+import { deployPaths, type DeployPaths } from "./deploy-paths.js";
+import { pathExists, resolveSymlinkTarget, symlinkForce } from "./deploy-fs.js";
+import { delay, runCommand, type CommandRunner } from "./exec.js";
+
+const SERVICE_NAME = process.env.MISSION_SERVICE_NAME ?? "pennair-autonomy.service";
+const PI_USER = process.env.PI_USER ?? "penn";
+
+interface SimpleResult {
+  success: boolean;
+  output?: string;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Extraction + release retention
+// ---------------------------------------------------------------------------
+
+export interface ExtractResult {
+  releaseId: string;
+  releaseDir: string;
+  previousTarget: string;
+}
+
+function releaseTimestamp(now: () => number = Date.now): string {
+  return new Date(now()).toISOString().replace(/[-:]/g, "").replace(/\.\d+Z$/, "").replace("T", "-");
+}
+
+/**
+ * Extracts an uploaded artifact tarball into a new timestamped release
+ * directory, atomically swaps the `current` symlink to point at it (keeping
+ * the previous target as `previous` for rollback), and prunes any older
+ * release directories. Mirrors the old dashboard's `_extract_release_on_pi`,
+ * just as local fs/child_process operations instead of an SSH bash heredoc.
+ */
+export async function extractRelease(
+  artifactPath: string,
+  artifactName: string,
+  paths: DeployPaths = deployPaths(),
+  now: () => number = Date.now,
+): Promise<ExtractResult> {
+  const releaseSlug = artifactName.replace(/\.tar\.gz$/, "").replace(/\.tgz$/, "");
+  const releaseId = `${releaseTimestamp(now)}-${releaseSlug}`;
+  const releaseDir = `${paths.releasesDir}/${releaseId}`;
+
+  await mkdir(releaseDir, { recursive: true });
+  await tar.x({ file: artifactPath, cwd: releaseDir });
+  await rm(artifactPath, { force: true });
+
+  if (!(await pathExists(`${releaseDir}/install`))) {
+    await rm(releaseDir, { recursive: true, force: true });
+    throw new Error(`Extracted release is missing an install/ directory: ${releaseDir}/install`);
+  }
+
+  const previousTarget = await resolveSymlinkTarget(paths.currentLink);
+
+  await symlinkForce(releaseDir, paths.currentLink);
+  if (previousTarget && (await pathExists(previousTarget))) {
+    await symlinkForce(previousTarget, paths.previousLink);
+  } else {
+    await rm(paths.previousLink, { force: true });
+  }
+
+  const entries = await readdir(paths.releasesDir, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const candidate = `${paths.releasesDir}/${entry.name}`;
+    if (candidate !== releaseDir && candidate !== previousTarget) {
+      await rm(candidate, { recursive: true, force: true });
+    }
+  }
+
+  return { releaseId, releaseDir, previousTarget };
+}
+
+// ---------------------------------------------------------------------------
+// Systemd unit + runner script
+// ---------------------------------------------------------------------------
+
+function runnerScriptText(paths: DeployPaths): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+DEPLOY_ROOT=${paths.deployRoot}
+cd "$DEPLOY_ROOT"
+mkdir -p "$DEPLOY_ROOT/state/logs"
+export ROS_LOG_DIR="$DEPLOY_ROOT/state/logs"
+set +u
+source /opt/ros/jazzy/setup.bash
+source "$DEPLOY_ROOT/current/install/setup.bash"
+set -u
+exec ros2 launch uav fleet.launch.py fleet_file:="$DEPLOY_ROOT/config/runtime_fleet.yaml"
+`;
+}
+
+function systemdUnitText(paths: DeployPaths): string {
+  return `[Unit]
+Description=PennAiR autonomy runtime
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${PI_USER}
+WorkingDirectory=${paths.deployRoot}
+ExecStart=${paths.runnerScript}
+Restart=on-failure
+RestartSec=2
+KillSignal=SIGINT
+TimeoutStopSec=20
+
+[Install]
+WantedBy=multi-user.target
+`;
+}
+
+/**
+ * Writes the runner script (owned by the deploy user, no sudo needed) and
+ * installs the systemd unit (needs sudo, same as the passwordless-sudo rules
+ * `provision-pi.sh` already sets up for `systemctl`/`install`).
+ */
+export async function ensureRuntimeService(
+  run: CommandRunner = runCommand,
+  paths: DeployPaths = deployPaths(),
+): Promise<SimpleResult> {
+  await mkdir(paths.configDir, { recursive: true });
+  await writeFile(paths.runnerScript, runnerScriptText(paths), "utf-8");
+  await chmod(paths.runnerScript, 0o755);
+
+  const tmpUnitPath = `${paths.incomingDir}/${SERVICE_NAME}.tmp`;
+  await mkdir(paths.incomingDir, { recursive: true });
+  await writeFile(tmpUnitPath, systemdUnitText(paths), "utf-8");
+
+  const install = await run(
+    "sudo",
+    ["-n", "install", "-D", "-m", "644", tmpUnitPath, `/etc/systemd/system/${SERVICE_NAME}`],
+    15_000,
+  );
+  await rm(tmpUnitPath, { force: true });
+  if (install.code !== 0) {
+    return {
+      success: false,
+      error:
+        install.stderr ||
+        "Install systemd unit failed. Bootstrap the Pi or grant passwordless sudo for systemctl/install.",
+    };
+  }
+
+  await run("sudo", ["-n", "systemctl", "daemon-reload"], 15_000);
+  const enable = await run("sudo", ["-n", "systemctl", "enable", SERVICE_NAME], 15_000);
+  if (enable.code !== 0) {
+    return { success: false, error: enable.stderr || "Failed to enable runtime service" };
+  }
+  return { success: true, output: "Runtime service installed" };
+}
+
+// ---------------------------------------------------------------------------
+// Health-check-and-rollback activation
+// ---------------------------------------------------------------------------
+
+interface SystemctlProps {
+  activeState: string;
+  subState: string;
+  mainPid: string;
+  restartCount: string;
+}
+
+async function readSystemctlProps(run: CommandRunner): Promise<SystemctlProps> {
+  const result = await run(
+    "sudo",
+    [
+      "-n",
+      "systemctl",
+      "show",
+      SERVICE_NAME,
+      "-p",
+      "ActiveState",
+      "-p",
+      "SubState",
+      "-p",
+      "MainPID",
+      "-p",
+      "NRestarts",
+      "--value",
+    ],
+    8_000,
+  );
+  const [activeState = "", subState = "", mainPid = "", restartCount = ""] = result.stdout.trim().split("\n");
+  return { activeState, subState, mainPid, restartCount };
+}
+
+async function revertToPrevious(
+  paths: DeployPaths,
+  releaseDir: string,
+  previousTarget: string,
+  run: CommandRunner,
+  errorMessage: string,
+): Promise<SimpleResult> {
+  if (previousTarget && (await pathExists(previousTarget))) {
+    await symlinkForce(previousTarget, paths.currentLink);
+    await symlinkForce(releaseDir, paths.previousLink);
+    await run("sudo", ["-n", "systemctl", "restart", SERVICE_NAME], 15_000); // best-effort, ignore outcome
+    return { success: false, error: `${errorMessage} Reverted to the previous release.` };
+  }
+  return { success: false, error: errorMessage };
+}
+
+/**
+ * Restarts the runtime service and polls for up to 8 seconds that it's
+ * actually stably running (active+running, with a main PID that doesn't
+ * change and a restart count that doesn't increment) before declaring
+ * success -- an unstable/failed activation automatically rolls back to
+ * `previousTarget` if one is available. Mirrors the old dashboard's
+ * `_activate_release` bash loop, just as real TS control flow instead of a
+ * bash heredoc polling `systemctl show` in a `while` loop.
+ */
+export async function activateRelease(
+  releaseDir: string,
+  previousTarget: string,
+  run: CommandRunner = runCommand,
+  wait: (ms: number) => Promise<void> = delay,
+  now: () => number = Date.now,
+  paths: DeployPaths = deployPaths(),
+): Promise<SimpleResult> {
+  const restart = await run("sudo", ["-n", "systemctl", "restart", SERVICE_NAME], 15_000);
+  if (restart.code !== 0) {
+    return revertToPrevious(
+      paths,
+      releaseDir,
+      previousTarget,
+      run,
+      restart.stderr || "Failed to restart runtime service.",
+    );
+  }
+
+  const deadline = now() + 8_000;
+  let stableMainPid = "";
+  let stableRestarts = "";
+
+  while (now() < deadline) {
+    const props = await readSystemctlProps(run);
+    const healthy =
+      props.activeState === "active" && props.subState === "running" && !!props.mainPid && props.mainPid !== "0";
+
+    if (!healthy) {
+      await wait(1000);
+      continue;
+    }
+
+    if (!stableMainPid) {
+      stableMainPid = props.mainPid;
+      stableRestarts = props.restartCount;
+    } else if (props.mainPid !== stableMainPid || props.restartCount !== stableRestarts) {
+      return revertToPrevious(paths, releaseDir, previousTarget, run, "Runtime service became unstable after restart.");
+    }
+    await wait(1000);
+  }
+
+  if (!stableMainPid) {
+    return revertToPrevious(paths, releaseDir, previousTarget, run, "Runtime service did not become active in time.");
+  }
+
+  return { success: true, output: "Release activated" };
+}
+
+/**
+ * A deliberate, operator-triggered "go back to the previous release" action
+ * -- distinct from activateRelease's automatic rollback-on-failure. Swaps
+ * current/previous symlinks (so a second rollback undoes the first, same as
+ * the old dashboard's `rollback_build`), then reactivates through the same
+ * health-check path.
+ */
+export async function rollbackRelease(
+  run: CommandRunner = runCommand,
+  wait: (ms: number) => Promise<void> = delay,
+  now: () => number = Date.now,
+  paths: DeployPaths = deployPaths(),
+): Promise<SimpleResult> {
+  if (!(await pathExists(paths.previousLink))) {
+    return { success: false, error: "No previous release to roll back to" };
+  }
+
+  const currentTarget = await resolveSymlinkTarget(paths.currentLink);
+  const previousTarget = await resolveSymlinkTarget(paths.previousLink);
+  if (!previousTarget) {
+    return { success: false, error: "No previous release to roll back to" };
+  }
+
+  await symlinkForce(previousTarget, paths.currentLink);
+  if (currentTarget && (await pathExists(currentTarget))) {
+    await symlinkForce(currentTarget, paths.previousLink);
+  }
+
+  return activateRelease(previousTarget, currentTarget, run, wait, now, paths);
+}
+
+// ---------------------------------------------------------------------------
+// Release metadata + current-build status
+// ---------------------------------------------------------------------------
+
+export interface ReleaseMetadata {
+  releaseId: string;
+  sourceType: string;
+  sourceLabel: string;
+  targetId?: string;
+  vehicleName?: string;
+  fleetFile?: string;
+  deployedAtUtc: string;
+  packages?: string[];
+}
+
+export async function writeReleaseMetadata(releaseDir: string, metadata: ReleaseMetadata): Promise<void> {
+  await writeFile(`${releaseDir}/RELEASE_METADATA.json`, JSON.stringify(metadata, null, 2), "utf-8");
+}
+
+function summarizeReleaseMetadata(metadata: Partial<ReleaseMetadata>): string {
+  const rows: string[] = [];
+  if (metadata.releaseId) rows.push(`Release: ${metadata.releaseId}`);
+  if (metadata.sourceType) rows.push(`Source: ${metadata.sourceType}`);
+  if (metadata.sourceLabel) rows.push(`Source label: ${metadata.sourceLabel}`);
+  if (metadata.targetId) rows.push(`Target: ${metadata.targetId}`);
+  if (metadata.vehicleName) rows.push(`Vehicle: ${metadata.vehicleName}`);
+  if (metadata.deployedAtUtc) rows.push(`Deployed: ${metadata.deployedAtUtc}`);
+  if (metadata.packages?.length) rows.push(`Packages: ${metadata.packages.join(", ")}`);
+  return rows.join("\n");
+}
+
+export interface CurrentBuildStatus {
+  success: boolean;
+  installed: boolean;
+  info: string;
+  releaseId?: string;
+}
+
+/** "Is a build installed" = the current symlink exists and resolves to a real
+ *  directory -- RELEASE_METADATA.json/BUILD_INFO.txt are only used to build a
+ *  human-readable `info` string, matching the old dashboard's `current_build`. */
+export async function currentBuild(paths: DeployPaths = deployPaths()): Promise<CurrentBuildStatus> {
+  const realTarget = await resolveSymlinkTarget(paths.currentLink);
+  if (!realTarget || !(await pathExists(realTarget))) {
+    return { success: true, installed: false, info: "No build deployed" };
+  }
+  const releaseId = basename(realTarget);
+
+  let metadataSummary = "";
+  try {
+    const raw = await readFile(`${realTarget}/RELEASE_METADATA.json`, "utf-8");
+    metadataSummary = summarizeReleaseMetadata(JSON.parse(raw) as Partial<ReleaseMetadata>);
+  } catch {
+    // no metadata file -- fine, just less info
+  }
+
+  let buildInfo = "";
+  try {
+    buildInfo = (await readFile(`${realTarget}/install/BUILD_INFO.txt`, "utf-8")).trim();
+  } catch {
+    // no build info file -- fine
+  }
+
+  const infoParts = [metadataSummary, buildInfo].filter(Boolean);
+  const info = infoParts.join("\n\n").trim() || "Build installed";
+  return { success: true, installed: true, info, releaseId };
+}
+
+// ---------------------------------------------------------------------------
+// Top-level orchestration: the full "here's an uploaded artifact, make it
+// live" sequence, mirroring the old dashboard's `_deploy_artifact_path`.
+// ---------------------------------------------------------------------------
+
+export interface DeployArtifactOptions {
+  artifactPath: string;
+  artifactName: string;
+  sourceType: string;
+  sourceLabel: string;
+  vehicleName?: string;
+  fleetFile?: string;
+}
+
+export interface DeployArtifactResult extends SimpleResult {
+  releaseId?: string;
+}
+
+export async function deployArtifact(
+  options: DeployArtifactOptions,
+  run: CommandRunner = runCommand,
+  wait: (ms: number) => Promise<void> = delay,
+  now: () => number = Date.now,
+  paths: DeployPaths = deployPaths(),
+): Promise<DeployArtifactResult> {
+  const { releaseId, releaseDir, previousTarget } = await extractRelease(
+    options.artifactPath,
+    options.artifactName,
+    paths,
+    now,
+  );
+
+  const serviceResult = await ensureRuntimeService(run, paths);
+  if (!serviceResult.success) {
+    // Extraction already succeeded at this point -- report which release it
+    // was, even though it never got activated, rather than dropping that
+    // diagnostic detail just because this particular stage failed.
+    return { ...serviceResult, releaseId };
+  }
+
+  await writeReleaseMetadata(releaseDir, {
+    releaseId,
+    sourceType: options.sourceType,
+    sourceLabel: options.sourceLabel,
+    vehicleName: options.vehicleName,
+    fleetFile: options.fleetFile,
+    deployedAtUtc: new Date(now()).toISOString(),
+  });
+
+  const activation = await activateRelease(releaseDir, previousTarget, run, wait, now, paths);
+  return { ...activation, releaseId };
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy.ts
@@ -45,13 +45,28 @@ function releaseTimestamp(now: () => number = Date.now): string {
   return new Date(now()).toISOString().replace(/[-:]/g, "").replace(/\.\d+Z$/, "").replace("T", "-");
 }
 
+/**
+ * Defense in depth: `artifactName` is the client-supplied upload filename,
+ * which ends up as part of a filesystem path (the release directory name)
+ * that later gets interpolated into shell commands elsewhere (e.g.
+ * schema-export.ts, which shell-quotes it properly at the point of use, but
+ * a release slug restricted to safe characters at the source removes the
+ * hazard from propagating into systemd unit content, JSON metadata, and log
+ * output too, not just the one place that was actually exploitable).
+ */
+function sanitizeReleaseSlug(artifactName: string): string {
+  const stripped = artifactName.replace(/\.tar\.gz$/, "").replace(/\.tgz$/, "");
+  const safe = stripped.replace(/[^A-Za-z0-9._-]/g, "_");
+  return safe || "release";
+}
+
 async function extractReleaseUnlocked(
   artifactPath: string,
   artifactName: string,
   paths: DeployPaths,
   now: () => number,
 ): Promise<ExtractResult> {
-  const releaseSlug = artifactName.replace(/\.tar\.gz$/, "").replace(/\.tgz$/, "");
+  const releaseSlug = sanitizeReleaseSlug(artifactName);
   // A random suffix guarantees a fresh release directory even when two
   // deploys land in the same clock tick with the same artifact filename --
   // without it, they'd collide on releaseId and silently merge into one

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy.ts
@@ -4,9 +4,9 @@ import { basename } from "node:path";
 import * as tar from "tar";
 import { deployPaths, type DeployPaths } from "./deploy-paths.js";
 import { pathExists, resolveSymlinkTarget, symlinkForce } from "./deploy-fs.js";
-import { delay, runCommand, type CommandRunner } from "./exec.js";
+import { delay, runCommand, type CommandRunner, type SimpleResult } from "./exec.js";
+import { SERVICE_NAME } from "./service-name.js";
 
-const SERVICE_NAME = process.env.MISSION_SERVICE_NAME ?? "pennair-autonomy.service";
 const PI_USER = process.env.PI_USER ?? "penn";
 
 // A single Pi only ever has one pi-agent process managing one deploy root, so
@@ -23,12 +23,6 @@ function withDeployLock<T>(task: () => Promise<T>): Promise<T> {
     () => undefined,
   );
   return result;
-}
-
-interface SimpleResult {
-  success: boolean;
-  output?: string;
-  error?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/deploy.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { mkdir, readdir, readFile, rm, writeFile, chmod } from "node:fs/promises";
 import { basename } from "node:path";
 import * as tar from "tar";
@@ -7,6 +8,22 @@ import { delay, runCommand, type CommandRunner } from "./exec.js";
 
 const SERVICE_NAME = process.env.MISSION_SERVICE_NAME ?? "pennair-autonomy.service";
 const PI_USER = process.env.PI_USER ?? "penn";
+
+// A single Pi only ever has one pi-agent process managing one deploy root, so
+// a plain in-process mutex (not file-based locking) is enough to serialize
+// deploys/rollbacks -- without it, concurrent requests race on the
+// current/previous symlink swap and on release-directory pruning (each call
+// computes its own view of "previous" and "what to prune" independently),
+// which can dangle `current` or delete a release another call just deployed.
+let deployMutex: Promise<unknown> = Promise.resolve();
+function withDeployLock<T>(task: () => Promise<T>): Promise<T> {
+  const result = deployMutex.then(task, task);
+  deployMutex = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
 
 interface SimpleResult {
   success: boolean;
@@ -28,25 +45,29 @@ function releaseTimestamp(now: () => number = Date.now): string {
   return new Date(now()).toISOString().replace(/[-:]/g, "").replace(/\.\d+Z$/, "").replace("T", "-");
 }
 
-/**
- * Extracts an uploaded artifact tarball into a new timestamped release
- * directory, atomically swaps the `current` symlink to point at it (keeping
- * the previous target as `previous` for rollback), and prunes any older
- * release directories. Mirrors the old dashboard's `_extract_release_on_pi`,
- * just as local fs/child_process operations instead of an SSH bash heredoc.
- */
-export async function extractRelease(
+async function extractReleaseUnlocked(
   artifactPath: string,
   artifactName: string,
-  paths: DeployPaths = deployPaths(),
-  now: () => number = Date.now,
+  paths: DeployPaths,
+  now: () => number,
 ): Promise<ExtractResult> {
   const releaseSlug = artifactName.replace(/\.tar\.gz$/, "").replace(/\.tgz$/, "");
-  const releaseId = `${releaseTimestamp(now)}-${releaseSlug}`;
+  // A random suffix guarantees a fresh release directory even when two
+  // deploys land in the same clock tick with the same artifact filename --
+  // without it, they'd collide on releaseId and silently merge into one
+  // directory, and `previous` could end up pointing at the same release as
+  // `current` (rollback would then "succeed" while doing nothing).
+  const releaseId = `${releaseTimestamp(now)}-${releaseSlug}-${randomBytes(3).toString("hex")}`;
   const releaseDir = `${paths.releasesDir}/${releaseId}`;
 
   await mkdir(releaseDir, { recursive: true });
-  await tar.x({ file: artifactPath, cwd: releaseDir });
+  try {
+    await tar.x({ file: artifactPath, cwd: releaseDir });
+  } catch (error) {
+    await rm(releaseDir, { recursive: true, force: true });
+    await rm(artifactPath, { force: true });
+    throw error;
+  }
   await rm(artifactPath, { force: true });
 
   if (!(await pathExists(`${releaseDir}/install`))) {
@@ -75,6 +96,23 @@ export async function extractRelease(
   return { releaseId, releaseDir, previousTarget };
 }
 
+/**
+ * Extracts an uploaded artifact tarball into a new timestamped release
+ * directory, atomically swaps the `current` symlink to point at it (keeping
+ * the previous target as `previous` for rollback), and prunes any older
+ * release directories. Mirrors the old dashboard's `_extract_release_on_pi`,
+ * just as local fs/child_process operations instead of an SSH bash heredoc.
+ * Serialized against concurrent deploys/rollbacks via `withDeployLock`.
+ */
+export function extractRelease(
+  artifactPath: string,
+  artifactName: string,
+  paths: DeployPaths = deployPaths(),
+  now: () => number = Date.now,
+): Promise<ExtractResult> {
+  return withDeployLock(() => extractReleaseUnlocked(artifactPath, artifactName, paths, now));
+}
+
 // ---------------------------------------------------------------------------
 // Systemd unit + runner script
 // ---------------------------------------------------------------------------
@@ -82,7 +120,7 @@ export async function extractRelease(
 function runnerScriptText(paths: DeployPaths): string {
   return `#!/usr/bin/env bash
 set -euo pipefail
-DEPLOY_ROOT=${paths.deployRoot}
+export DEPLOY_ROOT=${paths.deployRoot}
 cd "$DEPLOY_ROOT"
 mkdir -p "$DEPLOY_ROOT/state/logs"
 export ROS_LOG_DIR="$DEPLOY_ROOT/state/logs"
@@ -94,16 +132,30 @@ exec ros2 launch uav fleet.launch.py fleet_file:="$DEPLOY_ROOT/config/runtime_fl
 `;
 }
 
+// `provision-pi.sh`/`bootstrap-pi.sh` installs the same-named unit at
+// provisioning time with a pigpiod ordering dependency and
+// RUNTIME_FLEET_CONFIG/PENNAIR_MISSION_STARTED_MARKER_PATH env vars (see
+// `controls/sae_2025_ws/scripts/hardware/bootstrap-pi.sh`'s
+// `install_systemd_unit`, and `mode_manager.py`'s marker-path lookup, which
+// falls back to a throwaway /tmp path without that env var). Every deploy
+// re-installs this same unit, so it must keep matching that shape -- setting
+// these at the *unit* level (not just in the runner script) also means
+// they're present in the process environment from the very start, so they
+// reach the exec'd `ros2 launch` process even though the runner script's own
+// internal shell variables mostly aren't exported.
 function systemdUnitText(paths: DeployPaths): string {
   return `[Unit]
 Description=PennAiR autonomy runtime
-After=network-online.target
-Wants=network-online.target
+After=network-online.target pigpiod.service
+Wants=network-online.target pigpiod.service
 
 [Service]
 Type=simple
 User=${PI_USER}
 WorkingDirectory=${paths.deployRoot}
+Environment=DEPLOY_ROOT=${paths.deployRoot}
+Environment=RUNTIME_FLEET_CONFIG=${paths.runtimeFleet}
+Environment=PENNAIR_MISSION_STARTED_MARKER_PATH=${paths.deployRoot}/state/mission-started
 ExecStart=${paths.runnerScript}
 Restart=on-failure
 RestartSec=2
@@ -206,22 +258,13 @@ async function revertToPrevious(
   return { success: false, error: errorMessage };
 }
 
-/**
- * Restarts the runtime service and polls for up to 8 seconds that it's
- * actually stably running (active+running, with a main PID that doesn't
- * change and a restart count that doesn't increment) before declaring
- * success -- an unstable/failed activation automatically rolls back to
- * `previousTarget` if one is available. Mirrors the old dashboard's
- * `_activate_release` bash loop, just as real TS control flow instead of a
- * bash heredoc polling `systemctl show` in a `while` loop.
- */
-export async function activateRelease(
+async function activateReleaseUnlocked(
   releaseDir: string,
   previousTarget: string,
-  run: CommandRunner = runCommand,
-  wait: (ms: number) => Promise<void> = delay,
-  now: () => number = Date.now,
-  paths: DeployPaths = deployPaths(),
+  run: CommandRunner,
+  wait: (ms: number) => Promise<void>,
+  now: () => number,
+  paths: DeployPaths,
 ): Promise<SimpleResult> {
   const restart = await run("sudo", ["-n", "systemctl", "restart", SERVICE_NAME], 15_000);
   if (restart.code !== 0) {
@@ -265,17 +308,31 @@ export async function activateRelease(
 }
 
 /**
- * A deliberate, operator-triggered "go back to the previous release" action
- * -- distinct from activateRelease's automatic rollback-on-failure. Swaps
- * current/previous symlinks (so a second rollback undoes the first, same as
- * the old dashboard's `rollback_build`), then reactivates through the same
- * health-check path.
+ * Restarts the runtime service and polls for up to 8 seconds that it's
+ * actually stably running (active+running, with a main PID that doesn't
+ * change and a restart count that doesn't increment) before declaring
+ * success -- an unstable/failed activation automatically rolls back to
+ * `previousTarget` if one is available. Mirrors the old dashboard's
+ * `_activate_release` bash loop, just as real TS control flow instead of a
+ * bash heredoc polling `systemctl show` in a `while` loop. Serialized against
+ * concurrent deploys/rollbacks via `withDeployLock`.
  */
-export async function rollbackRelease(
+export function activateRelease(
+  releaseDir: string,
+  previousTarget: string,
   run: CommandRunner = runCommand,
   wait: (ms: number) => Promise<void> = delay,
   now: () => number = Date.now,
   paths: DeployPaths = deployPaths(),
+): Promise<SimpleResult> {
+  return withDeployLock(() => activateReleaseUnlocked(releaseDir, previousTarget, run, wait, now, paths));
+}
+
+async function rollbackReleaseUnlocked(
+  run: CommandRunner,
+  wait: (ms: number) => Promise<void>,
+  now: () => number,
+  paths: DeployPaths,
 ): Promise<SimpleResult> {
   if (!(await pathExists(paths.previousLink))) {
     return { success: false, error: "No previous release to roll back to" };
@@ -292,7 +349,24 @@ export async function rollbackRelease(
     await symlinkForce(currentTarget, paths.previousLink);
   }
 
-  return activateRelease(previousTarget, currentTarget, run, wait, now, paths);
+  return activateReleaseUnlocked(previousTarget, currentTarget, run, wait, now, paths);
+}
+
+/**
+ * A deliberate, operator-triggered "go back to the previous release" action
+ * -- distinct from activateRelease's automatic rollback-on-failure. Swaps
+ * current/previous symlinks (so a second rollback undoes the first, same as
+ * the old dashboard's `rollback_build`), then reactivates through the same
+ * health-check path. Serialized against concurrent deploys/rollbacks via
+ * `withDeployLock`.
+ */
+export function rollbackRelease(
+  run: CommandRunner = runCommand,
+  wait: (ms: number) => Promise<void> = delay,
+  now: () => number = Date.now,
+  paths: DeployPaths = deployPaths(),
+): Promise<SimpleResult> {
+  return withDeployLock(() => rollbackReleaseUnlocked(run, wait, now, paths));
 }
 
 // ---------------------------------------------------------------------------
@@ -381,37 +455,46 @@ export interface DeployArtifactResult extends SimpleResult {
   releaseId?: string;
 }
 
-export async function deployArtifact(
+/**
+ * The whole extract -> install service -> write metadata -> activate
+ * sequence runs under a single lock acquisition (not one per sub-step), so a
+ * concurrent deploy or rollback can't interleave between, say, this call's
+ * extraction and its own activation/rollback -- which could otherwise revert
+ * a different, concurrently-deployed release out from under it.
+ */
+export function deployArtifact(
   options: DeployArtifactOptions,
   run: CommandRunner = runCommand,
   wait: (ms: number) => Promise<void> = delay,
   now: () => number = Date.now,
   paths: DeployPaths = deployPaths(),
 ): Promise<DeployArtifactResult> {
-  const { releaseId, releaseDir, previousTarget } = await extractRelease(
-    options.artifactPath,
-    options.artifactName,
-    paths,
-    now,
-  );
+  return withDeployLock(async () => {
+    const { releaseId, releaseDir, previousTarget } = await extractReleaseUnlocked(
+      options.artifactPath,
+      options.artifactName,
+      paths,
+      now,
+    );
 
-  const serviceResult = await ensureRuntimeService(run, paths);
-  if (!serviceResult.success) {
-    // Extraction already succeeded at this point -- report which release it
-    // was, even though it never got activated, rather than dropping that
-    // diagnostic detail just because this particular stage failed.
-    return { ...serviceResult, releaseId };
-  }
+    const serviceResult = await ensureRuntimeService(run, paths);
+    if (!serviceResult.success) {
+      // Extraction already succeeded at this point -- report which release it
+      // was, even though it never got activated, rather than dropping that
+      // diagnostic detail just because this particular stage failed.
+      return { ...serviceResult, releaseId };
+    }
 
-  await writeReleaseMetadata(releaseDir, {
-    releaseId,
-    sourceType: options.sourceType,
-    sourceLabel: options.sourceLabel,
-    vehicleName: options.vehicleName,
-    fleetFile: options.fleetFile,
-    deployedAtUtc: new Date(now()).toISOString(),
+    await writeReleaseMetadata(releaseDir, {
+      releaseId,
+      sourceType: options.sourceType,
+      sourceLabel: options.sourceLabel,
+      vehicleName: options.vehicleName,
+      fleetFile: options.fleetFile,
+      deployedAtUtc: new Date(now()).toISOString(),
+    });
+
+    const activation = await activateReleaseUnlocked(releaseDir, previousTarget, run, wait, now, paths);
+    return { ...activation, releaseId };
   });
-
-  const activation = await activateRelease(releaseDir, previousTarget, run, wait, now, paths);
-  return { ...activation, releaseId };
 }

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/exec.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/exec.ts
@@ -9,6 +9,14 @@ export interface ExecResult {
   stderr: string;
 }
 
+/** Common shape for operations that either succeed with optional output or
+ *  fail with an error message -- shared by deploy.ts, mission.ts, wifi.ts. */
+export interface SimpleResult {
+  success: boolean;
+  output?: string;
+  error?: string;
+}
+
 export type CommandRunner = (command: string, args: string[], timeoutMs: number) => Promise<ExecResult>;
 
 /** Real command runner -- the default, unless a test injects a fake one. */

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/exec.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/exec.ts
@@ -1,0 +1,39 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFileCallback);
+
+export interface ExecResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type CommandRunner = (command: string, args: string[], timeoutMs: number) => Promise<ExecResult>;
+
+/** Real command runner -- the default, unless a test injects a fake one. */
+export const runCommand: CommandRunner = async (command, args, timeoutMs) => {
+  try {
+    const { stdout, stderr } = await execFileAsync(command, args, { timeout: timeoutMs });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const execError = error as {
+      code?: number | string;
+      stdout?: string;
+      stderr?: string;
+      message: string;
+    };
+    // On a spawn failure (command not found, etc.) `code` is a string like
+    // "ENOENT" and `stderr` is an empty string (not absent) -- fall back to
+    // `.message` for a useful error, and normalize `code` to a number.
+    const numericCode = typeof execError.code === "number" ? execError.code : -1;
+    return {
+      code: numericCode,
+      stdout: execError.stdout ?? "",
+      stderr: execError.stderr || execError.message,
+    };
+  }
+};
+
+/** Real delay -- the default, unless a test injects a no-op one. */
+export const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/heartbeat.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/heartbeat.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { attachHeartbeat, type HeartbeatSocket } from "./heartbeat.js";
+
+function fakeSocket() {
+  const listeners: Record<string, Array<() => void>> = {};
+  const socket: HeartbeatSocket = {
+    ping: vi.fn(),
+    terminate: vi.fn(),
+    on: (event, listener) => {
+      (listeners[event] ??= []).push(listener);
+    },
+  };
+  return { socket, emitPong: () => listeners.pong?.forEach((l) => l()), emitClose: () => listeners.close?.forEach((l) => l()) };
+}
+
+describe("attachHeartbeat", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("pings on each interval as long as a pong keeps arriving", () => {
+    const { socket, emitPong } = fakeSocket();
+    attachHeartbeat(socket, 1000);
+
+    vi.advanceTimersByTime(1000);
+    expect(socket.ping).toHaveBeenCalledTimes(1);
+    emitPong();
+
+    vi.advanceTimersByTime(1000);
+    expect(socket.ping).toHaveBeenCalledTimes(2);
+    expect(socket.terminate).not.toHaveBeenCalled();
+  });
+
+  it("terminates the connection if no pong arrives before the next interval", () => {
+    const { socket } = fakeSocket();
+    attachHeartbeat(socket, 1000);
+
+    vi.advanceTimersByTime(1000); // sends first ping, no pong follows
+    vi.advanceTimersByTime(1000); // next tick: still no pong -> terminate
+
+    expect(socket.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops the interval once the socket closes", () => {
+    const { socket, emitClose } = fakeSocket();
+    attachHeartbeat(socket, 1000);
+
+    emitClose();
+    vi.advanceTimersByTime(10_000);
+
+    expect(socket.ping).not.toHaveBeenCalled();
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/heartbeat.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/heartbeat.ts
@@ -1,0 +1,31 @@
+export interface HeartbeatSocket {
+  ping(): void;
+  terminate(): void;
+  on(event: "pong" | "close", listener: () => void): void;
+}
+
+/**
+ * Detects a client that vanished without a clean close handshake (WiFi
+ * drop, app killed, laptop sleep) -- without this, the server only notices
+ * via the OS's own (often very slow, sometimes effectively unbounded) TCP
+ * dead-peer detection, leaving whatever the connection was holding open
+ * (a spawned journalctl process, an upstream relay connection) running
+ * longer than necessary.
+ */
+export function attachHeartbeat(socket: HeartbeatSocket, intervalMs = 30_000): void {
+  let alive = true;
+  socket.on("pong", () => {
+    alive = true;
+  });
+
+  const timer = setInterval(() => {
+    if (!alive) {
+      socket.terminate();
+      return;
+    }
+    alive = false;
+    socket.ping();
+  }, intervalMs);
+
+  socket.on("close", () => clearInterval(timer));
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/index.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { buildServer } from "./index.js";
+
+describe("pi-agent server", () => {
+  it("responds ok on /health", async () => {
+    const app = buildServer();
+    const response = await app.inject({ method: "GET", url: "/health" });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ status: "ok" });
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/index.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/index.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as tar from "tar";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { buildServer } from "./index.js";
+import { pathExists } from "./deploy-fs.js";
 
 describe("pi-agent server", () => {
   it("responds ok on /health", async () => {
@@ -7,5 +12,82 @@ describe("pi-agent server", () => {
     const response = await app.inject({ method: "GET", url: "/health" });
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({ status: "ok" });
+  });
+});
+
+describe("pi-agent deploy upload endpoint, over a real HTTP multipart request", () => {
+  let scratchRoot: string;
+  let app: ReturnType<typeof buildServer>;
+  let port: number;
+  const originalDeployRoot = process.env.DEPLOY_ROOT;
+
+  beforeAll(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "pi-agent-upload-test-"));
+    process.env.DEPLOY_ROOT = scratchRoot;
+    app = buildServer();
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected server to listen on a TCP port");
+    }
+    port = address.port;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    process.env.DEPLOY_ROOT = originalDeployRoot;
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    // deployArtifact's real (non-injected) CommandRunner will genuinely try
+    // `sudo -n install ...`/`systemctl` on this dev machine and fail (no real
+    // systemd here) -- that's the expected, correct real response, same
+    // pattern as the wifi/mission relay tests. Clean the release dirs
+    // between tests so each starts fresh.
+    await rm(`${scratchRoot}/releases`, { recursive: true, force: true });
+    await rm(`${scratchRoot}/current`, { force: true });
+    await rm(`${scratchRoot}/previous`, { force: true });
+  });
+
+  it("accepts a real multipart upload, extracts it for real, and gracefully fails activation (no real systemd here)", async () => {
+    const stagingDir = join(scratchRoot, "staging");
+    await mkdir(join(stagingDir, "install"), { recursive: true });
+    await writeFile(join(stagingDir, "install", "marker.txt"), "v1", "utf-8");
+    const artifactPath = join(scratchRoot, "upload-test.tar.gz");
+    await tar.c({ file: artifactPath, cwd: stagingDir }, ["install"]);
+
+    const form = new FormData();
+    form.set("sourceType", "github");
+    form.set("sourceLabel", "build-42");
+    form.set("vehicleName", "air-01");
+    const fileBuffer = await import("node:fs/promises").then((fs) => fs.readFile(artifactPath));
+    form.set("file", new Blob([fileBuffer]), "upload-test.tar.gz");
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/deploy/upload`, {
+      method: "POST",
+      body: form,
+    });
+    const body = (await response.json()) as { success: boolean; error?: string; releaseId?: string };
+
+    // Real graceful failure expected: no real systemd/sudo on this dev machine.
+    expect(body.success).toBe(false);
+    expect(body.error).toBeTruthy();
+    expect(body.releaseId).toBeTruthy(); // extraction + metadata write happened before activation failed
+
+    // The real extraction genuinely happened, even though activation failed.
+    expect(await pathExists(`${scratchRoot}/current/install/marker.txt`)).toBe(true);
+  });
+
+  it("returns 400 when no file is uploaded", async () => {
+    const form = new FormData();
+    form.set("sourceType", "github");
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/deploy/upload`, {
+      method: "POST",
+      body: form,
+    });
+    expect(response.status).toBe(400);
+    expect((await response.json()) as { success: boolean }).toMatchObject({ success: false });
   });
 });

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
@@ -1,8 +1,12 @@
 import Fastify from "fastify";
+import websocketPlugin from "@fastify/websocket";
 import { wifiConnect, wifiHotspot, wifiScan, wifiStatus } from "./wifi.js";
+import { missionStatus, prepareMission, stopMission } from "./mission.js";
+import { streamMissionLogs } from "./logs.js";
 
 export function buildServer() {
   const app = Fastify();
+  app.register(websocketPlugin);
 
   app.get("/health", async () => ({ status: "ok" }));
 
@@ -22,6 +26,16 @@ export function buildServer() {
   );
 
   app.post("/api/wifi/hotspot", async () => wifiHotspot());
+
+  app.get("/api/mission/status", async () => missionStatus());
+  app.post("/api/mission/prepare", async () => prepareMission());
+  app.post("/api/mission/stop", async () => stopMission());
+
+  app.register(async (instance) => {
+    instance.get("/ws/mission/logs", { websocket: true }, (socket) => {
+      streamMissionLogs(socket);
+    });
+  });
 
   return app;
 }

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
@@ -1,9 +1,27 @@
 import Fastify from "fastify";
+import { wifiConnect, wifiHotspot, wifiScan, wifiStatus } from "./wifi.js";
 
 export function buildServer() {
   const app = Fastify();
 
   app.get("/health", async () => ({ status: "ok" }));
+
+  app.get("/api/wifi/status", async () => wifiStatus());
+  app.get("/api/wifi/scan", async () => wifiScan());
+
+  app.post<{ Body: { ssid: string; password?: string } }>(
+    "/api/wifi/connect",
+    async (request, reply) => {
+      const { ssid, password } = request.body;
+      if (!ssid) {
+        reply.code(400);
+        return { success: false, error: "ssid is required" };
+      }
+      return wifiConnect(ssid, password ?? "");
+    },
+  );
+
+  app.post("/api/wifi/hotspot", async () => wifiHotspot());
 
   return app;
 }

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
@@ -1,5 +1,5 @@
 import { createWriteStream } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { pipeline } from "node:stream/promises";
 import Fastify from "fastify";
 import websocketPlugin from "@fastify/websocket";
@@ -54,17 +54,26 @@ export function buildServer() {
     let vehicleName: string | undefined;
     let fleetFile: string | undefined;
 
-    for await (const part of request.parts()) {
-      if (part.type === "file") {
-        artifactPath = `${paths.incomingDir}/${part.filename}`;
-        await pipeline(part.file, createWriteStream(artifactPath));
-      } else {
-        const value = String(part.value ?? "");
-        if (part.fieldname === "sourceType") sourceType = value;
-        else if (part.fieldname === "sourceLabel") sourceLabel = value;
-        else if (part.fieldname === "vehicleName") vehicleName = value || undefined;
-        else if (part.fieldname === "fleetFile") fleetFile = value || undefined;
+    try {
+      for await (const part of request.parts()) {
+        if (part.type === "file") {
+          artifactPath = `${paths.incomingDir}/${part.filename}`;
+          await pipeline(part.file, createWriteStream(artifactPath));
+        } else {
+          const value = String(part.value ?? "");
+          if (part.fieldname === "sourceType") sourceType = value;
+          else if (part.fieldname === "sourceLabel") sourceLabel = value;
+          else if (part.fieldname === "vehicleName") vehicleName = value || undefined;
+          else if (part.fieldname === "fleetFile") fleetFile = value || undefined;
+        }
       }
+    } catch (error) {
+      // A disconnect/network error mid-upload leaves a partial file behind
+      // unless we clean it up here -- nothing downstream (extractRelease's
+      // own cleanup) ever runs for an artifact that never finished uploading.
+      if (artifactPath) await rm(artifactPath, { force: true }).catch(() => undefined);
+      reply.code(400);
+      return { success: false, error: `Upload failed: ${(error as Error).message}` };
     }
 
     if (!artifactPath) {
@@ -73,14 +82,20 @@ export function buildServer() {
     }
 
     const filename = artifactPath.split("/").pop() ?? "artifact.tar.gz";
-    return deployArtifact({
-      artifactPath,
-      artifactName: filename,
-      sourceType: sourceType || "unknown",
-      sourceLabel: sourceLabel || filename,
-      vehicleName,
-      fleetFile,
-    });
+    try {
+      return await deployArtifact({
+        artifactPath,
+        artifactName: filename,
+        sourceType: sourceType || "unknown",
+        sourceLabel: sourceLabel || filename,
+        vehicleName,
+        fleetFile,
+      });
+    } catch (error) {
+      await rm(artifactPath, { force: true }).catch(() => undefined);
+      reply.code(500);
+      return { success: false, error: (error as Error).message };
+    }
   });
 
   app.register(async (instance) => {

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
@@ -1,13 +1,22 @@
+import { createWriteStream } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { pipeline } from "node:stream/promises";
 import Fastify from "fastify";
 import websocketPlugin from "@fastify/websocket";
+import multipartPlugin from "@fastify/multipart";
 import { wifiConnect, wifiHotspot, wifiScan, wifiStatus } from "./wifi.js";
 import { missionStatus, prepareMission, stopMission } from "./mission.js";
 import { streamMissionLogs } from "./logs.js";
 import { attachHeartbeat } from "./heartbeat.js";
+import { currentBuild, deployArtifact, rollbackRelease } from "./deploy.js";
+import { deployPaths } from "./deploy-paths.js";
 
 export function buildServer() {
   const app = Fastify();
   app.register(websocketPlugin);
+  app.register(multipartPlugin, {
+    limits: { fileSize: 2 * 1024 * 1024 * 1024 }, // 2GB -- ROS2 build artifacts can be large
+  });
 
   app.get("/health", async () => ({ status: "ok" }));
 
@@ -31,6 +40,48 @@ export function buildServer() {
   app.get("/api/mission/status", async () => missionStatus());
   app.post("/api/mission/prepare", async () => prepareMission());
   app.post("/api/mission/stop", async () => stopMission());
+
+  app.get("/api/deploy/current", async () => currentBuild());
+  app.post("/api/deploy/rollback", async () => rollbackRelease());
+
+  app.post("/api/deploy/upload", async (request, reply) => {
+    const paths = deployPaths();
+    await mkdir(paths.incomingDir, { recursive: true });
+
+    let artifactPath: string | undefined;
+    let sourceType = "";
+    let sourceLabel = "";
+    let vehicleName: string | undefined;
+    let fleetFile: string | undefined;
+
+    for await (const part of request.parts()) {
+      if (part.type === "file") {
+        artifactPath = `${paths.incomingDir}/${part.filename}`;
+        await pipeline(part.file, createWriteStream(artifactPath));
+      } else {
+        const value = String(part.value ?? "");
+        if (part.fieldname === "sourceType") sourceType = value;
+        else if (part.fieldname === "sourceLabel") sourceLabel = value;
+        else if (part.fieldname === "vehicleName") vehicleName = value || undefined;
+        else if (part.fieldname === "fleetFile") fleetFile = value || undefined;
+      }
+    }
+
+    if (!artifactPath) {
+      reply.code(400);
+      return { success: false, error: "No file uploaded" };
+    }
+
+    const filename = artifactPath.split("/").pop() ?? "artifact.tar.gz";
+    return deployArtifact({
+      artifactPath,
+      artifactName: filename,
+      sourceType: sourceType || "unknown",
+      sourceLabel: sourceLabel || filename,
+      vehicleName,
+      fleetFile,
+    });
+  });
 
   app.register(async (instance) => {
     instance.get("/ws/mission/logs", { websocket: true }, (socket) => {

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
@@ -10,6 +10,8 @@ import { streamMissionLogs } from "./logs.js";
 import { attachHeartbeat } from "./heartbeat.js";
 import { currentBuild, deployArtifact, rollbackRelease } from "./deploy.js";
 import { deployPaths } from "./deploy-paths.js";
+import { exportSchema } from "./schema-export.js";
+import { missionNames, readFleetFile, readMissionFile, writeFleetFile, writeMissionFile } from "./mission-fleet-files.js";
 
 export function buildServer() {
   const app = Fastify();
@@ -96,6 +98,46 @@ export function buildServer() {
       reply.code(500);
       return { success: false, error: (error as Error).message };
     }
+  });
+
+  app.get("/api/schema", async () => exportSchema());
+
+  app.get("/api/mission/mission-names", async () => missionNames());
+
+  app.get<{ Querystring: { name?: string } }>("/api/mission/mission-file", async (request, reply) => {
+    const { name } = request.query;
+    if (!name) {
+      reply.code(400);
+      return { success: false, error: "name is required" };
+    }
+    return readMissionFile(name);
+  });
+
+  app.post<{ Body: { name?: string; content?: string } }>("/api/mission/mission-file", async (request, reply) => {
+    const { name, content } = request.body;
+    if (!name) {
+      reply.code(400);
+      return { success: false, error: "name is required" };
+    }
+    return writeMissionFile(name, content ?? "");
+  });
+
+  app.get<{ Querystring: { name?: string } }>("/api/fleet/fleet-file", async (request, reply) => {
+    const { name } = request.query;
+    if (!name) {
+      reply.code(400);
+      return { success: false, error: "name is required" };
+    }
+    return readFleetFile(name);
+  });
+
+  app.post<{ Body: { name?: string; content?: string } }>("/api/fleet/fleet-file", async (request, reply) => {
+    const { name, content } = request.body;
+    if (!name) {
+      reply.code(400);
+      return { success: false, error: "name is required" };
+    }
+    return writeFleetFile(name, content ?? "");
   });
 
   app.register(async (instance) => {

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
@@ -3,6 +3,7 @@ import websocketPlugin from "@fastify/websocket";
 import { wifiConnect, wifiHotspot, wifiScan, wifiStatus } from "./wifi.js";
 import { missionStatus, prepareMission, stopMission } from "./mission.js";
 import { streamMissionLogs } from "./logs.js";
+import { attachHeartbeat } from "./heartbeat.js";
 
 export function buildServer() {
   const app = Fastify();
@@ -33,6 +34,7 @@ export function buildServer() {
 
   app.register(async (instance) => {
     instance.get("/ws/mission/logs", { websocket: true }, (socket) => {
+      attachHeartbeat(socket);
       streamMissionLogs(socket);
     });
   });

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/index.ts
@@ -1,0 +1,18 @@
+import Fastify from "fastify";
+
+export function buildServer() {
+  const app = Fastify();
+
+  app.get("/health", async () => ({ status: "ok" }));
+
+  return app;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const port = Number(process.env.PORT ?? 8090);
+  const app = buildServer();
+  app.listen({ port, host: "0.0.0.0" }).catch((error) => {
+    app.log.error(error);
+    process.exit(1);
+  });
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/logs.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/logs.test.ts
@@ -15,16 +15,19 @@ function fakeChildProcess(): ChildProcessWithoutNullStreams & { killed: boolean 
   return proc;
 }
 
+/** `simulateClientDisconnect` fires the socket's "close" event (the WS client went away).
+ *  `socket.close` (a spy) is what OUR code calls to close the socket itself -- distinct things. */
 function fakeSocket() {
   const sent: string[] = [];
   const listeners: Record<string, Array<() => void>> = {};
   const socket: LogSocket = {
     send: (data) => sent.push(data),
+    close: vi.fn(),
     on: (event, listener) => {
       (listeners[event] ??= []).push(listener);
     },
   };
-  return { socket, sent, close: () => listeners.close?.forEach((l) => l()) };
+  return { socket, sent, simulateClientDisconnect: () => listeners.close?.forEach((l) => l()) };
 }
 
 describe("streamMissionLogs", () => {
@@ -63,22 +66,45 @@ describe("streamMissionLogs", () => {
 
   it("kills journalctl when the socket closes", () => {
     const proc = fakeChildProcess();
-    const { socket, close } = fakeSocket();
+    const { socket, simulateClientDisconnect } = fakeSocket();
 
     streamMissionLogs(socket, () => proc);
-    close();
+    simulateClientDisconnect();
 
     expect(proc.kill).toHaveBeenCalled();
   });
 
   it("does not try to kill an already-killed process", () => {
     const proc = fakeChildProcess();
-    const { socket, close } = fakeSocket();
+    const { socket, simulateClientDisconnect } = fakeSocket();
 
     streamMissionLogs(socket, () => proc);
-    close();
-    close();
+    simulateClientDisconnect();
+    simulateClientDisconnect();
 
     expect(proc.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies and closes the socket if journalctl exits unexpectedly (not from our own cleanup)", () => {
+    const proc = fakeChildProcess();
+    const { socket, sent } = fakeSocket();
+
+    streamMissionLogs(socket, () => proc);
+    proc.emit("exit", 1, null);
+
+    expect(sent).toEqual(["[journalctl exited unexpectedly] code=1 signal=null"]);
+    expect(socket.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send an unexpected-exit notice for our own intentional kill on client disconnect", () => {
+    const proc = fakeChildProcess();
+    const { socket, sent, simulateClientDisconnect } = fakeSocket();
+
+    streamMissionLogs(socket, () => proc);
+    simulateClientDisconnect();
+    proc.emit("exit", null, "SIGTERM"); // the kill() we issued actually taking effect
+
+    expect(sent).toEqual([]);
+    expect(socket.close).not.toHaveBeenCalled();
   });
 });

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/logs.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/logs.test.ts
@@ -1,0 +1,84 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import { streamMissionLogs, type LogSocket, type Spawner } from "./logs.js";
+
+function fakeChildProcess(): ChildProcessWithoutNullStreams & { killed: boolean } {
+  const proc = new EventEmitter() as unknown as ChildProcessWithoutNullStreams & { killed: boolean };
+  proc.stdout = new EventEmitter() as ChildProcessWithoutNullStreams["stdout"];
+  proc.stderr = new EventEmitter() as ChildProcessWithoutNullStreams["stderr"];
+  proc.killed = false;
+  proc.kill = vi.fn(() => {
+    proc.killed = true;
+    return true;
+  }) as ChildProcessWithoutNullStreams["kill"];
+  return proc;
+}
+
+function fakeSocket() {
+  const sent: string[] = [];
+  const listeners: Record<string, Array<() => void>> = {};
+  const socket: LogSocket = {
+    send: (data) => sent.push(data),
+    on: (event, listener) => {
+      (listeners[event] ??= []).push(listener);
+    },
+  };
+  return { socket, sent, close: () => listeners.close?.forEach((l) => l()) };
+}
+
+describe("streamMissionLogs", () => {
+  it("spawns journalctl -f for the configured service and forwards stdout to the socket", () => {
+    const proc = fakeChildProcess();
+    const spawnImpl: Spawner = vi.fn(() => proc);
+    const { socket, sent } = fakeSocket();
+
+    streamMissionLogs(socket, spawnImpl);
+
+    expect(spawnImpl).toHaveBeenCalledWith("sudo", [
+      "-n",
+      "journalctl",
+      "-f",
+      "-u",
+      "pennair-autonomy.service",
+      "-n",
+      "200",
+      "-o",
+      "short-iso",
+    ]);
+
+    proc.stdout.emit("data", Buffer.from("2026-01-01T00:00:00 unit started\n"));
+    expect(sent).toEqual(["2026-01-01T00:00:00 unit started\n"]);
+  });
+
+  it("forwards stderr as a prefixed error line", () => {
+    const proc = fakeChildProcess();
+    const { socket, sent } = fakeSocket();
+
+    streamMissionLogs(socket, () => proc);
+    proc.stderr.emit("data", Buffer.from("Failed to get journal\n"));
+
+    expect(sent).toEqual(["[journalctl error] Failed to get journal\n"]);
+  });
+
+  it("kills journalctl when the socket closes", () => {
+    const proc = fakeChildProcess();
+    const { socket, close } = fakeSocket();
+
+    streamMissionLogs(socket, () => proc);
+    close();
+
+    expect(proc.kill).toHaveBeenCalled();
+  });
+
+  it("does not try to kill an already-killed process", () => {
+    const proc = fakeChildProcess();
+    const { socket, close } = fakeSocket();
+
+    streamMissionLogs(socket, () => proc);
+    close();
+    close();
+
+    expect(proc.kill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/logs.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/logs.ts
@@ -1,0 +1,51 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+
+const SERVICE_NAME = process.env.MISSION_SERVICE_NAME ?? "pennair-autonomy.service";
+
+export type Spawner = (command: string, args: string[]) => ChildProcessWithoutNullStreams;
+
+export const realSpawn: Spawner = (command, args) => spawn(command, args);
+
+export interface LogSocket {
+  send(data: string): void;
+  on(event: "close", listener: () => void): void;
+}
+
+/**
+ * Streams `journalctl -f` for the mission service directly to a WebSocket --
+ * real continuous streaming, replacing the old dashboard's 1-second
+ * poll-and-resend-the-whole-buffer hack.
+ */
+export function streamMissionLogs(socket: LogSocket, spawnImpl: Spawner = realSpawn): void {
+  const journalctl = spawnImpl("sudo", [
+    "-n",
+    "journalctl",
+    "-f",
+    "-u",
+    SERVICE_NAME,
+    "-n",
+    "200",
+    "-o",
+    "short-iso",
+  ]);
+
+  journalctl.stdout.on("data", (chunk: Buffer) => {
+    socket.send(chunk.toString("utf-8"));
+  });
+
+  journalctl.stderr.on("data", (chunk: Buffer) => {
+    socket.send(`[journalctl error] ${chunk.toString("utf-8")}`);
+  });
+
+  const cleanup = () => {
+    if (!journalctl.killed) {
+      journalctl.kill();
+    }
+  };
+
+  socket.on("close", cleanup);
+  journalctl.on("error", (error) => {
+    socket.send(`[journalctl error] ${error.message}`);
+    cleanup();
+  });
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/logs.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/logs.ts
@@ -8,6 +8,7 @@ export const realSpawn: Spawner = (command, args) => spawn(command, args);
 
 export interface LogSocket {
   send(data: string): void;
+  close(): void;
   on(event: "close", listener: () => void): void;
 }
 
@@ -28,6 +29,7 @@ export function streamMissionLogs(socket: LogSocket, spawnImpl: Spawner = realSp
     "-o",
     "short-iso",
   ]);
+  let stoppedIntentionally = false;
 
   journalctl.stdout.on("data", (chunk: Buffer) => {
     socket.send(chunk.toString("utf-8"));
@@ -38,14 +40,26 @@ export function streamMissionLogs(socket: LogSocket, spawnImpl: Spawner = realSp
   });
 
   const cleanup = () => {
+    stoppedIntentionally = true;
     if (!journalctl.killed) {
       journalctl.kill();
     }
   };
 
   socket.on("close", cleanup);
+
   journalctl.on("error", (error) => {
     socket.send(`[journalctl error] ${error.message}`);
     cleanup();
+  });
+
+  // journalctl -f is meant to run forever; if it exits on its own (sudoers
+  // misconfigured, the unit rotated away, journalctl itself crashing) the
+  // client would otherwise be left with an open socket and no more data and
+  // no signal the stream ended -- tell it explicitly and close the socket.
+  journalctl.on("exit", (code, signal) => {
+    if (stoppedIntentionally) return;
+    socket.send(`[journalctl exited unexpectedly] code=${code} signal=${signal}`);
+    socket.close();
   });
 }

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/logs.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/logs.ts
@@ -1,6 +1,5 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-
-const SERVICE_NAME = process.env.MISSION_SERVICE_NAME ?? "pennair-autonomy.service";
+import { SERVICE_NAME } from "./service-name.js";
 
 export type Spawner = (command: string, args: string[]) => ChildProcessWithoutNullStreams;
 

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/mission-fleet-files.name-collision.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/mission-fleet-files.name-collision.test.ts
@@ -1,0 +1,80 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deployPaths, type DeployPaths } from "./deploy-paths.js";
+import { missionNames, readMissionFile } from "./mission-fleet-files.js";
+
+/**
+ * Known, deliberately-deferred gap (Low severity, zero current impact): if a
+ * mission name ever collides across the uav and payload packages,
+ * mission-fleet-files.ts's findMissionFilePath checks the uav package's
+ * missions dir before the payload package's, and missionNames() just pushes
+ * each package's bare basenames into a flat array with no de-duplication or
+ * package tagging. There's no collision in the repo today (verified: `comm
+ * -12` between uav/missions and payload/missions basenames is empty), but
+ * nothing prevents it, and the failure mode if it ever happens is silent and
+ * confusing rather than a clear error. A real fix requires changing
+ * missionNames()'s return shape from a flat string[] to target-qualified
+ * entries (mirroring schema_export.py's own `_available_mission_files`,
+ * which already carries a `target` per entry) and threading that through
+ * pi-agent, the orchestrator relay, core's client, and MissionEditor.tsx --
+ * deferred given it's unreachable with any mission files that exist today.
+ *
+ * - missionNames() returns the same name twice (once per package), which
+ *   the web UI's mission <select> renders as two indistinguishable, textually
+ *   identical option entries with the same `value`/`key` (MissionEditor.tsx
+ *   line 145-149's `key={name}` on the mapped <option>).
+ * - Selecting either one always resolves to the uav mission (uav is checked
+ *   first in MISSION_PACKAGES); the payload mission of the same name becomes
+ *   permanently unreachable/uneditable through this API, with no error or
+ *   warning anywhere -- you'd just always be editing (and, on save,
+ *   silently overwriting reads of) the wrong file if you meant the payload
+ *   one.
+ */
+describe("mission-fleet-files: uav/payload mission-name collision handling", () => {
+  let scratchRoot: string;
+  let paths: DeployPaths;
+
+  beforeEach(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "pi-agent-mission-collision-test-"));
+    paths = deployPaths(scratchRoot);
+
+    const releaseDir = join(scratchRoot, "releases", "20260101-000000-test");
+    await mkdir(join(releaseDir, "install", "uav", "share", "uav", "missions"), { recursive: true });
+    await mkdir(join(releaseDir, "install", "payload", "share", "payload", "missions"), { recursive: true });
+    await writeFile(
+      join(releaseDir, "install", "uav", "share", "uav", "missions", "patrol.yaml"),
+      "modes:\n  start:\n    mode: uav.LandingMode\n",
+      "utf-8",
+    );
+    await writeFile(
+      join(releaseDir, "install", "payload", "share", "payload", "missions", "patrol.yaml"),
+      "modes:\n  start:\n    mode: payload.PayloadWaitForDriveOutMode\n",
+      "utf-8",
+    );
+    await mkdir(scratchRoot, { recursive: true });
+    await symlink(releaseDir, paths.currentLink);
+  });
+
+  afterEach(async () => {
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  it("lists the colliding name twice with no way to tell the two apart", async () => {
+    const result = await missionNames(paths);
+    expect(result.success).toBe(true);
+    // Bug: "patrol" appears twice, indistinguishably -- a client has no way
+    // to know one instance means the uav mission and the other the payload
+    // one.
+    expect(result.missions).toEqual(["patrol", "patrol"]);
+  });
+
+  it("always resolves the colliding name to the uav file, silently hiding the payload one", async () => {
+    const result = await readMissionFile("patrol", paths);
+    expect(result.success).toBe(true);
+    // The payload/missions/patrol.yaml content is unreachable via this name.
+    expect(result.content).toContain("uav.LandingMode");
+    expect(result.content).not.toContain("payload.PayloadWaitForDriveOutMode");
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/mission-fleet-files.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/mission-fleet-files.test.ts
@@ -1,0 +1,122 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deployPaths, type DeployPaths } from "./deploy-paths.js";
+import { missionNames, readFleetFile, readMissionFile, writeFleetFile, writeMissionFile } from "./mission-fleet-files.js";
+
+describe("mission-fleet-files (real filesystem, no current release deployed)", () => {
+  let scratchRoot: string;
+  let paths: DeployPaths;
+
+  beforeEach(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "pi-agent-mission-fleet-files-test-"));
+    paths = deployPaths(scratchRoot);
+  });
+
+  afterEach(async () => {
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  it("reports 'No build deployed' for every operation when there's no current symlink", async () => {
+    expect(await missionNames(paths)).toEqual({ success: false, missions: [], error: "No build deployed" });
+    expect(await readMissionFile("patrol", paths)).toEqual({ success: false, error: "No build deployed" });
+    expect(await readFleetFile("example_fleet", paths)).toEqual({ success: false, error: "No build deployed" });
+  });
+});
+
+describe("mission-fleet-files (real filesystem, a real current release deployed)", () => {
+  let scratchRoot: string;
+  let paths: DeployPaths;
+
+  beforeEach(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "pi-agent-mission-fleet-files-test-"));
+    paths = deployPaths(scratchRoot);
+
+    const releaseDir = join(scratchRoot, "releases", "20260101-000000-test");
+    await mkdir(join(releaseDir, "install", "uav", "share", "uav", "missions"), { recursive: true });
+    await mkdir(join(releaseDir, "install", "uav", "share", "uav", "fleets"), { recursive: true });
+    await mkdir(join(releaseDir, "install", "payload", "share", "payload", "missions"), { recursive: true });
+    await writeFile(
+      join(releaseDir, "install", "uav", "share", "uav", "missions", "patrol.yaml"),
+      "modes:\n  start:\n    mode: uav.LandingMode\n",
+      "utf-8",
+    );
+    await writeFile(
+      join(releaseDir, "install", "payload", "share", "payload", "missions", "corner_navigate.yaml"),
+      "modes: {}\n",
+      "utf-8",
+    );
+    await writeFile(
+      join(releaseDir, "install", "uav", "share", "uav", "fleets", "example_fleet.yaml"),
+      "backend:\n  kind: hardware\nvehicles: []\n",
+      "utf-8",
+    );
+    await mkdir(scratchRoot, { recursive: true });
+    await symlink(releaseDir, paths.currentLink);
+  });
+
+  afterEach(async () => {
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  it("lists mission names from both the uav and payload share dirs, sorted", async () => {
+    const result = await missionNames(paths);
+    expect(result).toEqual({ success: true, missions: ["corner_navigate", "patrol"] });
+  });
+
+  it("reads an existing mission file's real content", async () => {
+    const result = await readMissionFile("patrol", paths);
+    expect(result.success).toBe(true);
+    expect(result.content).toContain("uav.LandingMode");
+  });
+
+  it("returns a clear error for a mission that doesn't exist", async () => {
+    expect(await readMissionFile("nonexistent", paths)).toEqual({
+      success: false,
+      error: "Mission 'nonexistent' not found",
+    });
+  });
+
+  it("rejects a mission name containing path traversal characters, never touching the filesystem", async () => {
+    expect(await readMissionFile("../../../etc/passwd", paths)).toEqual({
+      success: false,
+      error: "Invalid mission name",
+    });
+    expect(await writeMissionFile("../evil", "haha", paths)).toEqual({
+      success: false,
+      error: "Invalid mission name",
+    });
+  });
+
+  it("writes back to an existing mission file, and the write is genuinely persisted", async () => {
+    const write = await writeMissionFile("patrol", "modes:\n  start:\n    mode: uav.NavGPSMode\n", paths);
+    expect(write).toEqual({ success: true });
+
+    const reread = await readMissionFile("patrol", paths);
+    expect(reread.content).toContain("uav.NavGPSMode");
+  });
+
+  it("refuses to write a mission file that doesn't exist yet", async () => {
+    expect(await writeMissionFile("brand_new_mission", "modes: {}", paths)).toEqual({
+      success: false,
+      error: "Mission 'brand_new_mission' not found",
+    });
+  });
+
+  it("reads and writes an existing fleet file", async () => {
+    const read = await readFleetFile("example_fleet", paths);
+    expect(read.success).toBe(true);
+    expect(read.content).toContain("hardware");
+
+    const write = await writeFleetFile("example_fleet", "backend:\n  kind: hardware\nvehicles:\n  - name: air-01\n", paths);
+    expect(write).toEqual({ success: true });
+
+    const reread = await readFleetFile("example_fleet", paths);
+    expect(reread.content).toContain("air-01");
+  });
+
+  it("rejects a fleet file name containing path traversal characters", async () => {
+    expect(await readFleetFile("../../secrets", paths)).toEqual({ success: false, error: "Invalid fleet file name" });
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/mission-fleet-files.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/mission-fleet-files.ts
@@ -1,0 +1,118 @@
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import { deployPaths, type DeployPaths } from "./deploy-paths.js";
+import { pathExists, resolveSymlinkTarget } from "./deploy-fs.js";
+
+export interface FileResult {
+  success: boolean;
+  content?: string;
+  error?: string;
+}
+
+export interface MissionNamesResult {
+  success: boolean;
+  missions: string[];
+  error?: string;
+}
+
+const MISSION_PACKAGES = ["uav", "payload"] as const;
+
+/** Strict allowlist, not a blacklist -- names come straight from client-controlled input, this must not permit any path traversal. */
+function sanitizeFileName(name: string): string | null {
+  return /^[A-Za-z0-9_-]+$/.test(name) ? name : null;
+}
+
+async function currentReleaseRoot(paths: DeployPaths): Promise<string | null> {
+  const target = await resolveSymlinkTarget(paths.currentLink);
+  if (!target || !(await pathExists(target))) return null;
+  return target;
+}
+
+async function findMissionFilePath(root: string, name: string): Promise<string | null> {
+  for (const pkg of MISSION_PACKAGES) {
+    for (const ext of [".yaml", ".yml"]) {
+      const candidate = `${root}/install/${pkg}/share/${pkg}/missions/${name}${ext}`;
+      if (await pathExists(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+async function findFleetFilePath(root: string, name: string): Promise<string | null> {
+  for (const ext of [".yaml", ".yml"]) {
+    const candidate = `${root}/install/uav/share/uav/fleets/${name}${ext}`;
+    if (await pathExists(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Lists mission YAML files installed as package share data under the currently-deployed release (mirrors uav/payload setup.py's data_files). */
+export async function missionNames(paths: DeployPaths = deployPaths()): Promise<MissionNamesResult> {
+  const root = await currentReleaseRoot(paths);
+  if (!root) return { success: false, missions: [], error: "No build deployed" };
+
+  const missions: string[] = [];
+  for (const pkg of MISSION_PACKAGES) {
+    const dir = `${root}/install/${pkg}/share/${pkg}/missions`;
+    const entries = await readdir(dir).catch(() => [] as string[]);
+    for (const entry of entries) {
+      if (entry.endsWith(".yaml") || entry.endsWith(".yml")) {
+        missions.push(entry.replace(/\.ya?ml$/, ""));
+      }
+    }
+  }
+  return { success: true, missions: missions.sort() };
+}
+
+export async function readMissionFile(name: string, paths: DeployPaths = deployPaths()): Promise<FileResult> {
+  const safeName = sanitizeFileName(name);
+  if (!safeName) return { success: false, error: "Invalid mission name" };
+  const root = await currentReleaseRoot(paths);
+  if (!root) return { success: false, error: "No build deployed" };
+  const filePath = await findMissionFilePath(root, safeName);
+  if (!filePath) return { success: false, error: `Mission '${safeName}' not found` };
+  const content = await readFile(filePath, "utf-8");
+  return { success: true, content };
+}
+
+/** Writes back to an existing mission file only -- creating a brand new mission isn't supported yet. */
+export async function writeMissionFile(
+  name: string,
+  content: string,
+  paths: DeployPaths = deployPaths(),
+): Promise<FileResult> {
+  const safeName = sanitizeFileName(name);
+  if (!safeName) return { success: false, error: "Invalid mission name" };
+  const root = await currentReleaseRoot(paths);
+  if (!root) return { success: false, error: "No build deployed" };
+  const filePath = await findMissionFilePath(root, safeName);
+  if (!filePath) return { success: false, error: `Mission '${safeName}' not found` };
+  await writeFile(filePath, content, "utf-8");
+  return { success: true };
+}
+
+export async function readFleetFile(name: string, paths: DeployPaths = deployPaths()): Promise<FileResult> {
+  const safeName = sanitizeFileName(name);
+  if (!safeName) return { success: false, error: "Invalid fleet file name" };
+  const root = await currentReleaseRoot(paths);
+  if (!root) return { success: false, error: "No build deployed" };
+  const filePath = await findFleetFilePath(root, safeName);
+  if (!filePath) return { success: false, error: `Fleet file '${safeName}' not found` };
+  const content = await readFile(filePath, "utf-8");
+  return { success: true, content };
+}
+
+/** Writes back to an existing fleet file only -- creating a brand new fleet file isn't supported yet. */
+export async function writeFleetFile(
+  name: string,
+  content: string,
+  paths: DeployPaths = deployPaths(),
+): Promise<FileResult> {
+  const safeName = sanitizeFileName(name);
+  if (!safeName) return { success: false, error: "Invalid fleet file name" };
+  const root = await currentReleaseRoot(paths);
+  if (!root) return { success: false, error: "No build deployed" };
+  const filePath = await findFleetFilePath(root, safeName);
+  if (!filePath) return { success: false, error: `Fleet file '${safeName}' not found` };
+  await writeFile(filePath, content, "utf-8");
+  return { success: true };
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/mission.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/mission.test.ts
@@ -28,8 +28,11 @@ describe("missionStatus", () => {
     expect(status).toEqual({ success: true, running: true, state: "running", pid: "12345" });
   });
 
-  it("reports stopped for inactive/failed/activating/deactivating states", async () => {
-    for (const state of ["inactive", "failed", "activating", "deactivating"]) {
+  it("reports stopped for any non-active, non-empty state (matches the old bash case statement's catch-all)", async () => {
+    // Not just the enumerated inactive/failed/activating/deactivating --
+    // systemd can report other states too (e.g. "reloading"), and the old
+    // dashboard's `case ... *) echo STOPPED ;;` mapped all of them to stopped.
+    for (const state of ["inactive", "failed", "activating", "deactivating", "reloading", "some-future-state"]) {
       const run = fakeRunner({
         "sudo -n systemctl is-active pennair-autonomy.service": ok(`${state}\n`),
       });
@@ -38,7 +41,7 @@ describe("missionStatus", () => {
     }
   });
 
-  it("reports an error state on an unexpected systemctl response", async () => {
+  it("reports an error state when systemctl produces no output at all (e.g. a sudo password prompt)", async () => {
     const run = fakeRunner({
       "sudo -n systemctl is-active pennair-autonomy.service": fail("sudo: a password is required"),
     });

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/mission.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/mission.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { CommandRunner, ExecResult } from "./exec.js";
+import { missionStatus, prepareMission, stopMission } from "./mission.js";
+
+function ok(stdout: string): ExecResult {
+  return { code: 0, stdout, stderr: "" };
+}
+
+function fail(stderr: string): ExecResult {
+  return { code: 1, stdout: "", stderr };
+}
+
+function fakeRunner(responses: Record<string, ExecResult>): CommandRunner {
+  return async (command, args) => {
+    const key = [command, ...args].join(" ");
+    return responses[key] ?? fail(`no fake response registered for: ${key}`);
+  };
+}
+
+describe("missionStatus", () => {
+  it("reports running with a pid when the service is active", async () => {
+    const run = fakeRunner({
+      "sudo -n systemctl is-active pennair-autonomy.service": ok("active\n"),
+      "sudo -n systemctl show -p MainPID --value pennair-autonomy.service": ok("12345\n"),
+    });
+
+    const status = await missionStatus(run);
+    expect(status).toEqual({ success: true, running: true, state: "running", pid: "12345" });
+  });
+
+  it("reports stopped for inactive/failed/activating/deactivating states", async () => {
+    for (const state of ["inactive", "failed", "activating", "deactivating"]) {
+      const run = fakeRunner({
+        "sudo -n systemctl is-active pennair-autonomy.service": ok(`${state}\n`),
+      });
+      const status = await missionStatus(run);
+      expect(status).toEqual({ success: true, running: false, state: "stopped" });
+    }
+  });
+
+  it("reports an error state on an unexpected systemctl response", async () => {
+    const run = fakeRunner({
+      "sudo -n systemctl is-active pennair-autonomy.service": fail("sudo: a password is required"),
+    });
+    const status = await missionStatus(run);
+    expect(status.success).toBe(false);
+    expect(status.state).toBe("error");
+    expect(status.error).toContain("password");
+  });
+});
+
+describe("prepareMission", () => {
+  it("restarts the service and reports success", async () => {
+    const run = fakeRunner({ "sudo -n systemctl restart pennair-autonomy.service": ok("") });
+    expect(await prepareMission(run)).toEqual({ success: true, output: "Mission runtime started" });
+  });
+
+  it("reports failure with the systemctl error", async () => {
+    const run = fakeRunner({
+      "sudo -n systemctl restart pennair-autonomy.service": fail("Unit not found."),
+    });
+    expect(await prepareMission(run)).toEqual({ success: false, error: "Unit not found." });
+  });
+});
+
+describe("stopMission", () => {
+  it("stops the service and reports success", async () => {
+    const run = fakeRunner({ "sudo -n systemctl stop pennair-autonomy.service": ok("") });
+    expect(await stopMission(run)).toEqual({ success: true, output: "Mission runtime stopped" });
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/mission.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/mission.ts
@@ -22,15 +22,22 @@ export async function missionStatus(run: CommandRunner = runCommand): Promise<La
     return { success: true, running: true, state: "running", pid: pidResult.stdout.trim() || "0" };
   }
 
-  if (["inactive", "failed", "activating", "deactivating"].includes(state)) {
+  if (state) {
+    // Any other real, non-empty state (inactive/failed/activating/deactivating/
+    // reloading/etc.) means the unit exists and just isn't running -- matches
+    // the old dashboard's bash `case` statement, which mapped every non-"active"
+    // state to STOPPED via its `*)` catch-all, not just an enumerated list.
     return { success: true, running: false, state: "stopped" };
   }
 
+  // Empty stdout means systemctl didn't actually report a state at all (e.g.
+  // "sudo: a password is required" went to stderr with nothing on stdout) --
+  // that's a real failure to query status, not a legitimate stopped state.
   return {
     success: false,
     running: false,
     state: "error",
-    error: active.stderr || `Unexpected systemctl state: ${state || "(empty)"}`,
+    error: active.stderr || "systemctl produced no output",
   };
 }
 

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/mission.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/mission.ts
@@ -1,0 +1,51 @@
+import type { LaunchStatus } from "@pennair/integration-core";
+import { runCommand, type CommandRunner } from "./exec.js";
+
+const SERVICE_NAME = process.env.MISSION_SERVICE_NAME ?? "pennair-autonomy.service";
+
+interface SimpleResult {
+  success: boolean;
+  output?: string;
+  error?: string;
+}
+
+export async function missionStatus(run: CommandRunner = runCommand): Promise<LaunchStatus> {
+  const active = await run("sudo", ["-n", "systemctl", "is-active", SERVICE_NAME], 8_000);
+  const state = active.stdout.trim();
+
+  if (state === "active") {
+    const pidResult = await run(
+      "sudo",
+      ["-n", "systemctl", "show", "-p", "MainPID", "--value", SERVICE_NAME],
+      8_000,
+    );
+    return { success: true, running: true, state: "running", pid: pidResult.stdout.trim() || "0" };
+  }
+
+  if (["inactive", "failed", "activating", "deactivating"].includes(state)) {
+    return { success: true, running: false, state: "stopped" };
+  }
+
+  return {
+    success: false,
+    running: false,
+    state: "error",
+    error: active.stderr || `Unexpected systemctl state: ${state || "(empty)"}`,
+  };
+}
+
+export async function prepareMission(run: CommandRunner = runCommand): Promise<SimpleResult> {
+  const result = await run("sudo", ["-n", "systemctl", "restart", SERVICE_NAME], 25_000);
+  if (result.code !== 0) {
+    return { success: false, error: result.stderr || "Failed to start mission runtime" };
+  }
+  return { success: true, output: "Mission runtime started" };
+}
+
+export async function stopMission(run: CommandRunner = runCommand): Promise<SimpleResult> {
+  const result = await run("sudo", ["-n", "systemctl", "stop", SERVICE_NAME], 20_000);
+  if (result.code !== 0) {
+    return { success: false, error: result.stderr || "Failed to stop mission runtime" };
+  }
+  return { success: true, output: "Mission runtime stopped" };
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/mission.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/mission.ts
@@ -1,13 +1,6 @@
 import type { LaunchStatus } from "@pennair/integration-core";
-import { runCommand, type CommandRunner } from "./exec.js";
-
-const SERVICE_NAME = process.env.MISSION_SERVICE_NAME ?? "pennair-autonomy.service";
-
-interface SimpleResult {
-  success: boolean;
-  output?: string;
-  error?: string;
-}
+import { runCommand, type CommandRunner, type SimpleResult } from "./exec.js";
+import { SERVICE_NAME } from "./service-name.js";
 
 export async function missionStatus(run: CommandRunner = runCommand): Promise<LaunchStatus> {
   const active = await run("sudo", ["-n", "systemctl", "is-active", SERVICE_NAME], 8_000);

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/schema-export.command-injection.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/schema-export.command-injection.test.ts
@@ -1,0 +1,85 @@
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { deployPaths, type DeployPaths } from "./deploy-paths.js";
+import { exportSchema } from "./schema-export.js";
+import { runCommand } from "./exec.js";
+
+/**
+ * Reproduces a real command-injection vulnerability, using the REAL
+ * `runCommand` (packages/pi-agent/src/exec.ts), which really spawns
+ * `bash -c <command>`, not a mocked CommandRunner.
+ *
+ * schema-export.ts builds its command string as:
+ *
+ *   `source "${releaseRoot}/install/setup.bash" 2>/dev/null`
+ *   `python3 "${scriptPath}" --root "${releaseRoot}"`
+ *
+ * `releaseRoot` is interpolated into a double-quoted bash -c string with no
+ * escaping (schema-export.ts lines 47-51). `releaseRoot` is the resolved
+ * target of the deploy `current` symlink, which points at
+ * `<releasesDir>/<releaseId>`.
+ *
+ * `releaseId` is NOT purely server-derived: it's built in deploy.ts as
+ * `${releaseTimestamp()}-${releaseSlug}-${randomBytes(3)}` where
+ * `releaseSlug = artifactName.replace(/\.tar\.gz$/, "").replace(/\.tgz$/, "")`
+ * and `artifactName` is the client-supplied multipart upload filename,
+ * completely unsanitized (pi-agent/src/index.ts line 62:
+ * `artifactPath = \`${paths.incomingDir}/${part.filename}\`;` and line 86:
+ * `const filename = artifactPath.split("/").pop() ?? "artifact.tar.gz";` --
+ * this only strips "/", not quote characters). A double quote character
+ * anywhere in an uploaded artifact's filename survives, unescaped, all the
+ * way into the release directory name, and from there into this shell
+ * command string.
+ *
+ * This test simulates that: a "release directory" whose name contains a
+ * `"` followed by an injected shell command, exactly as would result from
+ * uploading a deploy artifact with a crafted filename. It uses the real
+ * exec.ts runCommand (real `bash -c`, real child process) and proves
+ * arbitrary command execution by observing a sentinel file get created
+ * outside of anything schema_export.py itself would ever touch.
+ */
+describe("exportSchema command construction with an attacker-influenced release directory name", () => {
+  let scratchRoot: string;
+  let paths: DeployPaths;
+
+  beforeEach(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "pi-agent-schema-export-injection-test-"));
+    paths = deployPaths(scratchRoot);
+  });
+
+  afterEach(async () => {
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  it("executes an injected shell command embedded in the release directory name", async () => {
+    const sentinel = join(scratchRoot, "PWNED");
+
+    // Mirrors deploy.ts's releaseId shape: <timestamp>-<artifactName-derived slug>-<random>.
+    // The slug here is exactly what an attacker-controlled upload filename
+    // (unsanitized end to end) would produce.
+    const maliciousReleaseDirName = `20260101-000000-test"; touch "${sentinel}"; echo "pwned`;
+    const releaseDir = join(scratchRoot, "releases", maliciousReleaseDirName);
+    await mkdir(releaseDir, { recursive: true });
+    await mkdir(scratchRoot, { recursive: true });
+    await symlink(releaseDir, paths.currentLink);
+
+    // A harmless stub standing in for schema_export.py.
+    const scriptPath = join(scratchRoot, "stub_schema_export.py");
+    await writeFile(scriptPath, "print('{}')\n", "utf-8");
+
+    await exportSchema(runCommand, paths, scriptPath);
+
+    const sentinelExists = await readFile(sentinel, "utf-8")
+      .then(() => true)
+      .catch(() => false);
+
+    // What should happen: a release directory name should never be able to
+    // inject arbitrary shell commands into schema export, regardless of
+    // what characters ended up in it. Currently it can -- this assertion
+    // fails against the buggy implementation (the sentinel file gets
+    // created, proving real command execution).
+    expect(sentinelExists).toBe(false);
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/schema-export.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/schema-export.test.ts
@@ -1,0 +1,80 @@
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CommandRunner, ExecResult } from "./exec.js";
+import { deployPaths, type DeployPaths } from "./deploy-paths.js";
+import { exportSchema } from "./schema-export.js";
+
+function ok(stdout: string): ExecResult {
+  return { code: 0, stdout, stderr: "" };
+}
+function fail(stderr: string): ExecResult {
+  return { code: 1, stdout: "", stderr };
+}
+
+describe("exportSchema", () => {
+  let scratchRoot: string;
+  let paths: DeployPaths;
+
+  beforeEach(async () => {
+    scratchRoot = await mkdtemp(join(tmpdir(), "pi-agent-schema-export-test-"));
+    paths = deployPaths(scratchRoot);
+  });
+
+  afterEach(async () => {
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  it("reports 'No build deployed' when there's no current release, without ever invoking the runner", async () => {
+    let called = false;
+    const run: CommandRunner = async () => {
+      called = true;
+      return ok("{}");
+    };
+    const result = await exportSchema(run, paths, "irrelevant.py");
+    expect(result).toEqual({ success: false, error: "No build deployed" });
+    expect(called).toBe(false);
+  });
+
+  it("sources ROS2 and the release's overlay, then runs the given script against --root, and parses stdout as JSON", async () => {
+    const releaseDir = join(scratchRoot, "releases", "20260101-000000-test");
+    await mkdir(releaseDir, { recursive: true });
+    await symlink(releaseDir, paths.currentLink);
+
+    let capturedCommand = "";
+    const run: CommandRunner = async (command, args) => {
+      expect(command).toBe("bash");
+      expect(args[0]).toBe("-c");
+      capturedCommand = args[1];
+      return ok(JSON.stringify({ modes: {}, fleet: { sections: [] }, missions: [] }));
+    };
+
+    const result = await exportSchema(run, paths, "/path/to/schema_export.py");
+    expect(result.success).toBe(true);
+    expect(result.schema).toEqual({ modes: {}, fleet: { sections: [] }, missions: [] });
+    expect(capturedCommand).toContain("source /opt/ros/jazzy/setup.bash");
+    expect(capturedCommand).toContain(`source "${releaseDir}/install/setup.bash"`);
+    expect(capturedCommand).toContain(`python3 "/path/to/schema_export.py" --root "${releaseDir}"`);
+  });
+
+  it("surfaces a graceful error when the script exits non-zero", async () => {
+    const releaseDir = join(scratchRoot, "releases", "20260101-000000-test");
+    await mkdir(releaseDir, { recursive: true });
+    await symlink(releaseDir, paths.currentLink);
+
+    const run: CommandRunner = async () => fail("Could not import vehicle_common.mode_loader");
+    const result = await exportSchema(run, paths, "irrelevant.py");
+    expect(result).toEqual({ success: false, error: "Could not import vehicle_common.mode_loader" });
+  });
+
+  it("surfaces a graceful error when the script produces non-JSON output", async () => {
+    const releaseDir = join(scratchRoot, "releases", "20260101-000000-test");
+    await mkdir(releaseDir, { recursive: true });
+    await symlink(releaseDir, paths.currentLink);
+
+    const run: CommandRunner = async () => ok("not json");
+    const result = await exportSchema(run, paths, "irrelevant.py");
+    expect(result).toEqual({ success: false, error: "schema export produced invalid JSON output" });
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/schema-export.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/schema-export.test.ts
@@ -53,9 +53,12 @@ describe("exportSchema", () => {
     const result = await exportSchema(run, paths, "/path/to/schema_export.py");
     expect(result.success).toBe(true);
     expect(result.schema).toEqual({ modes: {}, fleet: { sections: [] }, missions: [] });
+    // Single-quoted, not double-quoted -- shellQuote uses single quotes so
+    // that shell metacharacters in a client-controlled release path (see
+    // schema-export.command-injection.test.ts) are inert.
     expect(capturedCommand).toContain("source /opt/ros/jazzy/setup.bash");
-    expect(capturedCommand).toContain(`source "${releaseDir}/install/setup.bash"`);
-    expect(capturedCommand).toContain(`python3 "/path/to/schema_export.py" --root "${releaseDir}"`);
+    expect(capturedCommand).toContain(`source '${releaseDir}/install/setup.bash'`);
+    expect(capturedCommand).toContain(`python3 '/path/to/schema_export.py' --root '${releaseDir}'`);
   });
 
   it("surfaces a graceful error when the script exits non-zero", async () => {

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/schema-export.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/schema-export.ts
@@ -1,0 +1,56 @@
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { deployPaths, type DeployPaths } from "./deploy-paths.js";
+import { resolveSymlinkTarget, pathExists } from "./deploy-fs.js";
+import { runCommand, type CommandRunner } from "./exec.js";
+
+const SCHEMA_EXPORT_TIMEOUT_MS = 30_000;
+
+function defaultSchemaExportScriptPath(): string {
+  if (process.env.SCHEMA_EXPORT_SCRIPT_PATH) return process.env.SCHEMA_EXPORT_SCRIPT_PATH;
+  // Resolved relative to this module's own location (stable regardless of
+  // cwd/systemd WorkingDirectory), not process.cwd(): dist/schema-export.js
+  // -> packages/pi-agent/dist -> up to integration/ -> tools/schema-export.
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return join(moduleDir, "..", "..", "..", "tools", "schema-export", "schema_export.py");
+}
+
+export interface SchemaExportResult {
+  success: boolean;
+  schema?: unknown;
+  error?: string;
+}
+
+/**
+ * Runs `schema_export.py` against the currently-deployed release, sourcing
+ * ROS2 + the release's own colcon overlay first -- the Pi is guaranteed to
+ * have a working ROS2 + vehicle_common environment (that's what it's
+ * provisioned for), unlike the orchestrator, which may just be an
+ * operator's laptop.
+ */
+export async function exportSchema(
+  run: CommandRunner = runCommand,
+  paths: DeployPaths = deployPaths(),
+  scriptPath: string = defaultSchemaExportScriptPath(),
+): Promise<SchemaExportResult> {
+  const releaseRoot = await resolveSymlinkTarget(paths.currentLink);
+  if (!releaseRoot || !(await pathExists(releaseRoot))) {
+    return { success: false, error: "No build deployed" };
+  }
+
+  const command = [
+    "source /opt/ros/jazzy/setup.bash 2>/dev/null",
+    `source "${releaseRoot}/install/setup.bash" 2>/dev/null`,
+    `python3 "${scriptPath}" --root "${releaseRoot}"`,
+  ].join(" && ");
+
+  const result = await run("bash", ["-c", command], SCHEMA_EXPORT_TIMEOUT_MS);
+  if (result.code !== 0) {
+    return { success: false, error: result.stderr || "schema export failed" };
+  }
+  try {
+    return { success: true, schema: JSON.parse(result.stdout) };
+  } catch {
+    return { success: false, error: "schema export produced invalid JSON output" };
+  }
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/schema-export.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/schema-export.ts
@@ -38,11 +38,17 @@ export async function exportSchema(
     return { success: false, error: "No build deployed" };
   }
 
+  // Semicolons, not && -- sourcing ROS2/the release overlay is best-effort
+  // (2>/dev/null is deliberately silencing a missing-file error from
+  // `source` itself, not just python's stderr). Chaining with && meant a
+  // missing setup.bash short-circuited the whole command before python3
+  // ever ran, with no output at all -- always run the script regardless, so
+  // a real missing-vehicle_common failure surfaces its own clear stderr.
   const command = [
     "source /opt/ros/jazzy/setup.bash 2>/dev/null",
     `source "${releaseRoot}/install/setup.bash" 2>/dev/null`,
     `python3 "${scriptPath}" --root "${releaseRoot}"`,
-  ].join(" && ");
+  ].join("; ");
 
   const result = await run("bash", ["-c", command], SCHEMA_EXPORT_TIMEOUT_MS);
   if (result.code !== 0) {

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/schema-export.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/schema-export.ts
@@ -22,6 +22,20 @@ export interface SchemaExportResult {
 }
 
 /**
+ * POSIX single-quote shell escaping. releaseRoot is derived from the
+ * uploaded artifact's filename (see deploy.ts's releaseSlug), which is
+ * client-controlled -- interpolating it into a `bash -c` string without this
+ * is a shell injection vector (a filename containing `"`/`$()`/backticks
+ * could execute arbitrary commands on the Pi the next time /api/schema is
+ * called). Single quotes disable all shell interpreting; only an embedded
+ * single quote itself needs escaping, via the standard close-quote,
+ * escaped-quote, reopen-quote technique.
+ */
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
  * Runs `schema_export.py` against the currently-deployed release, sourcing
  * ROS2 + the release's own colcon overlay first -- the Pi is guaranteed to
  * have a working ROS2 + vehicle_common environment (that's what it's
@@ -46,8 +60,8 @@ export async function exportSchema(
   // a real missing-vehicle_common failure surfaces its own clear stderr.
   const command = [
     "source /opt/ros/jazzy/setup.bash 2>/dev/null",
-    `source "${releaseRoot}/install/setup.bash" 2>/dev/null`,
-    `python3 "${scriptPath}" --root "${releaseRoot}"`,
+    `source ${shellQuote(`${releaseRoot}/install/setup.bash`)} 2>/dev/null`,
+    `python3 ${shellQuote(scriptPath)} --root ${shellQuote(releaseRoot)}`,
   ].join("; ");
 
   const result = await run("bash", ["-c", command], SCHEMA_EXPORT_TIMEOUT_MS);

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/service-name.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/service-name.ts
@@ -1,0 +1,4 @@
+/** Name of the systemd unit that runs the deployed ROS2 fleet launch --
+ *  shared by deploy.ts, mission.ts, and logs.ts so they all target the same
+ *  unit `provision-pi.sh`/`bootstrap-pi.sh` installs. */
+export const SERVICE_NAME = process.env.MISSION_SERVICE_NAME ?? "pennair-autonomy.service";

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import type { CommandRunner, ExecResult } from "./wifi.js";
+import { wifiConnect, wifiHotspot, wifiScan, wifiStatus } from "./wifi.js";
+
+function ok(stdout: string): ExecResult {
+  return { code: 0, stdout, stderr: "" };
+}
+
+function fail(stderr: string): ExecResult {
+  return { code: 1, stdout: "", stderr };
+}
+
+/** Fake CommandRunner keyed by command+args, with no real nmcli/network involved. */
+function fakeRunner(responses: Record<string, ExecResult>): CommandRunner {
+  return async (command, args) => {
+    const key = [command, ...args].join(" ");
+    return responses[key] ?? fail(`no fake response registered for: ${key}`);
+  };
+}
+
+describe("wifiStatus", () => {
+  it("parses active connections and flags the wireless one as current", async () => {
+    const run = fakeRunner({
+      "sh -c if command -v pennair-wifi-failover >/dev/null 2>&1; then sudo -n pennair-wifi-failover --status 2>/dev/null || pennair-wifi-failover --status 2>/dev/null; fi":
+        ok(""),
+      "nmcli -f NAME,TYPE,DEVICE,STATE con show --active": ok(
+        "NAME        TYPE             DEVICE  STATE\n" +
+          "pennair_5G  802-11-wireless  wlan0   activated\n" +
+          "lo          loopback         lo      unmanaged\n",
+      ),
+    });
+
+    const status = await wifiStatus(run);
+    expect(status.success).toBe(true);
+    expect(status.currentWifi).toBe("pennair_5G");
+    expect(status.connections).toHaveLength(2);
+    expect(status.isHotspot).toBe(false);
+  });
+
+  it("prefers pennair-wifi-failover's policy fields when present", async () => {
+    const run = fakeRunner({
+      "sh -c if command -v pennair-wifi-failover >/dev/null 2>&1; then sudo -n pennair-wifi-failover --status 2>/dev/null || pennair-wifi-failover --status 2>/dev/null; fi":
+        ok(JSON.stringify({ is_hotspot: true, current_wifi: "pennair-ap-air-01", effective_role: "ap" })),
+      "nmcli -f NAME,TYPE,DEVICE,STATE con show --active": ok("NAME  TYPE  DEVICE  STATE\n"),
+    });
+
+    const status = await wifiStatus(run);
+    expect(status.isHotspot).toBe(true);
+    expect(status.currentWifi).toBe("pennair-ap-air-01");
+    expect(status.effectiveRole).toBe("ap");
+  });
+
+  it("returns success:false with the nmcli error on failure", async () => {
+    const run = fakeRunner({
+      "sh -c if command -v pennair-wifi-failover >/dev/null 2>&1; then sudo -n pennair-wifi-failover --status 2>/dev/null || pennair-wifi-failover --status 2>/dev/null; fi":
+        ok(""),
+      "nmcli -f NAME,TYPE,DEVICE,STATE con show --active": fail("nmcli: command not found"),
+    });
+
+    const status = await wifiStatus(run);
+    expect(status.success).toBe(false);
+    expect(status.error).toBe("nmcli: command not found");
+  });
+});
+
+describe("wifiScan", () => {
+  it("dedupes repeated SSIDs keeping the strongest signal, sorted descending", async () => {
+    const run = fakeRunner({
+      "nmcli -f SSID,SIGNAL,SECURITY dev wifi list --rescan yes": ok(
+        "SSID        SIGNAL  SECURITY\n" +
+          "pennair_5G  40      WPA2\n" +
+          "pennair_5G  75      WPA2\n" +
+          "other_ap    60      --\n",
+      ),
+    });
+
+    const scan = await wifiScan(run);
+    expect(scan.success).toBe(true);
+    expect(scan.networks).toEqual([
+      { ssid: "pennair_5G", signal: 75, security: "WPA2" },
+      { ssid: "other_ap", signal: 60, security: "--" },
+    ]);
+  });
+});
+
+describe("wifiConnect", () => {
+  it("brings the hotspot down, connects, and reports success", async () => {
+    const run = fakeRunner({
+      "sh -c if command -v pennair-wifi-failover >/dev/null 2>&1; then sudo -n pennair-wifi-failover --status 2>/dev/null || pennair-wifi-failover --status 2>/dev/null; fi":
+        ok(""),
+      "nmcli con down penn-desktop": ok(""),
+      "nmcli dev wifi connect pennair_5G password hunter2": ok(""),
+    });
+
+    const result = await wifiConnect("pennair_5G", "hunter2", run);
+    expect(result).toEqual({ success: true, output: "Pi connected to pennair_5G" });
+  });
+
+  it("rolls back to the hotspot if connecting fails", async () => {
+    let rolledBack = false;
+    const run: CommandRunner = async (command, args) => {
+      const key = [command, ...args].join(" ");
+      if (key === "nmcli con up penn-desktop") {
+        rolledBack = true;
+        return ok("");
+      }
+      if (key === "nmcli dev wifi connect bad_ssid") {
+        return fail("Error: No network with SSID 'bad_ssid' found.");
+      }
+      return ok("");
+    };
+
+    const result = await wifiConnect("bad_ssid", "", run);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("bad_ssid");
+    expect(rolledBack).toBe(true);
+  });
+});
+
+describe("wifiHotspot", () => {
+  it("disconnects wlan0 and brings the hotspot profile up", async () => {
+    const run = fakeRunner({
+      "sh -c if command -v pennair-wifi-failover >/dev/null 2>&1; then sudo -n pennair-wifi-failover --status 2>/dev/null || pennair-wifi-failover --status 2>/dev/null; fi":
+        ok(""),
+      "nmcli dev disconnect wlan0": ok(""),
+      "nmcli con up penn-desktop": ok(""),
+    });
+
+    const result = await wifiHotspot(run);
+    expect(result).toEqual({ success: true, output: "Hotspot activated" });
+  });
+});

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { CommandRunner, ExecResult } from "./wifi.js";
 import { wifiConnect, wifiHotspot, wifiScan, wifiStatus } from "./wifi.js";
 
+const noWait = async () => {};
+
 function ok(stdout: string): ExecResult {
   return { code: 0, stdout, stderr: "" };
 }
@@ -18,15 +20,15 @@ function fakeRunner(responses: Record<string, ExecResult>): CommandRunner {
   };
 }
 
+const NO_POLICY_KEY =
+  "sh -c if command -v pennair-wifi-failover >/dev/null 2>&1; then sudo -n pennair-wifi-failover --status 2>/dev/null || pennair-wifi-failover --status 2>/dev/null; fi";
+
 describe("wifiStatus", () => {
-  it("parses active connections and flags the wireless one as current", async () => {
+  it("parses active connections (terse, colon-separated) and flags the wireless one as current", async () => {
     const run = fakeRunner({
-      "sh -c if command -v pennair-wifi-failover >/dev/null 2>&1; then sudo -n pennair-wifi-failover --status 2>/dev/null || pennair-wifi-failover --status 2>/dev/null; fi":
-        ok(""),
-      "nmcli -f NAME,TYPE,DEVICE,STATE con show --active": ok(
-        "NAME        TYPE             DEVICE  STATE\n" +
-          "pennair_5G  802-11-wireless  wlan0   activated\n" +
-          "lo          loopback         lo      unmanaged\n",
+      [NO_POLICY_KEY]: ok(""),
+      "nmcli -t -f NAME,TYPE,DEVICE,STATE con show --active": ok(
+        "pennair_5G:802-11-wireless:wlan0:activated\nlo:loopback:lo:unmanaged\n",
       ),
     });
 
@@ -37,24 +39,68 @@ describe("wifiStatus", () => {
     expect(status.isHotspot).toBe(false);
   });
 
-  it("prefers pennair-wifi-failover's policy fields when present", async () => {
+  it("un-escapes backslash-escaped colons within a terse field", async () => {
     const run = fakeRunner({
-      "sh -c if command -v pennair-wifi-failover >/dev/null 2>&1; then sudo -n pennair-wifi-failover --status 2>/dev/null || pennair-wifi-failover --status 2>/dev/null; fi":
-        ok(JSON.stringify({ is_hotspot: true, current_wifi: "pennair-ap-air-01", effective_role: "ap" })),
-      "nmcli -f NAME,TYPE,DEVICE,STATE con show --active": ok("NAME  TYPE  DEVICE  STATE\n"),
+      [NO_POLICY_KEY]: ok(""),
+      "nmcli -t -f NAME,TYPE,DEVICE,STATE con show --active": ok(
+        "weird\\:name:802-11-wireless:wlan0:activated\n",
+      ),
+    });
+
+    const status = await wifiStatus(run);
+    expect(status.currentWifi).toBe("weird:name");
+  });
+
+  it("prefers pennair-wifi-failover's policy fields when present, including the previously-dropped ones", async () => {
+    const run = fakeRunner({
+      [NO_POLICY_KEY]: ok(
+        JSON.stringify({
+          is_hotspot: true,
+          current_wifi: "pennair-ap-air-01",
+          effective_role: "ap",
+          policy_source: "fleet",
+          runtime_active: true,
+          mission_started: false,
+          travel_router_locked: true,
+          switching_disabled: false,
+          local_ap_profile: "pennair-ap-air-01",
+          travel_router_profile: "pennair_5G",
+          allowed_ap_hosts: ["air-02"],
+        }),
+      ),
+      "nmcli -t -f NAME,TYPE,DEVICE,STATE con show --active": ok(""),
     });
 
     const status = await wifiStatus(run);
     expect(status.isHotspot).toBe(true);
     expect(status.currentWifi).toBe("pennair-ap-air-01");
     expect(status.effectiveRole).toBe("ap");
+    expect(status.policySource).toBe("fleet");
+    expect(status.runtimeActive).toBe(true);
+    expect(status.travelRouterLocked).toBe(true);
+    expect(status.localApProfile).toBe("pennair-ap-air-01");
+    expect(status.travelRouterProfile).toBe("pennair_5G");
+    expect(status.allowedApHosts).toEqual(["air-02"]);
+  });
+
+  it("does not treat an empty-string policy field as a real value", async () => {
+    // A policy JSON with is_hotspot but empty-string current_wifi should
+    // still fall back to the nmcli-derived value, not keep "".
+    const run = fakeRunner({
+      [NO_POLICY_KEY]: ok(JSON.stringify({ current_wifi: "" })),
+      "nmcli -t -f NAME,TYPE,DEVICE,STATE con show --active": ok(
+        "pennair_5G:802-11-wireless:wlan0:activated\n",
+      ),
+    });
+
+    const status = await wifiStatus(run);
+    expect(status.currentWifi).toBe("pennair_5G");
   });
 
   it("returns success:false with the nmcli error on failure", async () => {
     const run = fakeRunner({
-      "sh -c if command -v pennair-wifi-failover >/dev/null 2>&1; then sudo -n pennair-wifi-failover --status 2>/dev/null || pennair-wifi-failover --status 2>/dev/null; fi":
-        ok(""),
-      "nmcli -f NAME,TYPE,DEVICE,STATE con show --active": fail("nmcli: command not found"),
+      [NO_POLICY_KEY]: ok(""),
+      "nmcli -t -f NAME,TYPE,DEVICE,STATE con show --active": fail("nmcli: command not found"),
     });
 
     const status = await wifiStatus(run);
@@ -66,11 +112,8 @@ describe("wifiStatus", () => {
 describe("wifiScan", () => {
   it("dedupes repeated SSIDs keeping the strongest signal, sorted descending", async () => {
     const run = fakeRunner({
-      "nmcli -f SSID,SIGNAL,SECURITY dev wifi list --rescan yes": ok(
-        "SSID        SIGNAL  SECURITY\n" +
-          "pennair_5G  40      WPA2\n" +
-          "pennair_5G  75      WPA2\n" +
-          "other_ap    60      --\n",
+      "nmcli -t -f SSID,SIGNAL,SECURITY dev wifi list --rescan yes": ok(
+        "pennair_5G:40:WPA2\npennair_5G:75:WPA2\nother_ap:60:--\n",
       ),
     });
 
@@ -81,19 +124,32 @@ describe("wifiScan", () => {
       { ssid: "other_ap", signal: 60, security: "--" },
     ]);
   });
+
+  it("handles an SSID containing a colon without desyncing columns", async () => {
+    const run = fakeRunner({
+      "nmcli -t -f SSID,SIGNAL,SECURITY dev wifi list --rescan yes": ok("weird\\:ssid:50:WPA2\n"),
+    });
+
+    const scan = await wifiScan(run);
+    expect(scan.networks).toEqual([{ ssid: "weird:ssid", signal: 50, security: "WPA2" }]);
+  });
 });
 
 describe("wifiConnect", () => {
-  it("brings the hotspot down, connects, and reports success", async () => {
+  it("brings the hotspot down, waits for it to settle, connects, and reports success", async () => {
     const run = fakeRunner({
-      "sh -c if command -v pennair-wifi-failover >/dev/null 2>&1; then sudo -n pennair-wifi-failover --status 2>/dev/null || pennair-wifi-failover --status 2>/dev/null; fi":
-        ok(""),
+      [NO_POLICY_KEY]: ok(""),
       "nmcli con down penn-desktop": ok(""),
       "nmcli dev wifi connect pennair_5G password hunter2": ok(""),
     });
+    const waited: number[] = [];
 
-    const result = await wifiConnect("pennair_5G", "hunter2", run);
+    const result = await wifiConnect("pennair_5G", "hunter2", run, async (ms) => {
+      waited.push(ms);
+    });
+
     expect(result).toEqual({ success: true, output: "Pi connected to pennair_5G" });
+    expect(waited).toEqual([2000]);
   });
 
   it("rolls back to the hotspot if connecting fails", async () => {
@@ -110,23 +166,38 @@ describe("wifiConnect", () => {
       return ok("");
     };
 
-    const result = await wifiConnect("bad_ssid", "", run);
+    const result = await wifiConnect("bad_ssid", "", run, noWait);
     expect(result.success).toBe(false);
     expect(result.error).toContain("bad_ssid");
     expect(rolledBack).toBe(true);
   });
+
+  it("falls back to the default hotspot name if the policy's local_ap_profile is an empty string", async () => {
+    const run = fakeRunner({
+      [NO_POLICY_KEY]: ok(JSON.stringify({ local_ap_profile: "" })),
+      "nmcli con down penn-desktop": ok(""),
+      "nmcli dev wifi connect pennair_5G": ok(""),
+    });
+
+    const result = await wifiConnect("pennair_5G", "", run, noWait);
+    expect(result.success).toBe(true);
+  });
 });
 
 describe("wifiHotspot", () => {
-  it("disconnects wlan0 and brings the hotspot profile up", async () => {
+  it("disconnects wlan0, waits for it to settle, and brings the hotspot profile up", async () => {
     const run = fakeRunner({
-      "sh -c if command -v pennair-wifi-failover >/dev/null 2>&1; then sudo -n pennair-wifi-failover --status 2>/dev/null || pennair-wifi-failover --status 2>/dev/null; fi":
-        ok(""),
+      [NO_POLICY_KEY]: ok(""),
       "nmcli dev disconnect wlan0": ok(""),
       "nmcli con up penn-desktop": ok(""),
     });
+    const waited: number[] = [];
 
-    const result = await wifiHotspot(run);
+    const result = await wifiHotspot(run, async (ms) => {
+      waited.push(ms);
+    });
+
     expect(result).toEqual({ success: true, output: "Hotspot activated" });
+    expect(waited).toEqual([1000]);
   });
 });

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.test.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { CommandRunner, ExecResult } from "./wifi.js";
+import type { CommandRunner, ExecResult } from "./exec.js";
 import { wifiConnect, wifiHotspot, wifiScan, wifiStatus } from "./wifi.js";
 
 const noWait = async () => {};

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.ts
@@ -38,9 +38,33 @@ export const runCommand: CommandRunner = async (command, args, timeoutMs) => {
   }
 };
 
-/** Splits on runs of 2+ spaces, matching nmcli's fixed-width column output. */
-function splitColumns(line: string): string[] {
-  return line.trim().split(/\s{2,}/);
+/** Real delay -- the default, unless a test injects a no-op one. */
+export const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Parses one line of `nmcli -t` (terse) output: colon-separated fields,
+ * where a literal `:` or `\` inside a value is backslash-escaped. Terse mode
+ * is nmcli's own recommended machine-readable format -- unlike the
+ * fixed-width tabular output, it can't be desynced by an SSID containing
+ * spaces or a blank/hidden SSID.
+ */
+function parseTerseLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === "\\" && i + 1 < line.length) {
+      current += line[i + 1];
+      i++;
+    } else if (ch === ":") {
+      fields.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  fields.push(current);
+  return fields;
 }
 
 async function policyStatus(run: CommandRunner): Promise<Record<string, unknown>> {
@@ -67,9 +91,19 @@ async function policyStatus(run: CommandRunner): Promise<Record<string, unknown>
   }
 }
 
+function stringField(policy: Record<string, unknown>, key: string): string | undefined {
+  const value = policy[key];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function boolField(policy: Record<string, unknown>, key: string): boolean | undefined {
+  const value = policy[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
 export async function wifiStatus(run: CommandRunner = runCommand): Promise<WifiStatus> {
   const policy = await policyStatus(run);
-  const result = await run("nmcli", ["-f", "NAME,TYPE,DEVICE,STATE", "con", "show", "--active"], 15_000);
+  const result = await run("nmcli", ["-t", "-f", "NAME,TYPE,DEVICE,STATE", "con", "show", "--active"], 15_000);
   if (result.code !== 0) {
     return { success: false, connections: [], error: result.stderr };
   }
@@ -77,9 +111,8 @@ export async function wifiStatus(run: CommandRunner = runCommand): Promise<WifiS
   const connections: WifiConnection[] = result.stdout
     .trim()
     .split("\n")
-    .slice(1) // header row
     .filter((line) => line.trim())
-    .map(splitColumns)
+    .map(parseTerseLine)
     .filter((parts) => parts.length >= 4)
     .map(([name, type, device, state]) => ({ name, type, device, state }));
 
@@ -88,10 +121,18 @@ export async function wifiStatus(run: CommandRunner = runCommand): Promise<WifiS
 
   return {
     success: true,
-    isHotspot: typeof policy.is_hotspot === "boolean" ? policy.is_hotspot : legacyHotspot,
-    currentWifi: (policy.current_wifi as string | undefined) ?? wifiConnection?.name,
-    currentMode: policy.current_mode as string | undefined,
-    effectiveRole: policy.effective_role as string | undefined,
+    isHotspot: boolField(policy, "is_hotspot") ?? legacyHotspot,
+    currentWifi: stringField(policy, "current_wifi") ?? wifiConnection?.name,
+    currentMode: stringField(policy, "current_mode"),
+    effectiveRole: stringField(policy, "effective_role"),
+    policySource: stringField(policy, "policy_source"),
+    runtimeActive: boolField(policy, "runtime_active"),
+    missionStarted: boolField(policy, "mission_started"),
+    travelRouterLocked: boolField(policy, "travel_router_locked"),
+    switchingDisabled: boolField(policy, "switching_disabled"),
+    localApProfile: stringField(policy, "local_ap_profile"),
+    travelRouterProfile: stringField(policy, "travel_router_profile"),
+    allowedApHosts: Array.isArray(policy.allowed_ap_hosts) ? (policy.allowed_ap_hosts as string[]) : [],
     connections,
   };
 }
@@ -99,7 +140,7 @@ export async function wifiStatus(run: CommandRunner = runCommand): Promise<WifiS
 export async function wifiScan(run: CommandRunner = runCommand): Promise<WifiScanResult> {
   const result = await run(
     "nmcli",
-    ["-f", "SSID,SIGNAL,SECURITY", "dev", "wifi", "list", "--rescan", "yes"],
+    ["-t", "-f", "SSID,SIGNAL,SECURITY", "dev", "wifi", "list", "--rescan", "yes"],
     20_000,
   );
   if (result.code !== 0) {
@@ -107,9 +148,9 @@ export async function wifiScan(run: CommandRunner = runCommand): Promise<WifiSca
   }
 
   const strongestBySsid = new Map<string, WifiNetwork>();
-  for (const line of result.stdout.trim().split("\n").slice(1)) {
+  for (const line of result.stdout.trim().split("\n")) {
     if (!line.trim()) continue;
-    const parts = splitColumns(line);
+    const parts = parseTerseLine(line);
     if (parts.length < 3) continue;
     const [ssid, signalRaw, security] = parts;
     if (!ssid) continue;
@@ -130,11 +171,13 @@ export async function wifiConnect(
   ssid: string,
   password: string,
   run: CommandRunner = runCommand,
+  wait: (ms: number) => Promise<void> = delay,
 ): Promise<{ success: boolean; output?: string; error?: string }> {
   const policy = await policyStatus(run);
-  const hotspotName = (policy.local_ap_profile as string | undefined) ?? HOTSPOT_NAME;
+  const hotspotName = stringField(policy, "local_ap_profile") ?? HOTSPOT_NAME;
 
   await run("nmcli", ["con", "down", hotspotName], 15_000);
+  await wait(2000);
 
   const connectArgs = ["dev", "wifi", "connect", ssid];
   if (password) {
@@ -152,11 +195,13 @@ export async function wifiConnect(
 
 export async function wifiHotspot(
   run: CommandRunner = runCommand,
+  wait: (ms: number) => Promise<void> = delay,
 ): Promise<{ success: boolean; output?: string; error?: string }> {
   const policy = await policyStatus(run);
-  const hotspotName = (policy.local_ap_profile as string | undefined) ?? HOTSPOT_NAME;
+  const hotspotName = stringField(policy, "local_ap_profile") ?? HOTSPOT_NAME;
 
   await run("nmcli", ["dev", "disconnect", "wlan0"], 15_000);
+  await wait(1000);
   const result = await run("nmcli", ["con", "up", hotspotName], 15_000);
 
   if (result.code !== 0) {

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.ts
@@ -1,5 +1,5 @@
 import type { WifiConnection, WifiNetwork, WifiScanResult, WifiStatus } from "@pennair/integration-core";
-import { delay, runCommand, type CommandRunner } from "./exec.js";
+import { delay, runCommand, type CommandRunner, type SimpleResult } from "./exec.js";
 
 const HOTSPOT_NAME = process.env.HOTSPOT_NAME ?? "penn-desktop";
 
@@ -134,7 +134,7 @@ export async function wifiConnect(
   password: string,
   run: CommandRunner = runCommand,
   wait: (ms: number) => Promise<void> = delay,
-): Promise<{ success: boolean; output?: string; error?: string }> {
+): Promise<SimpleResult> {
   const policy = await policyStatus(run);
   const hotspotName = stringField(policy, "local_ap_profile") ?? HOTSPOT_NAME;
 
@@ -158,7 +158,7 @@ export async function wifiConnect(
 export async function wifiHotspot(
   run: CommandRunner = runCommand,
   wait: (ms: number) => Promise<void> = delay,
-): Promise<{ success: boolean; output?: string; error?: string }> {
+): Promise<SimpleResult> {
   const policy = await policyStatus(run);
   const hotspotName = stringField(policy, "local_ap_profile") ?? HOTSPOT_NAME;
 

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.ts
@@ -1,0 +1,166 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import type { WifiConnection, WifiNetwork, WifiScanResult, WifiStatus } from "@pennair/integration-core";
+
+const execFileAsync = promisify(execFileCallback);
+
+const HOTSPOT_NAME = process.env.HOTSPOT_NAME ?? "penn-desktop";
+
+export interface ExecResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type CommandRunner = (command: string, args: string[], timeoutMs: number) => Promise<ExecResult>;
+
+/** Real command runner -- the default, unless a test injects a fake one. */
+export const runCommand: CommandRunner = async (command, args, timeoutMs) => {
+  try {
+    const { stdout, stderr } = await execFileAsync(command, args, { timeout: timeoutMs });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const execError = error as {
+      code?: number | string;
+      stdout?: string;
+      stderr?: string;
+      message: string;
+    };
+    // On a spawn failure (command not found, etc.) `code` is a string like
+    // "ENOENT" and `stderr` is an empty string (not absent) -- fall back to
+    // `.message` for a useful error, and normalize `code` to a number.
+    const numericCode = typeof execError.code === "number" ? execError.code : -1;
+    return {
+      code: numericCode,
+      stdout: execError.stdout ?? "",
+      stderr: execError.stderr || execError.message,
+    };
+  }
+};
+
+/** Splits on runs of 2+ spaces, matching nmcli's fixed-width column output. */
+function splitColumns(line: string): string[] {
+  return line.trim().split(/\s{2,}/);
+}
+
+async function policyStatus(run: CommandRunner): Promise<Record<string, unknown>> {
+  const result = await run(
+    "sh",
+    [
+      "-c",
+      "if command -v pennair-wifi-failover >/dev/null 2>&1; then " +
+        "sudo -n pennair-wifi-failover --status 2>/dev/null || " +
+        "pennair-wifi-failover --status 2>/dev/null; " +
+        "fi",
+    ],
+    15_000,
+  );
+  const raw = result.stdout.trim();
+  if (result.code !== 0 || !raw) {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+export async function wifiStatus(run: CommandRunner = runCommand): Promise<WifiStatus> {
+  const policy = await policyStatus(run);
+  const result = await run("nmcli", ["-f", "NAME,TYPE,DEVICE,STATE", "con", "show", "--active"], 15_000);
+  if (result.code !== 0) {
+    return { success: false, connections: [], error: result.stderr };
+  }
+
+  const connections: WifiConnection[] = result.stdout
+    .trim()
+    .split("\n")
+    .slice(1) // header row
+    .filter((line) => line.trim())
+    .map(splitColumns)
+    .filter((parts) => parts.length >= 4)
+    .map(([name, type, device, state]) => ({ name, type, device, state }));
+
+  const legacyHotspot = connections.some((c) => c.name === HOTSPOT_NAME);
+  const wifiConnection = connections.find((c) => c.type === "802-11-wireless");
+
+  return {
+    success: true,
+    isHotspot: typeof policy.is_hotspot === "boolean" ? policy.is_hotspot : legacyHotspot,
+    currentWifi: (policy.current_wifi as string | undefined) ?? wifiConnection?.name,
+    currentMode: policy.current_mode as string | undefined,
+    effectiveRole: policy.effective_role as string | undefined,
+    connections,
+  };
+}
+
+export async function wifiScan(run: CommandRunner = runCommand): Promise<WifiScanResult> {
+  const result = await run(
+    "nmcli",
+    ["-f", "SSID,SIGNAL,SECURITY", "dev", "wifi", "list", "--rescan", "yes"],
+    20_000,
+  );
+  if (result.code !== 0) {
+    return { success: false, networks: [], error: result.stderr };
+  }
+
+  const strongestBySsid = new Map<string, WifiNetwork>();
+  for (const line of result.stdout.trim().split("\n").slice(1)) {
+    if (!line.trim()) continue;
+    const parts = splitColumns(line);
+    if (parts.length < 3) continue;
+    const [ssid, signalRaw, security] = parts;
+    if (!ssid) continue;
+    const signal = Number.parseInt(signalRaw, 10) || 0;
+    const existing = strongestBySsid.get(ssid);
+    if (!existing || signal > existing.signal) {
+      strongestBySsid.set(ssid, { ssid, signal, security: security ?? "" });
+    }
+  }
+
+  return {
+    success: true,
+    networks: [...strongestBySsid.values()].sort((a, b) => b.signal - a.signal),
+  };
+}
+
+export async function wifiConnect(
+  ssid: string,
+  password: string,
+  run: CommandRunner = runCommand,
+): Promise<{ success: boolean; output?: string; error?: string }> {
+  const policy = await policyStatus(run);
+  const hotspotName = (policy.local_ap_profile as string | undefined) ?? HOTSPOT_NAME;
+
+  await run("nmcli", ["con", "down", hotspotName], 15_000);
+
+  const connectArgs = ["dev", "wifi", "connect", ssid];
+  if (password) {
+    connectArgs.push("password", password);
+  }
+  const result = await run("nmcli", connectArgs, 30_000);
+
+  if (result.code !== 0) {
+    await run("nmcli", ["con", "up", hotspotName], 15_000);
+    return { success: false, error: result.stderr || "Failed to connect" };
+  }
+
+  return { success: true, output: `Pi connected to ${ssid}` };
+}
+
+export async function wifiHotspot(
+  run: CommandRunner = runCommand,
+): Promise<{ success: boolean; output?: string; error?: string }> {
+  const policy = await policyStatus(run);
+  const hotspotName = (policy.local_ap_profile as string | undefined) ?? HOTSPOT_NAME;
+
+  await run("nmcli", ["dev", "disconnect", "wlan0"], 15_000);
+  const result = await run("nmcli", ["con", "up", hotspotName], 15_000);
+
+  if (result.code !== 0) {
+    return { success: false, error: result.stderr };
+  }
+  return { success: true, output: "Hotspot activated" };
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.ts
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/src/wifi.ts
@@ -1,45 +1,7 @@
-import { execFile as execFileCallback } from "node:child_process";
-import { promisify } from "node:util";
 import type { WifiConnection, WifiNetwork, WifiScanResult, WifiStatus } from "@pennair/integration-core";
-
-const execFileAsync = promisify(execFileCallback);
+import { delay, runCommand, type CommandRunner } from "./exec.js";
 
 const HOTSPOT_NAME = process.env.HOTSPOT_NAME ?? "penn-desktop";
-
-export interface ExecResult {
-  code: number;
-  stdout: string;
-  stderr: string;
-}
-
-export type CommandRunner = (command: string, args: string[], timeoutMs: number) => Promise<ExecResult>;
-
-/** Real command runner -- the default, unless a test injects a fake one. */
-export const runCommand: CommandRunner = async (command, args, timeoutMs) => {
-  try {
-    const { stdout, stderr } = await execFileAsync(command, args, { timeout: timeoutMs });
-    return { code: 0, stdout, stderr };
-  } catch (error) {
-    const execError = error as {
-      code?: number | string;
-      stdout?: string;
-      stderr?: string;
-      message: string;
-    };
-    // On a spawn failure (command not found, etc.) `code` is a string like
-    // "ENOENT" and `stderr` is an empty string (not absent) -- fall back to
-    // `.message` for a useful error, and normalize `code` to a number.
-    const numericCode = typeof execError.code === "number" ? execError.code : -1;
-    return {
-      code: numericCode,
-      stdout: execError.stdout ?? "",
-      stderr: execError.stderr || execError.message,
-    };
-  }
-};
-
-/** Real delay -- the default, unless a test injects a no-op one. */
-export const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Parses one line of `nmcli -t` (terse) output: colon-separated fields,

--- a/controls/sae_2025_ws/integration/packages/pi-agent/tsconfig.build.json
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/tsconfig.build.json
@@ -7,5 +7,6 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts"],
+  "references": [{ "path": "../core/tsconfig.build.json" }]
 }

--- a/controls/sae_2025_ws/integration/packages/pi-agent/tsconfig.build.json
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/tsconfig.json
@@ -5,5 +5,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/controls/sae_2025_ws/integration/packages/pi-agent/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/controls/sae_2025_ws/integration/packages/pi-agent/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/pi-agent/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ES2022"],
-    "outDir": "dist",
-    "rootDir": "src"
+    "composite": false,
+    "noEmit": true
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }

--- a/controls/sae_2025_ws/integration/packages/web/index.html
+++ b/controls/sae_2025_ws/integration/packages/web/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PennAiR Fleet Ops</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/controls/sae_2025_ws/integration/packages/web/package.json
+++ b/controls/sae_2025_ws/integration/packages/web/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@pennair/web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@pennair/integration-core": "*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.3",
+    "vite": "^5.4.11"
+  }
+}

--- a/controls/sae_2025_ws/integration/packages/web/package.json
+++ b/controls/sae_2025_ws/integration/packages/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@pennair/integration-core": "*",

--- a/controls/sae_2025_ws/integration/packages/web/src/App.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/App.tsx
@@ -1,10 +1,52 @@
+import { useEffect, useState } from "react";
+import { OrchestratorClient } from "@pennair/integration-core";
 import { WifiCard } from "./WifiCard.js";
+import { MissionCard } from "./MissionCard.js";
+
+const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
+const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
 
 export function App() {
+  const [pis, setPis] = useState<string[]>([]);
+  const [hostname, setHostname] = useState("");
+
+  useEffect(() => {
+    client.discoverPis().then((discovered) => {
+      const hostnames = discovered.map((pi) => pi.hostname);
+      setPis(hostnames);
+      if (hostnames.length > 0 && !hostname) {
+        setHostname(hostnames[0]);
+      }
+    });
+    // Intentionally run once on mount; discovery is re-triggered by the button below.
+  }, []);
+
+  async function refreshDiscovery() {
+    setPis((await client.discoverPis()).map((pi) => pi.hostname));
+  }
+
   return (
     <main>
       <h1>PennAiR Fleet Ops</h1>
-      <WifiCard />
+
+      <label>
+        Pi hostname
+        <input
+          list="discovered-pis"
+          value={hostname}
+          onChange={(e) => setHostname(e.target.value)}
+          placeholder="air-01.local"
+        />
+        <datalist id="discovered-pis">
+          {pis.map((h) => (
+            <option key={h} value={h} />
+          ))}
+        </datalist>
+      </label>
+      <button onClick={refreshDiscovery}>Rediscover</button>
+
+      <WifiCard hostname={hostname} />
+      <MissionCard hostname={hostname} />
     </main>
   );
 }

--- a/controls/sae_2025_ws/integration/packages/web/src/App.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/App.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { OrchestratorClient } from "@pennair/integration-core";
 import { WifiCard } from "./WifiCard.js";
 import { MissionCard } from "./MissionCard.js";
+import { MissionEditor } from "./MissionEditor.js";
+import { FleetEditor } from "./FleetEditor.js";
 
 const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
 const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
@@ -47,6 +49,8 @@ export function App() {
 
       <WifiCard hostname={hostname} />
       <MissionCard hostname={hostname} />
+      <MissionEditor hostname={hostname} />
+      <FleetEditor hostname={hostname} />
     </main>
   );
 }

--- a/controls/sae_2025_ws/integration/packages/web/src/App.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/App.tsx
@@ -1,0 +1,8 @@
+export function App() {
+  return (
+    <main>
+      <h1>PennAiR Fleet Ops</h1>
+      <p>Phase 0 scaffold — wifi control lands in Phase 1.</p>
+    </main>
+  );
+}

--- a/controls/sae_2025_ws/integration/packages/web/src/App.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/App.tsx
@@ -1,8 +1,10 @@
+import { WifiCard } from "./WifiCard.js";
+
 export function App() {
   return (
     <main>
       <h1>PennAiR Fleet Ops</h1>
-      <p>Phase 0 scaffold — wifi control lands in Phase 1.</p>
+      <WifiCard />
     </main>
   );
 }

--- a/controls/sae_2025_ws/integration/packages/web/src/App.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/App.tsx
@@ -4,6 +4,7 @@ import { WifiCard } from "./WifiCard.js";
 import { MissionCard } from "./MissionCard.js";
 import { MissionEditor } from "./MissionEditor.js";
 import { FleetEditor } from "./FleetEditor.js";
+import { FleetBoard } from "./FleetBoard.js";
 
 const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
 const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
@@ -46,6 +47,8 @@ export function App() {
         </datalist>
       </label>
       <button onClick={refreshDiscovery}>Rediscover</button>
+
+      <FleetBoard onSelectHostname={setHostname} />
 
       <WifiCard hostname={hostname} />
       <MissionCard hostname={hostname} />

--- a/controls/sae_2025_ws/integration/packages/web/src/App.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/App.tsx
@@ -1,13 +1,10 @@
 import { useEffect, useState } from "react";
-import { OrchestratorClient } from "@pennair/integration-core";
+import { client } from "./orchestratorClient.js";
 import { WifiCard } from "./WifiCard.js";
 import { MissionCard } from "./MissionCard.js";
 import { MissionEditor } from "./MissionEditor.js";
 import { FleetEditor } from "./FleetEditor.js";
 import { FleetBoard } from "./FleetBoard.js";
-
-const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
-const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
 
 export function App() {
   const [pis, setPis] = useState<string[]>([]);

--- a/controls/sae_2025_ws/integration/packages/web/src/FleetBoard.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/FleetBoard.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from "react";
+import { OrchestratorClient, type FleetBoardResult } from "@pennair/integration-core";
+
+const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
+const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+
+const REFRESH_INTERVAL_MS = 5000;
+
+function statusPill(ready: boolean, connected: boolean): string {
+  if (!connected) return "Offline";
+  return ready ? "Ready" : "Not ready";
+}
+
+export function FleetBoard({ onSelectHostname }: { onSelectHostname?: (hostname: string) => void }) {
+  const [board, setBoard] = useState<FleetBoardResult | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  // De-dupes overlapping polls (a slow fan-out could otherwise still be
+  // in flight when the next interval tick fires) and discards a stale
+  // response that resolves after a newer one already landed.
+  const requestIdRef = useRef(0);
+
+  async function refresh() {
+    const requestId = ++requestIdRef.current;
+    setRefreshing(true);
+    const result = await client.fleetBoard();
+    if (requestId === requestIdRef.current) {
+      setBoard(result);
+      setRefreshing(false);
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+    const interval = setInterval(refresh, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <section>
+      <h2>Fleet Board</h2>
+      <button onClick={refresh} disabled={refreshing}>
+        Refresh
+      </button>
+
+      {board?.error && <p className="error">{board.error}</p>}
+
+      {board?.summary && (
+        <p>
+          {board.summary.readyDevices} / {board.summary.totalDevices} ready ({board.summary.connectedDevices}{" "}
+          connected, {board.summary.runningDevices} running)
+        </p>
+      )}
+
+      <ul className="fleet-board-grid">
+        {board?.devices.map((device) => (
+          <li key={device.hostname} className="fleet-board-card">
+            <button onClick={() => onSelectHostname?.(device.hostname)}>{device.hostname}</button>
+            <span className={`pill ${device.ready ? "pill-ready" : "pill-not-ready"}`}>
+              {statusPill(device.ready, device.connected)}
+            </span>
+            <div>Runtime: {device.runtimeState}</div>
+            {device.buildInfo && <div>Build: {device.buildInfo}</div>}
+            {device.notes.length > 0 && (
+              <ul className="fleet-board-notes">
+                {device.notes.map((note) => (
+                  <li key={note}>{note}</li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {board && board.devices.length === 0 && !board.error && <p>No Pis discovered.</p>}
+    </section>
+  );
+}

--- a/controls/sae_2025_ws/integration/packages/web/src/FleetBoard.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/FleetBoard.tsx
@@ -14,18 +14,31 @@ function statusPill(ready: boolean, connected: boolean): string {
 export function FleetBoard({ onSelectHostname }: { onSelectHostname?: (hostname: string) => void }) {
   const [board, setBoard] = useState<FleetBoardResult | null>(null);
   const [refreshing, setRefreshing] = useState(false);
-  // De-dupes overlapping polls (a slow fan-out could otherwise still be
-  // in flight when the next interval tick fires) and discards a stale
-  // response that resolves after a newer one already landed.
+  // Discards a stale response that resolves after a newer one already
+  // landed (requestIdRef) -- but that alone doesn't stop overlapping
+  // network calls: a single stuck/degraded Pi can make one fan-out take up
+  // to ~21s (discovery + the 20s missionStatus timeout) against a 5s poll
+  // interval, so inFlightRef additionally skips starting a new poll while
+  // one is still running, rather than piling up several concurrent fetches
+  // (and full re-discoveries) all hammering the same struggling Pi.
   const requestIdRef = useRef(0);
+  const inFlightRef = useRef(false);
 
   async function refresh() {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
     const requestId = ++requestIdRef.current;
     setRefreshing(true);
-    const result = await client.fleetBoard();
-    if (requestId === requestIdRef.current) {
-      setBoard(result);
-      setRefreshing(false);
+    try {
+      const result = await client.fleetBoard();
+      if (requestId === requestIdRef.current) {
+        setBoard(result);
+      }
+    } finally {
+      inFlightRef.current = false;
+      if (requestId === requestIdRef.current) {
+        setRefreshing(false);
+      }
     }
   }
 

--- a/controls/sae_2025_ws/integration/packages/web/src/FleetBoard.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/FleetBoard.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { OrchestratorClient, type FleetBoardResult } from "@pennair/integration-core";
-
-const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
-const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+import type { FleetBoardResult } from "@pennair/integration-core";
+import { client } from "./orchestratorClient.js";
 
 const REFRESH_INTERVAL_MS = 5000;
 

--- a/controls/sae_2025_ws/integration/packages/web/src/FleetEditor.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/FleetEditor.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from "react";
+import {
+  OrchestratorClient,
+  normalizeFleetEditorDocument,
+  normalizeIntegrationFleetDocument,
+  parseFleetEditorDocument,
+  renderFleetEditorDocument,
+  schemaFieldInputKind,
+  uniqueFleetVehicleName,
+  writeFleetFieldValue,
+  type FleetEditorDocument,
+  type FleetSchema,
+  type FleetVehicle,
+  type MissionCatalogEntry,
+  type SchemaField,
+} from "@pennair/integration-core";
+import { SchemaValueInput } from "./SchemaValueInput.js";
+
+const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
+const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+
+function VehicleFieldInput({
+  field,
+  vehicle,
+  missions,
+  onChange,
+}: {
+  field: SchemaField;
+  vehicle: FleetVehicle;
+  missions: MissionCatalogEntry[];
+  onChange: (nextValue: unknown) => void;
+}) {
+  const value = vehicle[field.name];
+  // "mission" gets a dropdown of real, currently-installed mission names,
+  // instead of free text -- the same convenience the old dashboard's
+  // FleetFileEditor gave this one field specifically.
+  if (field.name === "mission") {
+    return (
+      <label>
+        {field.name}
+        <select value={typeof value === "string" ? value : ""} onChange={(e) => onChange(e.target.value)}>
+          <option value="">--</option>
+          {missions.map((mission) => (
+            <option key={mission.name} value={mission.name}>
+              {mission.name}
+            </option>
+          ))}
+        </select>
+      </label>
+    );
+  }
+  return (
+    <label>
+      {field.name}
+      <SchemaValueInput kind={schemaFieldInputKind(field)} choices={field.choices} value={value} onChange={onChange} />
+    </label>
+  );
+}
+
+export function FleetEditor({ hostname }: { hostname: string }) {
+  const [availableFleets, setAvailableFleets] = useState<string[]>([]);
+  const [selectedFleet, setSelectedFleet] = useState("");
+  const [doc, setDoc] = useState<FleetEditorDocument | null>(null);
+  const [fleetSchema, setFleetSchema] = useState<FleetSchema | null>(null);
+  const [missions, setMissions] = useState<MissionCatalogEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    if (!hostname) return;
+    client.schema(hostname).then((result) => {
+      if (result.success && result.schema) {
+        setAvailableFleets(result.schema.availableFleets);
+        setFleetSchema(result.schema.fleet);
+        setMissions(result.schema.missions);
+      }
+    });
+  }, [hostname]);
+
+  const missionTargetByName = Object.fromEntries(missions.map((mission) => [mission.name, mission.target]));
+
+  async function loadFleet(name: string) {
+    setSelectedFleet(name);
+    if (!name) {
+      setDoc(null);
+      return;
+    }
+    setLoading(true);
+    const result = await client.readFleetFile(hostname, name);
+    setLoading(false);
+    if (result.success && result.content !== undefined) {
+      const parsed = parseFleetEditorDocument(result.content);
+      setDoc(parsed.doc ? normalizeIntegrationFleetDocument(parsed.doc, missionTargetByName) : null);
+      setMessage(parsed.error || "");
+    } else {
+      setDoc(null);
+      setMessage(result.error ?? "Failed to load fleet file");
+    }
+  }
+
+  async function save() {
+    if (!doc || !selectedFleet) return;
+    setSaving(true);
+    const normalized = normalizeIntegrationFleetDocument(doc, missionTargetByName);
+    const result = await client.writeFleetFile(hostname, selectedFleet, renderFleetEditorDocument(normalized));
+    setSaving(false);
+    setMessage(result.error ?? "Saved");
+    if (!result.error) setDoc(normalized);
+  }
+
+  function updateVehicleField(index: number, field: SchemaField, nextValue: unknown) {
+    if (!doc) return;
+    setDoc(writeFleetFieldValue(doc, ["vehicles", index, field.name], field, nextValue));
+  }
+
+  function addVehicle() {
+    if (!doc) return;
+    const name = uniqueFleetVehicleName(doc);
+    setDoc(normalizeFleetEditorDocument({ ...doc, vehicles: [...doc.vehicles, { name }] }));
+  }
+
+  function removeVehicle(index: number) {
+    if (!doc) return;
+    setDoc(normalizeFleetEditorDocument({ ...doc, vehicles: doc.vehicles.filter((_, i) => i !== index) }));
+  }
+
+  const vehicleCommonFields = fleetSchema?.sections.find((section) => section.name === "vehicle.common")?.fields ?? [];
+  const vehicleHardwareFields = fleetSchema?.sections.find((section) => section.name === "vehicle.hardware")?.fields ?? [];
+
+  return (
+    <section>
+      <h2>Fleet Editor</h2>
+
+      <label>
+        Fleet file
+        <select value={selectedFleet} onChange={(e) => loadFleet(e.target.value)} disabled={!hostname}>
+          <option value="">-- select --</option>
+          {availableFleets.map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {loading && <p>Loading...</p>}
+
+      {doc && (
+        <>
+          <div>
+            <button onClick={addVehicle}>Add vehicle</button>
+          </div>
+
+          {doc.vehicles.map((vehicle, index) => {
+            const isUav = vehicle.kind === "uav";
+            const hardwareFields = isUav
+              ? vehicleHardwareFields
+              : vehicleHardwareFields.filter((field) => field.name !== "px4_airframe_id" && field.name !== "px4_namespace");
+            return (
+              <fieldset key={index} className="vehicle-fieldset">
+                <legend>{vehicle.name || `vehicle ${index}`}</legend>
+                <button onClick={() => removeVehicle(index)}>Remove</button>
+                {[...vehicleCommonFields, ...hardwareFields].map((field) => (
+                  <VehicleFieldInput
+                    key={field.name}
+                    field={field}
+                    vehicle={vehicle}
+                    missions={missions}
+                    onChange={(nextValue) => updateVehicleField(index, field, nextValue)}
+                  />
+                ))}
+              </fieldset>
+            );
+          })}
+
+          <div>
+            <button onClick={save} disabled={saving}>
+              Save
+            </button>
+          </div>
+        </>
+      )}
+
+      {message && <p>{message}</p>}
+    </section>
+  );
+}

--- a/controls/sae_2025_ws/integration/packages/web/src/FleetEditor.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/FleetEditor.tsx
@@ -10,7 +10,6 @@ import {
   writeFleetFieldValue,
   type FleetEditorDocument,
   type FleetSchema,
-  type FleetVehicle,
   type MissionCatalogEntry,
   type SchemaField,
 } from "@pennair/integration-core";
@@ -19,18 +18,17 @@ import { SchemaValueInput } from "./SchemaValueInput.js";
 const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
 const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
 
-function VehicleFieldInput({
+function FleetFieldInput({
   field,
-  vehicle,
+  value,
   missions,
   onChange,
 }: {
   field: SchemaField;
-  vehicle: FleetVehicle;
+  value: unknown;
   missions: MissionCatalogEntry[];
   onChange: (nextValue: unknown) => void;
 }) {
-  const value = vehicle[field.name];
   // "mission" gets a dropdown of real, currently-installed mission names,
   // instead of free text -- the same convenience the old dashboard's
   // FleetFileEditor gave this one field specifically.
@@ -66,6 +64,7 @@ export function FleetEditor({ hostname }: { hostname: string }) {
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState("");
+  const [savedYaml, setSavedYaml] = useState("");
 
   useEffect(() => {
     if (!hostname) return;
@@ -81,9 +80,13 @@ export function FleetEditor({ hostname }: { hostname: string }) {
   const missionTargetByName = Object.fromEntries(missions.map((mission) => [mission.name, mission.target]));
 
   async function loadFleet(name: string) {
+    if (doc && renderFleetEditorDocument(doc) !== savedYaml) {
+      if (!window.confirm("You have unsaved changes to this fleet file. Discard them?")) return;
+    }
     setSelectedFleet(name);
     if (!name) {
       setDoc(null);
+      setSavedYaml("");
       return;
     }
     setLoading(true);
@@ -91,10 +94,13 @@ export function FleetEditor({ hostname }: { hostname: string }) {
     setLoading(false);
     if (result.success && result.content !== undefined) {
       const parsed = parseFleetEditorDocument(result.content);
-      setDoc(parsed.doc ? normalizeIntegrationFleetDocument(parsed.doc, missionTargetByName) : null);
+      const normalized = parsed.doc ? normalizeIntegrationFleetDocument(parsed.doc, missionTargetByName) : null;
+      setDoc(normalized);
+      setSavedYaml(normalized ? renderFleetEditorDocument(normalized) : "");
       setMessage(parsed.error || "");
     } else {
       setDoc(null);
+      setSavedYaml("");
       setMessage(result.error ?? "Failed to load fleet file");
     }
   }
@@ -106,12 +112,25 @@ export function FleetEditor({ hostname }: { hostname: string }) {
     const result = await client.writeFleetFile(hostname, selectedFleet, renderFleetEditorDocument(normalized));
     setSaving(false);
     setMessage(result.error ?? "Saved");
-    if (!result.error) setDoc(normalized);
+    if (!result.error) {
+      setDoc(normalized);
+      setSavedYaml(renderFleetEditorDocument(normalized));
+    }
   }
 
   function updateVehicleField(index: number, field: SchemaField, nextValue: unknown) {
     if (!doc) return;
     setDoc(writeFleetFieldValue(doc, ["vehicles", index, field.name], field, nextValue));
+  }
+
+  function updateBackendField(field: SchemaField, nextValue: unknown) {
+    if (!doc) return;
+    setDoc(writeFleetFieldValue(doc, ["backend", field.name], field, nextValue));
+  }
+
+  function updateDefaultsField(field: SchemaField, nextValue: unknown) {
+    if (!doc) return;
+    setDoc(writeFleetFieldValue(doc, ["defaults", field.name], field, nextValue));
   }
 
   function addVehicle() {
@@ -125,6 +144,8 @@ export function FleetEditor({ hostname }: { hostname: string }) {
     setDoc(normalizeFleetEditorDocument({ ...doc, vehicles: doc.vehicles.filter((_, i) => i !== index) }));
   }
 
+  const backendFields = fleetSchema?.sections.find((section) => section.name === "backend")?.fields ?? [];
+  const defaultsFields = fleetSchema?.sections.find((section) => section.name === "defaults")?.fields ?? [];
   const vehicleCommonFields = fleetSchema?.sections.find((section) => section.name === "vehicle.common")?.fields ?? [];
   const vehicleHardwareFields = fleetSchema?.sections.find((section) => section.name === "vehicle.hardware")?.fields ?? [];
 
@@ -148,6 +169,36 @@ export function FleetEditor({ hostname }: { hostname: string }) {
 
       {doc && (
         <>
+          {backendFields.length > 0 && (
+            <fieldset className="backend-fieldset">
+              <legend>Backend</legend>
+              {backendFields.map((field) => (
+                <FleetFieldInput
+                  key={field.name}
+                  field={field}
+                  value={doc.backend[field.name]}
+                  missions={missions}
+                  onChange={(nextValue) => updateBackendField(field, nextValue)}
+                />
+              ))}
+            </fieldset>
+          )}
+
+          {defaultsFields.length > 0 && (
+            <fieldset className="defaults-fieldset">
+              <legend>Defaults</legend>
+              {defaultsFields.map((field) => (
+                <FleetFieldInput
+                  key={field.name}
+                  field={field}
+                  value={doc.defaults[field.name]}
+                  missions={missions}
+                  onChange={(nextValue) => updateDefaultsField(field, nextValue)}
+                />
+              ))}
+            </fieldset>
+          )}
+
           <div>
             <button onClick={addVehicle}>Add vehicle</button>
           </div>
@@ -162,10 +213,10 @@ export function FleetEditor({ hostname }: { hostname: string }) {
                 <legend>{vehicle.name || `vehicle ${index}`}</legend>
                 <button onClick={() => removeVehicle(index)}>Remove</button>
                 {[...vehicleCommonFields, ...hardwareFields].map((field) => (
-                  <VehicleFieldInput
+                  <FleetFieldInput
                     key={field.name}
                     field={field}
-                    vehicle={vehicle}
+                    value={vehicle[field.name]}
                     missions={missions}
                     onChange={(nextValue) => updateVehicleField(index, field, nextValue)}
                   />

--- a/controls/sae_2025_ws/integration/packages/web/src/FleetEditor.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/FleetEditor.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import {
-  OrchestratorClient,
   normalizeFleetEditorDocument,
   normalizeIntegrationFleetDocument,
   parseFleetEditorDocument,
@@ -14,9 +13,7 @@ import {
   type SchemaField,
 } from "@pennair/integration-core";
 import { SchemaValueInput } from "./SchemaValueInput.js";
-
-const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
-const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+import { client } from "./orchestratorClient.js";
 
 function FleetFieldInput({
   field,

--- a/controls/sae_2025_ws/integration/packages/web/src/MissionCard.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/MissionCard.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { OrchestratorClient, type LaunchStatus } from "@pennair/integration-core";
-
-const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
-const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+import type { LaunchStatus } from "@pennair/integration-core";
+import { client } from "./orchestratorClient.js";
 
 export function MissionCard({ hostname }: { hostname: string }) {
   const [vehicleName, setVehicleName] = useState("");

--- a/controls/sae_2025_ws/integration/packages/web/src/MissionCard.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/MissionCard.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from "react";
+import { OrchestratorClient, type LaunchStatus } from "@pennair/integration-core";
+
+const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
+const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+
+export function MissionCard({ hostname }: { hostname: string }) {
+  const [vehicleName, setVehicleName] = useState("");
+  const [status, setStatus] = useState<LaunchStatus | null>(null);
+  const [message, setMessage] = useState("");
+  const [logs, setLogs] = useState("");
+  const [streaming, setStreaming] = useState(false);
+  const socketRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    return () => {
+      socketRef.current?.close();
+    };
+  }, []);
+
+  async function refreshStatus() {
+    if (!hostname) return;
+    setStatus(await client.missionStatus(hostname));
+  }
+
+  async function prepare() {
+    if (!hostname) return;
+    const result = await client.prepareMission(hostname);
+    setMessage(result.error ?? result.output ?? "");
+    await refreshStatus();
+  }
+
+  async function stop() {
+    if (!hostname) return;
+    const result = await client.stopMission(hostname);
+    setMessage(result.error ?? result.output ?? "");
+    await refreshStatus();
+  }
+
+  async function startMission() {
+    if (!vehicleName) return;
+    const result = await client.startMission(vehicleName);
+    setMessage(result.error ?? result.output ?? "");
+  }
+
+  async function failsafe() {
+    if (!vehicleName) return;
+    const result = await client.triggerFailsafe(vehicleName);
+    setMessage(result.error ?? result.output ?? "");
+  }
+
+  function toggleLogStream() {
+    if (socketRef.current) {
+      socketRef.current.close();
+      socketRef.current = null;
+      setStreaming(false);
+      return;
+    }
+    if (!hostname) return;
+    const socket = new WebSocket(client.missionLogsUrl(hostname));
+    socket.onmessage = (event) => setLogs((prev) => `${prev}${event.data}`);
+    socket.onerror = () => setMessage("Log stream error");
+    socket.onclose = () => setStreaming(false);
+    socketRef.current = socket;
+    setStreaming(true);
+  }
+
+  return (
+    <section>
+      <h2>Mission</h2>
+
+      <div>
+        <button onClick={refreshStatus} disabled={!hostname}>
+          Refresh status
+        </button>
+        <button onClick={prepare} disabled={!hostname}>
+          Prepare (start process)
+        </button>
+        <button onClick={stop} disabled={!hostname}>
+          Stop (stop process)
+        </button>
+        <button onClick={toggleLogStream} disabled={!hostname}>
+          {streaming ? "Stop log stream" : "Stream logs"}
+        </button>
+      </div>
+
+      {status && (
+        <dl>
+          <dt>State</dt>
+          <dd>{status.state}</dd>
+          <dt>Running</dt>
+          <dd>{String(status.running)}</dd>
+          {status.pid && (
+            <>
+              <dt>PID</dt>
+              <dd>{status.pid}</dd>
+            </>
+          )}
+          {status.error && (
+            <>
+              <dt>Error</dt>
+              <dd>{status.error}</dd>
+            </>
+          )}
+        </dl>
+      )}
+
+      <div>
+        <input
+          placeholder="Vehicle name (e.g. air-01)"
+          value={vehicleName}
+          onChange={(e) => setVehicleName(e.target.value)}
+        />
+        <button onClick={startMission} disabled={!vehicleName}>
+          Start mission
+        </button>
+        <button onClick={failsafe} disabled={!vehicleName}>
+          Failsafe
+        </button>
+      </div>
+
+      {message && <p>{message}</p>}
+      {logs && <pre>{logs}</pre>}
+    </section>
+  );
+}

--- a/controls/sae_2025_ws/integration/packages/web/src/MissionEditor.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/MissionEditor.tsx
@@ -58,6 +58,8 @@ export function MissionEditor({ hostname }: { hostname: string }) {
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState("");
+  const [modeNameError, setModeNameError] = useState("");
+  const [savedRawText, setSavedRawText] = useState("");
 
   useEffect(() => {
     if (!hostname) return;
@@ -68,10 +70,15 @@ export function MissionEditor({ hostname }: { hostname: string }) {
   }, [hostname]);
 
   async function loadMission(name: string) {
+    if (doc && doc.rawText !== savedRawText) {
+      if (!window.confirm("You have unsaved changes to this mission. Discard them?")) return;
+    }
     setSelectedMission(name);
     setSelectedModeName("");
+    setModeNameError("");
     if (!name) {
       setDoc(null);
+      setSavedRawText("");
       return;
     }
     setLoading(true);
@@ -79,9 +86,11 @@ export function MissionEditor({ hostname }: { hostname: string }) {
     setLoading(false);
     if (result.success && result.content !== undefined) {
       setDoc(parseMissionDocument(result.content));
+      setSavedRawText(result.content);
       setMessage("");
     } else {
       setDoc(null);
+      setSavedRawText("");
       setMessage(result.error ?? "Failed to load mission");
     }
   }
@@ -92,6 +101,7 @@ export function MissionEditor({ hostname }: { hostname: string }) {
     const result = await client.writeMissionFile(hostname, selectedMission, doc.rawText);
     setSaving(false);
     setMessage(result.error ?? "Saved");
+    if (!result.error) setSavedRawText(doc.rawText);
   }
 
   function updateMode(modeName: string, updater: (mode: MissionMode) => MissionMode) {
@@ -128,6 +138,30 @@ export function MissionEditor({ hostname }: { hostname: string }) {
   function applyModeDefaults(mode: MissionMode, metadata: ModeMetadata | undefined) {
     if (!metadata) return;
     updateMode(mode.name, (m) => ({ ...m, paramsRaw: defaultParamsRawForMode(metadata) }));
+  }
+
+  /**
+   * updateMissionDocumentMode matches *every* mode with the given name, so
+   * renaming into a name that collides with another mode (or into the
+   * reserved "start" entrypoint name) would silently merge two modes into
+   * one on the next edit, and removeMode's filter would then remove both at
+   * once -- reject the rename instead of applying it.
+   */
+  function renameSelectedMode(currentName: string, nextName: string) {
+    if (!doc) return;
+    if (nextName !== currentName) {
+      if (nextName === RESERVED_MODE_NAME) {
+        setModeNameError(`"${RESERVED_MODE_NAME}" is reserved for the mission entrypoint`);
+        return;
+      }
+      if (doc.modes.some((mode) => mode.name === nextName)) {
+        setModeNameError(`A mode named "${nextName}" already exists`);
+        return;
+      }
+    }
+    setModeNameError("");
+    updateMode(currentName, (mode) => ({ ...mode, name: nextName }));
+    setSelectedModeName(nextName);
   }
 
   const selectedMode = doc?.modes.find((mode) => mode.name === selectedModeName) ?? null;
@@ -167,7 +201,14 @@ export function MissionEditor({ hostname }: { hostname: string }) {
           <ul className="mode-list">
             {doc.modes.map((mode) => (
               <li key={mode.name}>
-                <button onClick={() => setSelectedModeName(mode.name)}>{mode.name === selectedModeName ? `> ${mode.name}` : mode.name}</button>
+                <button
+                  onClick={() => {
+                    setSelectedModeName(mode.name);
+                    setModeNameError("");
+                  }}
+                >
+                  {mode.name === selectedModeName ? `> ${mode.name}` : mode.name}
+                </button>
                 <button onClick={() => removeMode(mode.name)} disabled={mode.name === RESERVED_MODE_NAME}>
                   Remove
                 </button>
@@ -182,13 +223,10 @@ export function MissionEditor({ hostname }: { hostname: string }) {
                 <input
                   value={selectedMode.name}
                   disabled={selectedMode.name === RESERVED_MODE_NAME}
-                  onChange={(e) => {
-                    const newName = e.target.value;
-                    updateMode(selectedMode.name, (mode) => ({ ...mode, name: newName }));
-                    setSelectedModeName(newName);
-                  }}
+                  onChange={(e) => renameSelectedMode(selectedMode.name, e.target.value)}
                 />
               </label>
+              {modeNameError && <p className="error">{modeNameError}</p>}
               <label>
                 Mode class
                 <input

--- a/controls/sae_2025_ws/integration/packages/web/src/MissionEditor.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/MissionEditor.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import {
-  OrchestratorClient,
   defaultParamsRawForMode,
   effectiveSchemaFieldValue,
   fieldHelpText,
@@ -18,9 +17,7 @@ import {
   type SchemaField,
 } from "@pennair/integration-core";
 import { SchemaValueInput } from "./SchemaValueInput.js";
-
-const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
-const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+import { client } from "./orchestratorClient.js";
 
 /** "start" is the mission entrypoint mode name by convention (mirrors the old dashboard's reserved-name rule) -- renaming or removing it would break the mission. */
 const RESERVED_MODE_NAME = "start";

--- a/controls/sae_2025_ws/integration/packages/web/src/MissionEditor.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/MissionEditor.tsx
@@ -1,0 +1,274 @@
+import { useEffect, useState } from "react";
+import {
+  OrchestratorClient,
+  defaultParamsRawForMode,
+  effectiveSchemaFieldValue,
+  fieldHelpText,
+  normalizeModeRegistry,
+  parseMissionDocument,
+  renderMissionDocument,
+  schemaFieldInputKind,
+  uniqueModeName,
+  updateMissionDocumentMode,
+  writeSchemaFieldValue,
+  type ModeMetadata,
+  type ModeRegistryByTarget,
+  type MissionMode,
+  type ParsedMissionDocument,
+  type SchemaField,
+} from "@pennair/integration-core";
+import { SchemaValueInput } from "./SchemaValueInput.js";
+
+const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
+const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+
+/** "start" is the mission entrypoint mode name by convention (mirrors the old dashboard's reserved-name rule) -- renaming or removing it would break the mission. */
+const RESERVED_MODE_NAME = "start";
+
+function ParamField({
+  field,
+  paramsRaw,
+  onChange,
+}: {
+  field: SchemaField;
+  paramsRaw: string;
+  onChange: (nextRaw: string) => void;
+}) {
+  const kind = schemaFieldInputKind(field);
+  const value = effectiveSchemaFieldValue(paramsRaw, field);
+  const help = fieldHelpText(field);
+
+  return (
+    <div className="param-field">
+      <label>
+        {field.name}
+        <SchemaValueInput kind={kind} choices={field.choices} value={value} onChange={(next) => onChange(writeSchemaFieldValue(paramsRaw, field, next))} />
+      </label>
+      {help && <p className="help">{help}</p>}
+    </div>
+  );
+}
+
+export function MissionEditor({ hostname }: { hostname: string }) {
+  const [missionNames, setMissionNames] = useState<string[]>([]);
+  const [selectedMission, setSelectedMission] = useState("");
+  const [doc, setDoc] = useState<ParsedMissionDocument | null>(null);
+  const [selectedModeName, setSelectedModeName] = useState("");
+  const [modeRegistry, setModeRegistry] = useState<ModeRegistryByTarget>({});
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    if (!hostname) return;
+    client.missionNames(hostname).then((result) => setMissionNames(result.missions));
+    client.schema(hostname).then((result) => {
+      if (result.success && result.schema) setModeRegistry(result.schema.modes);
+    });
+  }, [hostname]);
+
+  async function loadMission(name: string) {
+    setSelectedMission(name);
+    setSelectedModeName("");
+    if (!name) {
+      setDoc(null);
+      return;
+    }
+    setLoading(true);
+    const result = await client.readMissionFile(hostname, name);
+    setLoading(false);
+    if (result.success && result.content !== undefined) {
+      setDoc(parseMissionDocument(result.content));
+      setMessage("");
+    } else {
+      setDoc(null);
+      setMessage(result.error ?? "Failed to load mission");
+    }
+  }
+
+  async function save() {
+    if (!doc || !selectedMission) return;
+    setSaving(true);
+    const result = await client.writeMissionFile(hostname, selectedMission, doc.rawText);
+    setSaving(false);
+    setMessage(result.error ?? "Saved");
+  }
+
+  function updateMode(modeName: string, updater: (mode: MissionMode) => MissionMode) {
+    setDoc((prev) => (prev ? updateMissionDocumentMode(prev, modeName, updater) : prev));
+  }
+
+  function addMode() {
+    if (!doc) return;
+    const name = uniqueModeName(doc);
+    const newMode: MissionMode = {
+      name,
+      mode: "",
+      paramsRaw: "",
+      transitionsRaw: "",
+      transitions: [],
+      target: "",
+      hasParams: true,
+      hasTransitions: true,
+    };
+    const next: ParsedMissionDocument = { ...doc, modes: [...doc.modes, newMode] };
+    next.rawText = renderMissionDocument(next);
+    setDoc(next);
+    setSelectedModeName(name);
+  }
+
+  function removeMode(modeName: string) {
+    if (!doc || modeName === RESERVED_MODE_NAME) return;
+    const next: ParsedMissionDocument = { ...doc, modes: doc.modes.filter((mode) => mode.name !== modeName) };
+    next.rawText = renderMissionDocument(next);
+    setDoc(next);
+    if (selectedModeName === modeName) setSelectedModeName("");
+  }
+
+  function applyModeDefaults(mode: MissionMode, metadata: ModeMetadata | undefined) {
+    if (!metadata) return;
+    updateMode(mode.name, (m) => ({ ...m, paramsRaw: defaultParamsRawForMode(metadata) }));
+  }
+
+  const selectedMode = doc?.modes.find((mode) => mode.name === selectedModeName) ?? null;
+  const flatRegistry = normalizeModeRegistry(modeRegistry);
+  const modeMetadata = selectedMode ? flatRegistry[selectedMode.mode] : undefined;
+
+  return (
+    <section>
+      <h2>Mission Editor</h2>
+
+      <label>
+        Mission
+        <select value={selectedMission} onChange={(e) => loadMission(e.target.value)} disabled={!hostname}>
+          <option value="">-- select --</option>
+          {missionNames.map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {loading && <p>Loading...</p>}
+
+      {doc && (
+        <>
+          {doc.warnings.map((warning) => (
+            <p key={warning} className="warning">
+              {warning}
+            </p>
+          ))}
+
+          <div>
+            <button onClick={addMode}>Add mode</button>
+          </div>
+
+          <ul className="mode-list">
+            {doc.modes.map((mode) => (
+              <li key={mode.name}>
+                <button onClick={() => setSelectedModeName(mode.name)}>{mode.name === selectedModeName ? `> ${mode.name}` : mode.name}</button>
+                <button onClick={() => removeMode(mode.name)} disabled={mode.name === RESERVED_MODE_NAME}>
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          {selectedMode && (
+            <div className="mode-editor">
+              <label>
+                Name
+                <input
+                  value={selectedMode.name}
+                  disabled={selectedMode.name === RESERVED_MODE_NAME}
+                  onChange={(e) => {
+                    const newName = e.target.value;
+                    updateMode(selectedMode.name, (mode) => ({ ...mode, name: newName }));
+                    setSelectedModeName(newName);
+                  }}
+                />
+              </label>
+              <label>
+                Mode class
+                <input
+                  value={selectedMode.mode}
+                  onChange={(e) => updateMode(selectedMode.name, (mode) => ({ ...mode, mode: e.target.value }))}
+                />
+              </label>
+
+              <h3>Params</h3>
+              {modeMetadata && (
+                <button onClick={() => applyModeDefaults(selectedMode, modeMetadata)}>Reset to defaults</button>
+              )}
+              {modeMetadata?.params?.length ? (
+                modeMetadata.params.map((field) => (
+                  <ParamField
+                    key={field.name}
+                    field={field}
+                    paramsRaw={selectedMode.paramsRaw}
+                    onChange={(nextRaw) => updateMode(selectedMode.name, (mode) => ({ ...mode, paramsRaw: nextRaw }))}
+                  />
+                ))
+              ) : (
+                <textarea
+                  value={selectedMode.paramsRaw}
+                  rows={6}
+                  onChange={(e) => updateMode(selectedMode.name, (mode) => ({ ...mode, paramsRaw: e.target.value }))}
+                />
+              )}
+
+              <h3>Transitions</h3>
+              {selectedMode.transitions.map((transition, index) => (
+                <div key={index} className="transition-row">
+                  <input
+                    placeholder="on"
+                    value={transition.key}
+                    onChange={(e) => {
+                      const next = [...selectedMode.transitions];
+                      next[index] = { ...next[index], key: e.target.value };
+                      updateMode(selectedMode.name, (mode) => ({ ...mode, transitions: next }));
+                    }}
+                  />
+                  <input
+                    placeholder="target mode"
+                    value={transition.value}
+                    onChange={(e) => {
+                      const next = [...selectedMode.transitions];
+                      next[index] = { ...next[index], value: e.target.value };
+                      updateMode(selectedMode.name, (mode) => ({ ...mode, transitions: next }));
+                    }}
+                  />
+                  <button
+                    onClick={() => {
+                      const next = selectedMode.transitions.filter((_, i) => i !== index);
+                      updateMode(selectedMode.name, (mode) => ({ ...mode, transitions: next, hasTransitions: true }));
+                    }}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              <button
+                onClick={() => {
+                  const next = [...selectedMode.transitions, { key: "", value: "" }];
+                  updateMode(selectedMode.name, (mode) => ({ ...mode, transitions: next, hasTransitions: true }));
+                }}
+              >
+                Add transition
+              </button>
+            </div>
+          )}
+
+          <div>
+            <button onClick={save} disabled={saving}>
+              Save
+            </button>
+          </div>
+        </>
+      )}
+
+      {message && <p>{message}</p>}
+    </section>
+  );
+}

--- a/controls/sae_2025_ws/integration/packages/web/src/SchemaValueInput.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/SchemaValueInput.tsx
@@ -1,0 +1,51 @@
+import type { SchemaFieldInputKind } from "@pennair/integration-core";
+
+/** Renders the right HTML input for a schema field's input kind -- shared by the mission param editor and the fleet vehicle field editor, which each have their own get/set logic around it (raw YAML text vs. a parsed doc). */
+export function SchemaValueInput({
+  kind,
+  choices,
+  value,
+  onChange,
+}: {
+  kind: SchemaFieldInputKind;
+  choices?: string[];
+  value: unknown;
+  onChange: (next: unknown) => void;
+}) {
+  if (kind === "select") {
+    return (
+      <select value={value === undefined || value === null ? "" : String(value)} onChange={(e) => onChange(e.target.value)}>
+        <option value="">--</option>
+        {(choices ?? []).map((choice) => (
+          <option key={choice} value={choice}>
+            {choice}
+          </option>
+        ))}
+      </select>
+    );
+  }
+  if (kind === "boolean") {
+    return <input type="checkbox" checked={Boolean(value)} onChange={(e) => onChange(e.target.checked)} />;
+  }
+  if (kind === "number") {
+    return (
+      <input
+        type="number"
+        value={value === undefined || value === null ? "" : String(value)}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  }
+  if (kind === "tuple") {
+    const arr = Array.isArray(value) ? value : [];
+    return (
+      <input
+        value={arr.join(", ")}
+        placeholder="x, y, z"
+        onChange={(e) => onChange(e.target.value.split(",").map((part) => Number(part.trim())))}
+      />
+    );
+  }
+  const text = typeof value === "string" ? value : value === undefined || value === null ? "" : JSON.stringify(value);
+  return <textarea value={text} rows={kind === "block" ? 4 : 1} onChange={(e) => onChange(e.target.value)} />;
+}

--- a/controls/sae_2025_ws/integration/packages/web/src/WifiCard.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/WifiCard.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from "react";
+import { OrchestratorClient, type WifiNetwork, type WifiStatus } from "@pennair/integration-core";
+
+const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
+const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+
+export function WifiCard() {
+  const [pis, setPis] = useState<string[]>([]);
+  const [hostname, setHostname] = useState("");
+  const [status, setStatus] = useState<WifiStatus | null>(null);
+  const [networks, setNetworks] = useState<WifiNetwork[]>([]);
+  const [ssid, setSsid] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    client.discoverPis().then((discovered) => {
+      const hostnames = discovered.map((pi) => pi.hostname);
+      setPis(hostnames);
+      if (hostnames.length > 0 && !hostname) {
+        setHostname(hostnames[0]);
+      }
+    });
+    // Intentionally run once on mount; discovery is re-triggered by the button below.
+  }, []);
+
+  async function refreshDiscovery() {
+    setPis((await client.discoverPis()).map((pi) => pi.hostname));
+  }
+
+  async function refreshStatus() {
+    if (!hostname) return;
+    setBusy(true);
+    setStatus(await client.wifiStatus(hostname));
+    setBusy(false);
+  }
+
+  async function scan() {
+    if (!hostname) return;
+    setBusy(true);
+    const result = await client.wifiScan(hostname);
+    setNetworks(result.networks);
+    setMessage(result.error ?? "");
+    setBusy(false);
+  }
+
+  async function connect() {
+    if (!hostname || !ssid) return;
+    setBusy(true);
+    const result = await client.wifiConnect(hostname, ssid, password);
+    setMessage(result.error ?? result.output ?? "");
+    setBusy(false);
+    await refreshStatus();
+  }
+
+  async function activateHotspot() {
+    if (!hostname) return;
+    setBusy(true);
+    const result = await client.wifiHotspot(hostname);
+    setMessage(result.error ?? result.output ?? "");
+    setBusy(false);
+    await refreshStatus();
+  }
+
+  return (
+    <section>
+      <h2>Wifi</h2>
+
+      <label>
+        Pi hostname
+        <input
+          list="discovered-pis"
+          value={hostname}
+          onChange={(e) => setHostname(e.target.value)}
+          placeholder="air-01.local"
+        />
+        <datalist id="discovered-pis">
+          {pis.map((h) => (
+            <option key={h} value={h} />
+          ))}
+        </datalist>
+      </label>
+      <button onClick={refreshDiscovery} disabled={busy}>
+        Rediscover
+      </button>
+
+      <div>
+        <button onClick={refreshStatus} disabled={busy || !hostname}>
+          Refresh status
+        </button>
+        <button onClick={scan} disabled={busy || !hostname}>
+          Scan networks
+        </button>
+        <button onClick={activateHotspot} disabled={busy || !hostname}>
+          Activate hotspot
+        </button>
+      </div>
+
+      {status && (
+        <dl>
+          <dt>Success</dt>
+          <dd>{String(status.success)}</dd>
+          <dt>Current wifi</dt>
+          <dd>{status.currentWifi ?? "(none)"}</dd>
+          <dt>Is hotspot</dt>
+          <dd>{String(status.isHotspot ?? false)}</dd>
+          {status.error && (
+            <>
+              <dt>Error</dt>
+              <dd>{status.error}</dd>
+            </>
+          )}
+        </dl>
+      )}
+
+      {networks.length > 0 && (
+        <ul>
+          {networks.map((n) => (
+            <li key={n.ssid}>
+              {n.ssid} ({n.signal}%, {n.security || "open"})
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div>
+        <input placeholder="SSID" value={ssid} onChange={(e) => setSsid(e.target.value)} />
+        <input
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button onClick={connect} disabled={busy || !hostname || !ssid}>
+          Connect
+        </button>
+      </div>
+
+      {message && <p>{message}</p>}
+    </section>
+  );
+}

--- a/controls/sae_2025_ws/integration/packages/web/src/WifiCard.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/WifiCard.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
-import { OrchestratorClient, type WifiNetwork, type WifiStatus } from "@pennair/integration-core";
-
-const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
-const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
+import type { WifiNetwork, WifiStatus } from "@pennair/integration-core";
+import { client } from "./orchestratorClient.js";
 
 export function WifiCard({ hostname }: { hostname: string }) {
   const [status, setStatus] = useState<WifiStatus | null>(null);

--- a/controls/sae_2025_ws/integration/packages/web/src/WifiCard.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/WifiCard.tsx
@@ -1,33 +1,16 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { OrchestratorClient, type WifiNetwork, type WifiStatus } from "@pennair/integration-core";
 
 const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
 const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });
 
-export function WifiCard() {
-  const [pis, setPis] = useState<string[]>([]);
-  const [hostname, setHostname] = useState("");
+export function WifiCard({ hostname }: { hostname: string }) {
   const [status, setStatus] = useState<WifiStatus | null>(null);
   const [networks, setNetworks] = useState<WifiNetwork[]>([]);
   const [ssid, setSsid] = useState("");
   const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState("");
-
-  useEffect(() => {
-    client.discoverPis().then((discovered) => {
-      const hostnames = discovered.map((pi) => pi.hostname);
-      setPis(hostnames);
-      if (hostnames.length > 0 && !hostname) {
-        setHostname(hostnames[0]);
-      }
-    });
-    // Intentionally run once on mount; discovery is re-triggered by the button below.
-  }, []);
-
-  async function refreshDiscovery() {
-    setPis((await client.discoverPis()).map((pi) => pi.hostname));
-  }
 
   async function refreshStatus() {
     if (!hostname) return;
@@ -66,24 +49,6 @@ export function WifiCard() {
   return (
     <section>
       <h2>Wifi</h2>
-
-      <label>
-        Pi hostname
-        <input
-          list="discovered-pis"
-          value={hostname}
-          onChange={(e) => setHostname(e.target.value)}
-          placeholder="air-01.local"
-        />
-        <datalist id="discovered-pis">
-          {pis.map((h) => (
-            <option key={h} value={h} />
-          ))}
-        </datalist>
-      </label>
-      <button onClick={refreshDiscovery} disabled={busy}>
-        Rediscover
-      </button>
 
       <div>
         <button onClick={refreshStatus} disabled={busy || !hostname}>

--- a/controls/sae_2025_ws/integration/packages/web/src/WifiCard.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/WifiCard.tsx
@@ -105,6 +105,12 @@ export function WifiCard() {
           <dd>{status.currentWifi ?? "(none)"}</dd>
           <dt>Is hotspot</dt>
           <dd>{String(status.isHotspot ?? false)}</dd>
+          <dt>Effective role</dt>
+          <dd>{status.effectiveRole ?? "(unknown)"}</dd>
+          <dt>Travel router locked</dt>
+          <dd>{String(status.travelRouterLocked ?? false)}</dd>
+          <dt>Allowed AP hosts</dt>
+          <dd>{status.allowedApHosts?.join(", ") || "(none)"}</dd>
           {status.error && (
             <>
               <dt>Error</dt>

--- a/controls/sae_2025_ws/integration/packages/web/src/main.tsx
+++ b/controls/sae_2025_ws/integration/packages/web/src/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+
+const container = document.getElementById("root");
+if (!container) {
+  throw new Error("Missing #root element");
+}
+
+createRoot(container).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/controls/sae_2025_ws/integration/packages/web/src/orchestratorClient.ts
+++ b/controls/sae_2025_ws/integration/packages/web/src/orchestratorClient.ts
@@ -1,0 +1,5 @@
+import { OrchestratorClient } from "@pennair/integration-core";
+
+const ORCHESTRATOR_URL = import.meta.env.VITE_ORCHESTRATOR_URL ?? "http://localhost:8080";
+
+export const client = new OrchestratorClient({ baseUrl: ORCHESTRATOR_URL });

--- a/controls/sae_2025_ws/integration/packages/web/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/web/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
+    "types": ["vite/client"],
     "noEmit": true,
     "composite": false
   },

--- a/controls/sae_2025_ws/integration/packages/web/tsconfig.json
+++ b/controls/sae_2025_ws/integration/packages/web/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "composite": false
+  },
+  "include": ["src"]
+}

--- a/controls/sae_2025_ws/integration/packages/web/vite.config.ts
+++ b/controls/sae_2025_ws/integration/packages/web/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});

--- a/controls/sae_2025_ws/integration/tools/schema-export/schema_export.py
+++ b/controls/sae_2025_ws/integration/tools/schema-export/schema_export.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Dump the live mode registry from vehicle_common as JSON.
+
+Not a server -- invoked on demand (e.g. `python3 schema_export.py > schema.json`)
+whenever the TypeScript apps need an up to date copy of the mission-mode schema
+that drives the mission-graph/fleet editors. Requires a sourced ROS2 + colcon
+environment where `vehicle_common` (and the `uav`/`payload` packages whose
+modes it discovers) are importable.
+
+Uses `vehicle_common.mode_loader.ModeRegistry.get()`, which does live
+introspection of `@register_mode`-decorated classes -- not a static
+`mode_registry.json` file. That file is referenced by the (now-deleted) old
+integration backend, but the build step that would generate it is disabled
+(see the commented-out `BuildUAVModeRegistry` step in `uav/setup.py`), and no
+such file exists anywhere in this repo. Calling `ModeRegistry.get()` directly
+is the mechanism that actually works today.
+
+Phase 0 scope: dumps the raw mode registry only. Fleet/mission document JSON
+schema (from `vehicle_common.runtime.fleet_spec`/`mission_spec`) and the
+richer per-field shaping the old `schema.py` did (choices, defaults,
+descriptions) lands in Phase 4, once the mission/fleet YAML editors are
+actually being ported.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    try:
+        from vehicle_common.mode_loader import ModeRegistry
+    except ImportError as exc:
+        print(
+            f"Could not import vehicle_common.mode_loader: {exc}\n"
+            "Run this from a sourced ROS2 + colcon environment where "
+            "vehicle_common is built and on PYTHONPATH.",
+            file=sys.stderr,
+        )
+        return 1
+
+    registry = ModeRegistry.get()
+    print(json.dumps(json.loads(registry.model_dump_json()), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/controls/sae_2025_ws/integration/tools/schema-export/schema_export.py
+++ b/controls/sae_2025_ws/integration/tools/schema-export/schema_export.py
@@ -98,6 +98,15 @@ def _schema_field(
                 schema_type = "enum"
                 annotation = "enum"
                 choices = list(variant["enum"])
+            elif "prefixItems" in variant:
+                # An Optional[tuple[...]] field (e.g. FleetDefaultsModel's
+                # camera_mount_offsets: tuple[float, float, float] | None)
+                # wraps the tuple schema inside anyOf alongside {type: null}
+                # -- prefixItems only ever appears on the top-level schema
+                # for a non-Optional tuple, so without this check every
+                # Optional tuple field is misclassified as a plain "list".
+                schema_type = "tuple"
+                annotation = "tuple"
             elif "$ref" in variant:
                 annotation = variant["$ref"].rsplit("/", 1)[-1]
             else:

--- a/controls/sae_2025_ws/integration/tools/schema-export/schema_export.py
+++ b/controls/sae_2025_ws/integration/tools/schema-export/schema_export.py
@@ -24,7 +24,6 @@ actually being ported.
 
 from __future__ import annotations
 
-import json
 import sys
 
 
@@ -41,7 +40,7 @@ def main() -> int:
         return 1
 
     registry = ModeRegistry.get()
-    print(json.dumps(json.loads(registry.model_dump_json()), indent=2))
+    print(registry.model_dump_json(indent=2))
     return 0
 
 

--- a/controls/sae_2025_ws/integration/tools/schema-export/schema_export.py
+++ b/controls/sae_2025_ws/integration/tools/schema-export/schema_export.py
@@ -1,35 +1,282 @@
 #!/usr/bin/env python3
-"""Dump the live mode registry from vehicle_common as JSON.
+"""Dump mode/fleet/mission schema data as JSON, for the mission and fleet
+YAML editors in the TypeScript dashboard.
 
-Not a server -- invoked on demand (e.g. `python3 schema_export.py > schema.json`)
-whenever the TypeScript apps need an up to date copy of the mission-mode schema
-that drives the mission-graph/fleet editors. Requires a sourced ROS2 + colcon
-environment where `vehicle_common` (and the `uav`/`payload` packages whose
-modes it discovers) are importable.
+Not a server -- invoked on demand by pi-agent (which sources the deployed
+release's ROS2 environment first), e.g.:
 
-Uses `vehicle_common.mode_loader.ModeRegistry.get()`, which does live
-introspection of `@register_mode`-decorated classes -- not a static
-`mode_registry.json` file. That file is referenced by the (now-deleted) old
-integration backend, but the build step that would generate it is disabled
-(see the commented-out `BuildUAVModeRegistry` step in `uav/setup.py`), and no
-such file exists anywhere in this repo. Calling `ModeRegistry.get()` directly
-is the mechanism that actually works today.
+    source /opt/ros/jazzy/setup.bash
+    source <deploy_root>/current/install/setup.bash
+    python3 schema_export.py --root <deploy_root>/current
 
-Phase 0 scope: dumps the raw mode registry only. Fleet/mission document JSON
-schema (from `vehicle_common.runtime.fleet_spec`/`mission_spec`) and the
-richer per-field shaping the old `schema.py` did (choices, defaults,
-descriptions) lands in Phase 4, once the mission/fleet YAML editors are
-actually being ported.
+Requires a sourced ROS2 + colcon environment where `vehicle_common` (and the
+`uav`/`payload` packages whose modes it discovers) are importable.
+
+Ported from the old (deleted) integration dashboard's `backend/schema.py`,
+adapted to the current `vehicle_common` surface:
+
+- `vehicle_common.runtime.fleet_spec` is unchanged, so `fleet_schema()`
+  ports close to 1:1.
+- `vehicle_common.runtime.mission_spec` and `vehicle_common.runtime.schema`
+  (which the old code used for mission/fleet catalog file discovery) no
+  longer exist -- mission/fleet YAML files are now colcon package share
+  data, installed under `install/<pkg>/share/<pkg>/{missions,fleets}/*.yaml`
+  (see `uav/setup.py`, `payload/setup.py`). `_available_mission_names`/
+  `_available_fleet_names` below re-glob those installed locations directly
+  instead of the old repo-relative source-tree helpers.
+- `vehicle_common.mode_loader.ModeRegistry.get()` replaces the old static
+  `mode_registry.json` file entirely (see the module docstring history in
+  git blame). Its `RegisteredMode` entries carry no `mission_target`
+  (a single string) or pre-baked `params_schema` the way the old compat
+  layer's entries did -- `targets: list[type[Vehicle]]` and a live
+  `mode_cls.get_params_cls().model_json_schema()` call replace them. A
+  best-effort uav/payload target label is derived from each target
+  Vehicle class's top-level package name (`uav.*` -> "uav",
+  `payload.*` -> "payload"), since that label isn't carried as data.
+  There's also no `description` field left on `RegisteredMode` -- each
+  mode class's own docstring is used instead, which is a real (if less
+  structured) substitute already present on every mode class.
 """
 
 from __future__ import annotations
 
+import argparse
+import json
 import sys
+from pathlib import Path
+from typing import Any
+
+
+def _required_names(schema: dict[str, Any]) -> set[str]:
+    return set(schema.get("required", []))
+
+
+def _schema_field(
+    name: str,
+    property_schema: dict[str, Any],
+    *,
+    required: bool,
+) -> dict[str, Any]:
+    schema_type = "object"
+    annotation = "object"
+    nullable = False
+    choices: list[Any] = []
+
+    type_name_map = {
+        "boolean": "bool",
+        "integer": "int",
+        "number": "float",
+        "string": "str",
+        "array": "list",
+        "object": "dict",
+    }
+
+    if "enum" in property_schema:
+        schema_type = "enum"
+        annotation = "enum"
+        choices = list(property_schema["enum"])
+    elif "prefixItems" in property_schema:
+        schema_type = "tuple"
+        annotation = "tuple"
+    elif "$ref" in property_schema:
+        annotation = property_schema["$ref"].rsplit("/", 1)[-1]
+    else:
+        schema_type = str(property_schema.get("type", schema_type))
+        annotation = schema_type
+
+    variants = property_schema.get("anyOf") or property_schema.get("oneOf") or []
+    if variants:
+        non_null = []
+        for variant in variants:
+            if variant.get("type") == "null":
+                nullable = True
+            else:
+                non_null.append(variant)
+        if len(non_null) == 1:
+            variant = non_null[0]
+            if "enum" in variant:
+                schema_type = "enum"
+                annotation = "enum"
+                choices = list(variant["enum"])
+            elif "$ref" in variant:
+                annotation = variant["$ref"].rsplit("/", 1)[-1]
+            else:
+                schema_type = str(variant.get("type", schema_type))
+                annotation = schema_type
+        elif non_null:
+            schema_type = "union"
+            annotation = "union"
+
+    schema_type = type_name_map.get(schema_type, schema_type)
+    annotation = type_name_map.get(annotation, annotation)
+
+    default_kind = "missing"
+    default = None
+    if "default" in property_schema:
+        default = property_schema["default"]
+        default_kind = "none" if default is None else "value"
+
+    return {
+        "name": name,
+        "schemaType": schema_type,
+        "annotation": annotation,
+        "required": required,
+        "default": default,
+        "defaultKind": default_kind,
+        "nullable": nullable,
+        "choices": choices,
+        "description": property_schema.get("description"),
+    }
+
+
+def _fields_from_model(schema: dict[str, Any], calibration_choices: list[str]) -> list[dict[str, Any]]:
+    properties = schema.get("properties", {})
+    required = _required_names(schema)
+    fields = [
+        _schema_field(name, property_schema, required=name in required) for name, property_schema in properties.items()
+    ]
+    if calibration_choices:
+        for field in fields:
+            if field["name"] == "camera_calibration_file":
+                field["choices"] = calibration_choices
+    return fields
+
+
+def _available_camera_calibration_files(root: Path) -> list[str]:
+    calibrations_dir = root / "install" / "uav" / "share" / "uav" / "config" / "camera_calibrations"
+    if not calibrations_dir.is_dir():
+        return []
+    filenames = {path.name for pattern in ("*.yaml", "*.yml") for path in calibrations_dir.glob(pattern) if path.is_file()}
+    return sorted(filenames)
+
+
+def fleet_schema(root: Path) -> dict[str, Any]:
+    from vehicle_common.runtime.fleet_spec import (
+        FleetDefaultsModel,
+        FleetVehicleModel,
+        HardwareBackendModel,
+        SimBackendModel,
+    )
+
+    calibration_choices = _available_camera_calibration_files(root)
+
+    sim_backend_schema = SimBackendModel.model_json_schema()
+    hardware_backend_schema = HardwareBackendModel.model_json_schema()
+    defaults_schema = FleetDefaultsModel.model_json_schema()
+    vehicle_schema = FleetVehicleModel.model_json_schema()
+
+    sim_backend_fields = {f["name"]: f for f in _fields_from_model(sim_backend_schema, calibration_choices)}
+    hardware_backend_fields = {f["name"]: f for f in _fields_from_model(hardware_backend_schema, calibration_choices)}
+
+    backend_fields: list[dict[str, Any]] = []
+    seen_backend: set[str] = set()
+    for source in (sim_backend_fields, hardware_backend_fields):
+        for name, field in source.items():
+            if name in seen_backend:
+                continue
+            backend_fields.append(field)
+            seen_backend.add(name)
+
+    defaults_fields = _fields_from_model(defaults_schema, calibration_choices)
+    vehicle_fields = {f["name"]: f for f in _fields_from_model(vehicle_schema, calibration_choices)}
+
+    def section_fields(names: tuple[str, ...]) -> list[dict[str, Any]]:
+        return [vehicle_fields[name] for name in names if name in vehicle_fields]
+
+    return {
+        "backendKinds": ["sim", "hardware", "real"],
+        "sections": [
+            {"name": "backend", "fields": backend_fields},
+            {"name": "defaults", "fields": defaults_fields},
+            {"name": "vehicle.common", "fields": section_fields(("name", "mission", "mission_path", "kind"))},
+            {"name": "vehicle.sim", "fields": section_fields(("controllable", "px4_instance"))},
+            {
+                "name": "vehicle.hardware",
+                "fields": section_fields(
+                    (
+                        "px4_airframe_id",
+                        "px4_namespace",
+                        "payload_controller",
+                        "network_role",
+                        "allowed_ap_vehicles",
+                        "ap_selection",
+                    )
+                ),
+            },
+        ],
+    }
+
+
+def _target_label_for_vehicle_cls(vehicle_cls: type) -> str:
+    top_level_package = (vehicle_cls.__module__ or "").split(".")[0]
+    if top_level_package in ("uav", "payload"):
+        return top_level_package
+    return ""
+
+
+def mode_registry() -> dict[str, list[dict[str, Any]]]:
+    from vehicle_common.mode_loader import ModeRegistry
+
+    registry = ModeRegistry.get()
+    grouped: dict[str, list[dict[str, Any]]] = {}
+
+    for mode_id, registered in registry.modes.items():
+        targets = [_target_label_for_vehicle_cls(t) for t in registered.targets]
+        target = next((t for t in targets if t), "")
+        params_schema = registered.mode_cls.get_params_cls().model_json_schema()
+        entry = {
+            "name": registered.mode_cls.__name__,
+            "mode": mode_id,
+            "classPath": f"{registered.mode_cls.__module__}:{registered.mode_cls.__qualname__}",
+            "target": target,
+            "description": (registered.mode_cls.__doc__ or "").strip() or None,
+            "requiredVisionNodes": [v.__name__ for v in registered.required_vision_nodes],
+            "transitionLabels": list(registered.transition_labels),
+            "params": _fields_from_model(params_schema, []),
+        }
+        grouped.setdefault(target or "unknown", []).append(entry)
+
+    return grouped
+
+
+def _available_mission_files(root: Path) -> list[dict[str, str]]:
+    missions: list[dict[str, str]] = []
+    for pkg, target in (("uav", "uav"), ("payload", "payload")):
+        missions_dir = root / "install" / pkg / "share" / pkg / "missions"
+        if not missions_dir.is_dir():
+            continue
+        for path in sorted(missions_dir.glob("*.yaml")):
+            missions.append({"name": path.stem, "target": target})
+    return missions
+
+
+def _available_fleet_files(root: Path) -> list[str]:
+    fleets_dir = root / "install" / "uav" / "share" / "uav" / "fleets"
+    if not fleets_dir.is_dir():
+        return []
+    return sorted(path.stem for path in fleets_dir.glob("*.yaml"))
+
+
+def schema_index(root: Path) -> dict[str, Any]:
+    return {
+        "modes": mode_registry(),
+        "fleet": fleet_schema(root),
+        "missions": _available_mission_files(root),
+        "availableFleets": _available_fleet_files(root),
+    }
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Deploy release root containing install/ (defaults to the current directory).",
+    )
+    args = parser.parse_args()
+
     try:
-        from vehicle_common.mode_loader import ModeRegistry
+        from vehicle_common.mode_loader import ModeRegistry  # noqa: F401
     except ImportError as exc:
         print(
             f"Could not import vehicle_common.mode_loader: {exc}\n"
@@ -39,8 +286,7 @@ def main() -> int:
         )
         return 1
 
-    registry = ModeRegistry.get()
-    print(registry.model_dump_json(indent=2))
+    print(json.dumps(schema_index(Path(args.root)), indent=2))
     return 0
 
 

--- a/controls/sae_2025_ws/integration/tools/schema-export/test_schema_export.py
+++ b/controls/sae_2025_ws/integration/tools/schema-export/test_schema_export.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Tests for the parts of schema_export.py that don't require a sourced
+ROS2 + vehicle_common environment (the JSON-schema shaping helpers and the
+filesystem glob helpers). `fleet_schema()`/`mode_registry()`/`schema_index()`
+themselves import `vehicle_common` and can't be exercised here -- those need
+a real Pi (or a sourced colcon workspace) and are covered by manual/agent
+verification instead, same constraint as the rest of this project.
+
+Run with: python3 -m unittest tools/schema-export/test_schema_export.py
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import schema_export
+
+
+class SchemaFieldTests(unittest.TestCase):
+    def test_boolean_field(self) -> None:
+        field = schema_export._schema_field("enabled", {"type": "boolean", "default": True}, required=False)
+        self.assertEqual(field["schemaType"], "bool")
+        self.assertEqual(field["annotation"], "bool")
+        self.assertEqual(field["default"], True)
+        self.assertEqual(field["defaultKind"], "value")
+        self.assertFalse(field["nullable"])
+        self.assertEqual(field["choices"], [])
+
+    def test_enum_field(self) -> None:
+        field = schema_export._schema_field(
+            "network_role", {"enum": ["default", "ap", "client"]}, required=False
+        )
+        self.assertEqual(field["schemaType"], "enum")
+        self.assertEqual(field["choices"], ["default", "ap", "client"])
+
+    def test_tuple_field(self) -> None:
+        field = schema_export._schema_field(
+            "camera_mount_offsets", {"prefixItems": [{}, {}, {}]}, required=False
+        )
+        self.assertEqual(field["schemaType"], "tuple")
+
+    def test_ref_field(self) -> None:
+        field = schema_export._schema_field("backend", {"$ref": "#/$defs/HardwareBackendModel"}, required=True)
+        self.assertEqual(field["annotation"], "HardwareBackendModel")
+        self.assertTrue(field["required"])
+
+    def test_nullable_union_collapses_to_the_single_non_null_variant(self) -> None:
+        field = schema_export._schema_field(
+            "px4_airframe_id",
+            {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+            required=False,
+        )
+        self.assertEqual(field["schemaType"], "int")
+        self.assertTrue(field["nullable"])
+
+    def test_multi_variant_union_becomes_union_type(self) -> None:
+        field = schema_export._schema_field(
+            "backend",
+            {"anyOf": [{"$ref": "#/$defs/HardwareBackendModel"}, {"$ref": "#/$defs/SimBackendModel"}]},
+            required=True,
+        )
+        self.assertEqual(field["schemaType"], "union")
+
+    def test_missing_default_is_distinguished_from_an_explicit_none_default(self) -> None:
+        missing = schema_export._schema_field("x", {"type": "string"}, required=False)
+        self.assertEqual(missing["defaultKind"], "missing")
+        explicit_none = schema_export._schema_field("x", {"type": "string", "default": None}, required=False)
+        self.assertEqual(explicit_none["defaultKind"], "none")
+
+
+class FieldsFromModelTests(unittest.TestCase):
+    def test_derives_required_from_the_schema_required_list(self) -> None:
+        schema = {
+            "properties": {"name": {"type": "string"}, "mission": {"type": "string"}},
+            "required": ["name"],
+        }
+        fields = schema_export._fields_from_model(schema, [])
+        by_name = {f["name"]: f for f in fields}
+        self.assertTrue(by_name["name"]["required"])
+        self.assertFalse(by_name["mission"]["required"])
+
+    def test_injects_calibration_choices_onto_the_matching_field_only(self) -> None:
+        schema = {
+            "properties": {
+                "camera_calibration_file": {"type": "string"},
+                "other": {"type": "string"},
+            }
+        }
+        fields = schema_export._fields_from_model(schema, ["a.yaml", "b.yaml"])
+        by_name = {f["name"]: f for f in fields}
+        self.assertEqual(by_name["camera_calibration_file"]["choices"], ["a.yaml", "b.yaml"])
+        self.assertEqual(by_name["other"]["choices"], [])
+
+
+class TargetLabelTests(unittest.TestCase):
+    def test_uav_package_module_maps_to_uav(self) -> None:
+        class FakeUAV:
+            pass
+
+        FakeUAV.__module__ = "uav.uav.vehicles.UAV"
+        self.assertEqual(schema_export._target_label_for_vehicle_cls(FakeUAV), "uav")
+
+    def test_payload_package_module_maps_to_payload(self) -> None:
+        class FakePayload:
+            pass
+
+        FakePayload.__module__ = "payload.payload.payload"
+        self.assertEqual(schema_export._target_label_for_vehicle_cls(FakePayload), "payload")
+
+    def test_unknown_package_maps_to_empty_string(self) -> None:
+        class FakeOther:
+            pass
+
+        FakeOther.__module__ = "some_other_package.thing"
+        self.assertEqual(schema_export._target_label_for_vehicle_cls(FakeOther), "")
+
+
+class FilesystemGlobTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmpdir.name)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_available_mission_files_globs_both_uav_and_payload_share_dirs(self) -> None:
+        uav_missions = self.root / "install" / "uav" / "share" / "uav" / "missions"
+        uav_missions.mkdir(parents=True)
+        (uav_missions / "test_takeoff.yaml").write_text("modes: {}")
+
+        payload_missions = self.root / "install" / "payload" / "share" / "payload" / "missions"
+        payload_missions.mkdir(parents=True)
+        (payload_missions / "corner_navigate.yaml").write_text("modes: {}")
+
+        missions = schema_export._available_mission_files(self.root)
+        self.assertEqual(
+            sorted(missions, key=lambda m: m["name"]),
+            [{"name": "corner_navigate", "target": "payload"}, {"name": "test_takeoff", "target": "uav"}],
+        )
+
+    def test_available_mission_files_returns_empty_when_no_install_tree_exists(self) -> None:
+        self.assertEqual(schema_export._available_mission_files(self.root), [])
+
+    def test_available_fleet_files_globs_the_uav_share_fleets_dir(self) -> None:
+        fleets_dir = self.root / "install" / "uav" / "share" / "uav" / "fleets"
+        fleets_dir.mkdir(parents=True)
+        (fleets_dir / "example_fleet.yaml").write_text("vehicles: []")
+        (fleets_dir / "another.yaml").write_text("vehicles: []")
+
+        self.assertEqual(schema_export._available_fleet_files(self.root), ["another", "example_fleet"])
+
+    def test_available_camera_calibration_files_globs_yaml_and_yml(self) -> None:
+        calibrations_dir = self.root / "install" / "uav" / "share" / "uav" / "config" / "camera_calibrations"
+        calibrations_dir.mkdir(parents=True)
+        (calibrations_dir / "cam1.yaml").write_text("{}")
+        (calibrations_dir / "cam2.yml").write_text("{}")
+
+        self.assertEqual(schema_export._available_camera_calibration_files(self.root), ["cam1.yaml", "cam2.yml"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/controls/sae_2025_ws/integration/tools/schema-export/test_schema_export.py
+++ b/controls/sae_2025_ws/integration/tools/schema-export/test_schema_export.py
@@ -55,6 +55,27 @@ class SchemaFieldTests(unittest.TestCase):
         self.assertEqual(field["schemaType"], "int")
         self.assertTrue(field["nullable"])
 
+    def test_optional_tuple_field_is_still_classified_as_tuple_not_list(self) -> None:
+        # FleetDefaultsModel.camera_mount_offsets: tuple[float, float, float]
+        # | None -- pydantic wraps the tuple schema inside anyOf alongside
+        # {type: null}, so prefixItems lives on the anyOf variant, not the
+        # top-level property schema. Regression test: this used to fall
+        # through to the plain `type` branch and get classified as "list".
+        field = schema_export._schema_field(
+            "camera_mount_offsets",
+            {
+                "anyOf": [
+                    {"maxItems": 3, "minItems": 3, "prefixItems": [{"type": "number"}] * 3, "type": "array"},
+                    {"type": "null"},
+                ],
+                "default": None,
+            },
+            required=False,
+        )
+        self.assertEqual(field["schemaType"], "tuple")
+        self.assertEqual(field["annotation"], "tuple")
+        self.assertTrue(field["nullable"])
+
     def test_multi_variant_union_becomes_union_type(self) -> None:
         field = schema_export._schema_field(
             "backend",

--- a/controls/sae_2025_ws/integration/tsconfig.base.json
+++ b/controls/sae_2025_ws/integration/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "composite": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  }
+}

--- a/controls/sae_2025_ws/integration/vitest.config.ts
+++ b/controls/sae_2025_ws/integration/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["packages/*/src/**/*.test.ts"],
+  },
+});

--- a/controls/sae_2025_ws/integration/vitest.config.ts
+++ b/controls/sae_2025_ws/integration/vitest.config.ts
@@ -1,6 +1,21 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+// Resolve workspace packages to their TS source rather than their built
+// `dist/` output, so `vitest` never depends on packages having been built
+// first -- regardless of whether it's invoked via `npm test` (which builds
+// via the `pretest` hook) or directly via `npx vitest run`.
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@pennair/integration-core": fileURLToPath(
+        new URL("./packages/core/src/index.ts", import.meta.url),
+      ),
+      "@pennair/pi-agent": fileURLToPath(
+        new URL("./packages/pi-agent/src/index.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     include: ["packages/*/src/**/*.test.ts"],
   },

--- a/controls/sae_2025_ws/scripts/hardware/provision-pi.sh
+++ b/controls/sae_2025_ws/scripts/hardware/provision-pi.sh
@@ -27,6 +27,9 @@ FALLBACK_AP_PREFIX="${FALLBACK_AP_PREFIX:-pennair-ap}"
 FALLBACK_PSK="${FALLBACK_PSK:-pennair123!}"
 LOCAL_AP_SSID="${LOCAL_AP_SSID:-}"
 INSTALL_WIFI_FAILOVER="${INSTALL_WIFI_FAILOVER:-1}"
+INSTALL_PI_AGENT="${INSTALL_PI_AGENT:-1}"
+PI_AGENT_PORT="${PI_AGENT_PORT:-8090}"
+NODE_MAJOR_VERSION="${NODE_MAJOR_VERSION:-20}"
 
 usage() {
     cat <<EOF
@@ -36,10 +39,13 @@ Provision a PennAiR hardware Pi for dashboard-managed deploys.
 
 This script is intended to run on the Pi itself. It configures:
   - hostname / mDNS identity
-  - openssh-server and avahi-daemon
+  - openssh-server and avahi-daemon (kept for manual operator debugging; the
+    dashboard itself no longer requires SSH -- see pi-agent below)
   - deploy user creation and sudo membership
   - authorized_keys installation
   - optional passwordless sudo for the deploy user
+  - Node.js and the pi-agent daemon as a systemd service (the dashboard's
+    orchestrator talks to this instead of SSH)
   - the existing hardware bootstrap path
 
 Options:
@@ -63,6 +69,9 @@ Options:
   --fallback-ap-prefix PREF  Prefix for Pi-hosted fallback AP SSIDs
   --local-ap-ssid SSID       Override the local Pi-hosted fallback AP SSID
   --no-wifi-failover         Skip NetworkManager failover setup during bootstrap
+  --no-pi-agent              Skip installing Node.js and the pi-agent daemon
+  --pi-agent-port PORT       Port for the pi-agent daemon (default: $PI_AGENT_PORT)
+  --node-major-version N     Node.js major version to install via NodeSource (default: $NODE_MAJOR_VERSION)
   --no-nopasswd-sudo         Do not install a passwordless sudoers drop-in
   --no-bootstrap             Skip hardware bootstrap after provisioning
   --start                    Start the runtime service during bootstrap
@@ -210,6 +219,76 @@ EOF
     run_root install -m 0644 "$tmpfile" "$service_path"
     rm -f "$tmpfile"
     run_root systemctl restart avahi-daemon
+}
+
+install_nodejs() {
+    if command -v node >/dev/null 2>&1; then
+        local existing_major
+        existing_major="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+        if [[ "$existing_major" -ge "$NODE_MAJOR_VERSION" ]]; then
+            deploy_info "Node.js $(node -v) already installed"
+            return 0
+        fi
+    fi
+
+    deploy_info "Installing Node.js $NODE_MAJOR_VERSION via NodeSource"
+    deploy_apt_update run_root
+    run_root apt-get install -y ca-certificates curl gnupg
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR_VERSION}.x" | run_root bash -
+    run_root apt-get install -y nodejs
+}
+
+PI_AGENT_DIR="$SCRIPT_DIR/../../integration/packages/pi-agent"
+PI_AGENT_INTEGRATION_ROOT="$SCRIPT_DIR/../../integration"
+
+install_pi_agent() {
+    local user_name="$1"
+
+    if [[ ! -d "$PI_AGENT_INTEGRATION_ROOT" ]]; then
+        deploy_warn "Integration workspace not found at $PI_AGENT_INTEGRATION_ROOT -- skipping pi-agent install. Make sure the monorepo is checked out on this Pi before provisioning."
+        return 1
+    fi
+
+    deploy_info "Installing pi-agent dependencies and building"
+    # Scoped to the pi-agent workspace so this doesn't also pull in the much
+    # heavier web/mobile (Vite, Expo, React Native) dependency trees onto
+    # constrained Pi hardware -- they aren't needed here. Run as the deploy
+    # user (not root) so the resulting node_modules/dist are owned by the
+    # user the systemd service will actually run as.
+    (cd "$PI_AGENT_INTEGRATION_ROOT" && deploy_run_as_user "$user_name" npm ci --workspace=@pennair/pi-agent)
+    (cd "$PI_AGENT_INTEGRATION_ROOT" && deploy_run_as_user "$user_name" npm run build --workspace=@pennair/pi-agent)
+}
+
+install_pi_agent_service() {
+    local user_name="$1"
+    local unit_path="/etc/systemd/system/pennair-pi-agent.service"
+    local tmpfile
+    tmpfile="$(mktemp)"
+
+    cat > "$tmpfile" <<EOF
+[Unit]
+Description=PennAiR pi-agent (dashboard device-ops daemon)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$user_name
+WorkingDirectory=$PI_AGENT_DIR
+Environment=PORT=$PI_AGENT_PORT
+ExecStart=/usr/bin/node dist/index.js
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    deploy_info "Installing pi-agent systemd service (port $PI_AGENT_PORT)"
+    run_root install -m 0644 "$tmpfile" "$unit_path"
+    rm -f "$tmpfile"
+    run_root systemctl daemon-reload
+    run_root systemctl enable --now pennair-pi-agent.service
 }
 
 configure_hostname() {
@@ -415,6 +494,18 @@ while [[ $# -gt 0 ]]; do
             INSTALL_WIFI_FAILOVER=0
             shift
             ;;
+        --no-pi-agent)
+            INSTALL_PI_AGENT=0
+            shift
+            ;;
+        --pi-agent-port)
+            PI_AGENT_PORT="$2"
+            shift 2
+            ;;
+        --node-major-version)
+            NODE_MAJOR_VERSION="$2"
+            shift 2
+            ;;
         --no-nopasswd-sudo)
             ENABLE_NOPASSWD_SUDO=0
             shift
@@ -464,6 +555,17 @@ if [[ "$ENABLE_NOPASSWD_SUDO" == "1" ]]; then
     configure_nopasswd_sudo "$DEPLOY_USER"
 fi
 
+PI_AGENT_INSTALLED=0
+if [[ "$INSTALL_PI_AGENT" == "1" ]]; then
+    install_nodejs
+    if install_pi_agent "$DEPLOY_USER"; then
+        install_pi_agent_service "$DEPLOY_USER"
+        PI_AGENT_INSTALLED=1
+    fi
+else
+    deploy_info "Skipping pi-agent install (--no-pi-agent)"
+fi
+
 if [[ "$RUN_BOOTSTRAP" == "1" ]]; then
     run_bootstrap "$DEPLOY_USER" "$DEPLOY_ROOT"
 else
@@ -476,8 +578,14 @@ printf 'Hostname: %s.local\n' "$HOSTNAME_VALUE"
 printf 'Deploy user: %s\n' "$DEPLOY_USER"
 printf 'Deploy root: %s\n' "$DEPLOY_ROOT"
 printf 'SSH target: %s@%s.local\n' "$DEPLOY_USER" "$HOSTNAME_VALUE"
+if [[ "$PI_AGENT_INSTALLED" == "1" ]]; then
+    printf 'pi-agent: running on port %s (systemctl status pennair-pi-agent)\n' "$PI_AGENT_PORT"
+else
+    printf 'pi-agent: not installed\n'
+fi
 printf '\n'
 printf 'Next steps:\n'
-printf '  1. Add %s.local to the integration inventory.\n' "$HOSTNAME_VALUE"
-printf '  2. Use target_id %s in inventory for a clean hostname-to-target mapping.\n' "$HOSTNAME_VALUE"
-printf '  3. Set fleet_file, vehicle_name, and overlay_yaml in the dashboard.\n'
+printf '  1. Confirm the orchestrator can reach %s.local:%s/health.\n' "$HOSTNAME_VALUE" "$PI_AGENT_PORT"
+printf '  2. Add %s.local to the integration inventory.\n' "$HOSTNAME_VALUE"
+printf '  3. Use target_id %s in inventory for a clean hostname-to-target mapping.\n' "$HOSTNAME_VALUE"
+printf '  4. Set fleet_file, vehicle_name, and overlay_yaml in the dashboard.\n'


### PR DESCRIPTION
## Summary

Rewrites `controls/sae_2025_ws/integration` from Python/FastAPI + React into a TypeScript workspace (`core`, `pi-agent`, `orchestrator`, `web`, `mobile`), removing SSH as the transport in favor of an orchestrator-mediated architecture:

- **`pi-agent`** — a small daemon running on each Pi, replacing every SSH-shelled command (wifi via `nmcli`, deploy/systemd, mission process lifecycle, `journalctl` log streaming) with local `child_process` calls exposed over HTTP/WS.
- **`orchestrator`** — the single process every client (web/mobile) talks to. Relays device-ops to each Pi's `pi-agent`, and is itself a ROS2 participant (`rclnodejs`) for mission RPC (start-mission/failsafe) and Pi discovery.
- **`core`** — platform-agnostic types and pure logic shared by the above: mission/fleet YAML parsing & rendering, fleet-catalog resolution, fleet-board readiness computation.
- **`web`** / **`mobile`** — thin UI layers over one `OrchestratorClient`.
- **`tools/schema-export`** — the one remaining Python file, run on-demand on the Pi to introspect `vehicle_common` for the dynamic mission/fleet forms.

Implemented through Phase 5 of the rollout plan (wifi, mission RPC + log streaming, deploy pipeline, mission/fleet YAML editors, fleet board). Each phase went through implementation + background test/review agent passes; 266 TS tests and 17 Python tests pass, with a clean build/lint/typecheck.

**Known gaps, called out for follow-up, not addressed in this PR:**
- No independent-of-orchestrator fallback for `failsafe` — recommend confirming PX4/`mode_manager` has a hardware-level failsafe before this ships.
- No real-hardware/ROS2 validation yet — everything is covered by local-process integration tests only.
- Inventory/operator-config UI (saved targets, GitHub credentials) not yet built.

This PR is a draft opened for a cleanup/code-review pass before requesting real review.

## Test plan

- [x] `npm run build && npm run typecheck && npm run lint && npm test` clean from a fresh `npm ci`
- [x] `python3 -m unittest test_schema_export` (17 tests) in `tools/schema-export/`
- [ ] Real-hardware validation against an actual Pi (not done in this PR)