### PR TITLE
remove get_params_cls abstract method bc its useless

### DIFF
--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadAprilTagApproachMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadAprilTagApproachMode.py
@@ -49,6 +49,7 @@ class PayloadAprilTagApproachParams(BaseModel):
 
 @register_mode(
     id="payload.PayloadAprilTagApproachMode",
+    params_cls=PayloadAprilTagApproachParams,
     targets=[Payload],
     transition_labels=["done", "tag_lost"],
     requires_camera=True,
@@ -274,8 +275,3 @@ class PayloadAprilTagApproachMode(Mode):
 
     def on_exit(self) -> None:
         self.vehicle.stop()
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return PayloadAprilTagApproachParams

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadAprilTagApproachMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadAprilTagApproachMode.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, override
 
-from pydantic import BaseModel
 from rclpy.node import Node
 from sensor_msgs.msg import CameraInfo, CompressedImage, Image
 from cv_bridge import CvBridge
@@ -18,7 +17,7 @@ from uav.vision_nodes.payload_perception_common import (
 )
 
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 
 @dataclass(frozen=True)
@@ -33,7 +32,7 @@ class TagObservation:
     area: float
 
 
-class PayloadAprilTagApproachParams(BaseModel):
+class PayloadAprilTagApproachParams(ParamsBase):
     tag_id: Optional[int] = None
     tag_size_m: float = 0.0508
     tag_family: str = DEFAULT_TAG_FAMILY

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadColorStringApproachMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadColorStringApproachMode.py
@@ -24,14 +24,13 @@ from typing import Optional, Tuple, override
 import cv2
 import numpy as np
 from cv_bridge import CvBridge
-from pydantic import BaseModel
 from rclpy.node import Node
 from sensor_msgs.msg import CompressedImage, Image
 
 from payload.payload import Payload
 
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 
 def _vertical_blob_centroid_area(
@@ -89,7 +88,7 @@ def _vertical_blob_centroid_area(
     return (best_cx, best_cy, best_area_i)
 
 
-class PayloadColorStringApproachParams(BaseModel):
+class PayloadColorStringApproachParams(ParamsBase):
     lower_hsv: list[int] = (0, 0, 30)
     upper_hsv: list[int] = (179, 40, 120)
     forward_speed: float = 0.08

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadColorStringApproachMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadColorStringApproachMode.py
@@ -107,6 +107,7 @@ class PayloadColorStringApproachParams(BaseModel):
 
 @register_mode(
     id="payload.PayloadColorStringApproachMode",
+    params_cls=PayloadColorStringApproachParams,
     targets=[Payload],
     requires_camera=True,
 )
@@ -299,8 +300,3 @@ class PayloadColorStringApproachMode(Mode):
 
     def on_exit(self) -> None:
         self.vehicle.stop()
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return PayloadColorStringApproachParams

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadCornerNavigateMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadCornerNavigateMode.py
@@ -56,7 +56,6 @@ from typing import Optional, Tuple, override
 import cv2
 import numpy as np
 from cv_bridge import CvBridge
-from pydantic import BaseModel
 from rclpy.node import Node
 from sensor_msgs.msg import CompressedImage, Image
 
@@ -64,7 +63,7 @@ from vehicle_common.cv.dlz_convex_hull import build_dlz_hull_mask
 from payload.payload import Payload
 
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 # Mirrors PayloadColorSquareNode._COLOR_RATIO: when one tape colour has at
 # least this many times more pixels than the other in the line-follow strip,
@@ -72,7 +71,7 @@ from vehicle_common.mode_loader import register_mode
 _COLOR_DOMINANCE_RATIO = 1.5
 
 
-class PayloadCornerNavigateParams(BaseModel):
+class PayloadCornerNavigateParams(ParamsBase):
     direction: str = "ccw"
     # HSV color ranges — ccw=color A, cw=color B
     ccw_lower_hsv: list[int] = (0, 80, 80)

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadCornerNavigateMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadCornerNavigateMode.py
@@ -110,6 +110,7 @@ class PayloadCornerNavigateParams(BaseModel):
 
 @register_mode(
     id="payload.PayloadCornerNavigateMode",
+    params_cls=PayloadCornerNavigateParams,
     targets=[Payload],
     transition_labels=["complete"],
     requires_camera=True,
@@ -1244,8 +1245,3 @@ class PayloadCornerNavigateMode(Mode):
             62,
         )
         self._publish_annotated(debug)
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return PayloadCornerNavigateParams

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadDLZNavigateMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadDLZNavigateMode.py
@@ -8,13 +8,12 @@ from typing_extensions import TypedDict
 import cv2
 import numpy as np
 from cv_bridge import CvBridge
-from pydantic import BaseModel
 from rclpy.node import Node
 from sensor_msgs.msg import CompressedImage, Image
 
 from vehicle_common.cv.dlz_convex_hull import build_dlz_hull_mask
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 from payload.payload import Payload
 from uav.vision_nodes import PayloadAprilTagNode
 from uav.vision_nodes.payload_perception_common import DEFAULT_TAG_FAMILY
@@ -131,7 +130,7 @@ class TagTransitionRule(TypedDict):
     direction: Literal["cw", "ccw"]
 
 
-class PayloadDLZNavigateParams(BaseModel):
+class PayloadDLZNavigateParams(ParamsBase):
     direction: Literal["cw", "ccw"] = "ccw"
     target_transitions: int = 1
     turn_angular_speed: float = 0.5

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadDLZNavigateMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadDLZNavigateMode.py
@@ -13,13 +13,13 @@ from rclpy.node import Node
 from sensor_msgs.msg import CompressedImage, Image
 
 from vehicle_common.cv.dlz_convex_hull import build_dlz_hull_mask
+from vehicle_common.mode import Mode
+from vehicle_common.mode_loader import register_mode
 from payload.payload import Payload
 from uav.vision_nodes import PayloadAprilTagNode
 from uav.vision_nodes.payload_perception_common import DEFAULT_TAG_FAMILY
 from uav_interfaces.srv import PayloadAprilTagState
 
-from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
 
 # Corner-turn vision thresholds (mirrors PayloadCornerNavigateMode defaults)
 _CORNER_CENTER_TOL_PX = 75.0  # lateral error tolerance (px)
@@ -163,6 +163,7 @@ class PayloadDLZNavigateParams(BaseModel):
 
 @register_mode(
     id="payload.PayloadDLZNavigateMode",
+    params_cls=PayloadDLZNavigateParams,
     targets=[Payload],
     required_vision_nodes=[PayloadAprilTagNode],
     transition_labels=["done"],
@@ -1180,8 +1181,3 @@ class PayloadDLZNavigateMode(Mode):
             1,
         )
         self._publish_annotated(debug)
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return PayloadDLZNavigateParams

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadDualApproachMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadDualApproachMode.py
@@ -18,7 +18,6 @@ from typing import Optional, Tuple, override
 import cv2
 import numpy as np
 from cv_bridge import CvBridge
-from pydantic import BaseModel
 from rclpy.node import Node
 from sensor_msgs.msg import CameraInfo, CompressedImage, Image
 
@@ -30,7 +29,7 @@ from uav.vision_nodes.payload_perception_common import (
 )
 
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 
 def _color_blob_info(
@@ -61,7 +60,7 @@ def _color_blob_info(
     return (cx, cy, int(a), bh)
 
 
-class PayloadDualApproachParams(BaseModel):
+class PayloadDualApproachParams(ParamsBase):
     # --- AprilTag params ---
     tag_id: Optional[int] = 0
     tag_size_m: float = 0.0508
@@ -89,6 +88,7 @@ class PayloadDualApproachParams(BaseModel):
 
 @register_mode(
     id="payload.PayloadDualApproachMode",
+    params_cls=PayloadDualApproachParams,
     targets=[Payload],
     requires_camera=True,
 )

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadDualApproachMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadDualApproachMode.py
@@ -421,8 +421,3 @@ class PayloadDualApproachMode(Mode):
 
     def on_exit(self) -> None:
         self.vehicle.stop()
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return PayloadDualApproachParams

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadRetreatMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadRetreatMode.py
@@ -26,6 +26,8 @@ from vehicle_common.mode_loader import register_mode
 from payload.payload import Payload
 from uav.vision_nodes import PayloadAprilTagNode
 
+from controls.sae_2025_ws.src.payload.payload.modes.PayloadWaitForDriveOutMode import PayloadWaitForDriveOutParams
+
 # HSV range for white (high value, low saturation)
 _WHITE_LOWER = np.array([0, 0, 200], dtype=np.uint8)
 _WHITE_UPPER = np.array([180, 30, 255], dtype=np.uint8)
@@ -47,6 +49,7 @@ class PayloadRetreatParams(BaseModel):
 
 @register_mode(
     id="payload.PayloadRetreatMode",
+    params_cls=PayloadWaitForDriveOutParams,
     targets=[Payload],
     required_vision_nodes=[PayloadAprilTagNode],
 )
@@ -288,8 +291,3 @@ class PayloadRetreatMode(Mode):
         self._drive_pub.publish(
             DriveCommand(linear=float(linear), angular=float(angular))
         )
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return PayloadRetreatParams

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadRetreatMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadRetreatMode.py
@@ -15,25 +15,22 @@ from typing import Optional, Tuple, override
 
 import cv2
 import numpy as np
-from pydantic import BaseModel
 from rclpy.node import Node
 from sensor_msgs.msg import CompressedImage, Image
 from payload_interfaces.msg import DriveCommand
 from cv_bridge import CvBridge
 
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 from payload.payload import Payload
 from uav.vision_nodes import PayloadAprilTagNode
-
-from controls.sae_2025_ws.src.payload.payload.modes.PayloadWaitForDriveOutMode import PayloadWaitForDriveOutParams
 
 # HSV range for white (high value, low saturation)
 _WHITE_LOWER = np.array([0, 0, 200], dtype=np.uint8)
 _WHITE_UPPER = np.array([180, 30, 255], dtype=np.uint8)
 
 
-class PayloadRetreatParams(BaseModel):
+class PayloadRetreatParams(ParamsBase):
     forward_speed_mps: float = 0.12
     edge_threshold: float = 0.30
     edge_stable_frames: int = 5
@@ -49,7 +46,7 @@ class PayloadRetreatParams(BaseModel):
 
 @register_mode(
     id="payload.PayloadRetreatMode",
-    params_cls=PayloadWaitForDriveOutParams,
+    params_cls=PayloadRetreatParams,
     targets=[Payload],
     required_vision_nodes=[PayloadAprilTagNode],
 )

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadScanForTagMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadScanForTagMode.py
@@ -6,7 +6,6 @@ from typing import Optional, override
 import cv2
 import numpy as np
 from cv_bridge import CvBridge
-from pydantic import BaseModel
 from rclpy.node import Node
 from sensor_msgs.msg import CompressedImage, Image
 
@@ -16,12 +15,12 @@ from uav.vision_nodes.payload_perception_common import DEFAULT_TAG_FAMILY
 from uav_interfaces.srv import PayloadAprilTagState
 
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 _TWO_PI = 2.0 * math.pi
 
 
-class PayloadScanForTagParams(BaseModel):
+class PayloadScanForTagParams(ParamsBase):
     tag_id: int = 0
     tag_size_m: float = 0.0508
     tag_family: str = DEFAULT_TAG_FAMILY

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadScanForTagMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadScanForTagMode.py
@@ -32,6 +32,7 @@ class PayloadScanForTagParams(BaseModel):
 
 @register_mode(
     id="payload.PayloadScanForTagMode",
+    params_cls=PayloadScanForTagParams,
     targets=[Payload],
     required_vision_nodes=[PayloadAprilTagNode],
     transition_labels=["found", "not_found"],
@@ -210,8 +211,3 @@ class PayloadScanForTagMode(Mode):
         if self._annotated_pub is not None:
             self.node.destroy_publisher(self._annotated_pub)
             self._annotated_pub = None
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return PayloadScanForTagParams

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadWaitForDriveOutMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadWaitForDriveOutMode.py
@@ -29,17 +29,16 @@ from typing import Optional, List, override
 import cv2
 import numpy as np
 from cv_bridge import CvBridge
-from pydantic import BaseModel
 from rclpy.node import Node
 from sensor_msgs.msg import CompressedImage, Image
 
 from payload.payload import Payload
 
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 
-class PayloadWaitForDriveOutParams(BaseModel):
+class PayloadWaitForDriveOutParams(ParamsBase):
     # DLZ color detection
     dlz_color_lower_hsv: List[int] = (5, 120, 120)
     dlz_color_upper_hsv: List[int] = (20, 255, 255)

--- a/controls/sae_2025_ws/src/payload/payload/modes/PayloadWaitForDriveOutMode.py
+++ b/controls/sae_2025_ws/src/payload/payload/modes/PayloadWaitForDriveOutMode.py
@@ -74,6 +74,7 @@ class DriveOutState(Enum):
 
 @register_mode(
     id="payload.PayloadWaitForDriveOutMode",
+    params_cls=PayloadWaitForDriveOutParams,
     targets=[Payload],
     transition_labels=["complete"],
     requires_camera=True,
@@ -373,8 +374,3 @@ class PayloadWaitForDriveOutMode(Mode):
 
     def on_exit(self) -> None:
         pass
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return PayloadWaitForDriveOutParams

--- a/controls/sae_2025_ws/src/uav/uav/modes/LandingMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/LandingMode.py
@@ -9,10 +9,6 @@ from vehicle_common.mode import Mode
 from vehicle_common.mode_loader import register_mode
 
 
-class LandingParams(BaseModel):
-    pass
-
-
 @register_mode(id="uav.LandingMode", targets=[UAV])
 class LandingMode(Mode):
     """
@@ -20,7 +16,7 @@ class LandingMode(Mode):
     """
 
     @override
-    def initialize(self, node: Node, vehicle: UAV, params: LandingParams) -> None:
+    def initialize(self, node: Node, vehicle: UAV, params: BaseModel) -> None:
         self.node = node
         self.vehicle = vehicle
         self.p = params
@@ -59,8 +55,3 @@ class LandingMode(Mode):
         ):
             return "terminate"  # Mission complete - shut down
         return "continue"
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return LandingParams

--- a/controls/sae_2025_ws/src/uav/uav/modes/LandingMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/LandingMode.py
@@ -2,11 +2,10 @@ from typing import override
 
 from rclpy.node import Node
 from px4_msgs.msg import VehicleStatus
-from pydantic import BaseModel
 
 from uav.vehicles.UAV import UAV
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 
 @register_mode(id="uav.LandingMode", targets=[UAV])
@@ -16,7 +15,7 @@ class LandingMode(Mode):
     """
 
     @override
-    def initialize(self, node: Node, vehicle: UAV, params: BaseModel) -> None:
+    def initialize(self, node: Node, vehicle: UAV, params: ParamsBase) -> None:
         self.node = node
         self.vehicle = vehicle
         self.p = params

--- a/controls/sae_2025_ws/src/uav/uav/modes/NavGPSMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/NavGPSMode.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 from typing import Literal, override
 from rclpy.node import Node
 
-from pydantic import BaseModel
-
 from uav.vehicles.UAV import UAV
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 
-class NavGPSParams(BaseModel):
+class NavGPSParams(ParamsBase):
     """
     coordinates: The coordinates to navigate to (x/y/z or lon/lat/alt, wait time, GPS/LOCAL).
         Local are NED coordinates, relative to the starting position (https://docs.px4.io/main/en/ros2/user_guide.html#ros-2-px4-frame-conventions).
@@ -25,7 +23,7 @@ class NavGPSParams(BaseModel):
     id="uav.NavGPSMode",
     params_cls=NavGPSParams,
     targets=[UAV],
-    transition_labels=["complete"]
+    transition_labels=["complete"],
 )
 class NavGPSMode(Mode[UAV, NavGPSParams]):
     """

--- a/controls/sae_2025_ws/src/uav/uav/modes/NavGPSMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/NavGPSMode.py
@@ -21,7 +21,12 @@ class NavGPSParams(BaseModel):
     margin: float = 1
 
 
-@register_mode(id="uav.NavGPSMode", targets=[UAV], transition_labels=["complete"])
+@register_mode(
+    id="uav.NavGPSMode",
+    params_cls=NavGPSParams,
+    targets=[UAV],
+    transition_labels=["complete"]
+)
 class NavGPSMode(Mode[UAV, NavGPSParams]):
     """
     A mode for navigating to a GPS coordinate
@@ -153,8 +158,3 @@ class NavGPSMode(Mode[UAV, NavGPSParams]):
             return "complete"
         else:
             return "continue"
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return NavGPSParams

--- a/controls/sae_2025_ws/src/uav/uav/modes/PayloadDropoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/PayloadDropoffMode.py
@@ -24,6 +24,7 @@ class PayloadDropoffParams(BaseModel):
 
 @register_mode(
     id="uav.PayloadDropoffMode",
+    params_cls=PayloadDropoffParams,
     targets=[UAV],
     required_vision_nodes=[PayloadTrackingNode],
     transition_labels=["complete"],
@@ -134,8 +135,3 @@ class PayloadDropoffMode(Mode):
         if self.done:
             return "complete"
         return "continue"
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return PayloadDropoffParams

--- a/controls/sae_2025_ws/src/uav/uav/modes/PayloadDropoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/PayloadDropoffMode.py
@@ -1,7 +1,6 @@
 from typing import Optional, Tuple, override
 
 import numpy as np
-from pydantic import BaseModel
 from px4_msgs.msg import VehicleStatus
 from rclpy.node import Node
 
@@ -10,10 +9,10 @@ from uav.vision_nodes import PayloadTrackingNode
 from uav_interfaces.srv import PayloadTracking
 
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 
-class PayloadDropoffParams(BaseModel):
+class PayloadDropoffParams(ParamsBase):
     """
     offsets: Should denote the position of dropoff relative to the center of zone, in meters
         In NED frame: x is forward, y is right, and z is down.

--- a/controls/sae_2025_ws/src/uav/uav/modes/PayloadPickupMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/PayloadPickupMode.py
@@ -18,6 +18,7 @@ class PayloadPickupParams(BaseModel):
 
 @register_mode(
     id="uav.PayloadPickupMode",
+    params_cls=PayloadPickupParams,
     targets=[UAV],
     required_vision_nodes=[PayloadTrackingNode],
     transition_labels=["complete"],
@@ -112,8 +113,3 @@ class PayloadPickupMode(Mode):
         if self.done:
             return "complete"
         return "continue"
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return PayloadPickupParams

--- a/controls/sae_2025_ws/src/uav/uav/modes/PayloadPickupMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/PayloadPickupMode.py
@@ -1,7 +1,6 @@
 from typing import override
 
 import numpy as np
-from pydantic import BaseModel
 from rclpy.node import Node
 
 from uav.vehicles.UAV import UAV
@@ -9,10 +8,10 @@ from uav.vision_nodes import PayloadTrackingNode
 from uav_interfaces.srv import PayloadTracking
 
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 
-class PayloadPickupParams(BaseModel):
+class PayloadPickupParams(ParamsBase):
     color: str = "green"
 
 

--- a/controls/sae_2025_ws/src/uav/uav/modes/ServoDropoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/ServoDropoffMode.py
@@ -1,12 +1,11 @@
 from typing import Optional, Tuple, override
-from pydantic import BaseModel
 from rclpy.node import Node
 from uav.vehicles.UAV import UAV
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 
-class ServoDropoffParams(BaseModel):
+class ServoDropoffParams(ParamsBase):
     """
     offsets: Should denote the position of dropoff relative to the center of zone, in meters
         In NED frame: x is forward, y is right, and z is down.
@@ -22,7 +21,7 @@ class ServoDropoffParams(BaseModel):
     id="uav.ServoDropoffMode",
     params_cls=ServoDropoffParams,
     targets=[UAV],
-    transition_labels=["complete"]
+    transition_labels=["complete"],
 )
 class ServoDropoffMode(Mode):
     """

--- a/controls/sae_2025_ws/src/uav/uav/modes/ServoDropoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/ServoDropoffMode.py
@@ -18,7 +18,12 @@ class ServoDropoffParams(BaseModel):
     camera_offsets: Optional[Tuple[float, float, float]] = (0.0, 0.0, 0.0)
 
 
-@register_mode(id="uav.ServoDropoffMode", targets=[UAV], transition_labels=["complete"])
+@register_mode(
+    id="uav.ServoDropoffMode",
+    params_cls=ServoDropoffParams,
+    targets=[UAV],
+    transition_labels=["complete"]
+)
 class ServoDropoffMode(Mode):
     """
     A mode for dropping off the payload.
@@ -63,8 +68,3 @@ class ServoDropoffMode(Mode):
         if self.done:
             return "complete"
         return "continue"
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return ServoDropoffParams

--- a/controls/sae_2025_ws/src/uav/uav/modes/VerticalTakeoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/VerticalTakeoffMode.py
@@ -21,7 +21,10 @@ class VerticalTakeoffParams(BaseModel):
 
 
 @register_mode(
-    id="uav.VerticalTakeoffMode", targets=[UAV], transition_labels=["complete"]
+    id="uav.VerticalTakeoffMode",
+    params_cls=VerticalTakeoffParams,
+    targets=[UAV],
+    transition_labels=["complete"]
 )
 class VerticalTakeoffMode(Mode):
     """Vertical takeoff for any UAV airframe (multicopter or VTOL)."""
@@ -138,8 +141,3 @@ class VerticalTakeoffMode(Mode):
                 return "complete"
 
         return "continue"
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return VerticalTakeoffParams

--- a/controls/sae_2025_ws/src/uav/uav/modes/VerticalTakeoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/VerticalTakeoffMode.py
@@ -1,12 +1,11 @@
 from typing import override
 
-from pydantic import BaseModel
 from px4_msgs.msg import VehicleStatus
 from rclpy.node import Node
 
 from uav.vehicles.UAV import UAV
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 from enum import StrEnum
 
 
@@ -15,7 +14,7 @@ class TakeoffMethod(StrEnum):
     PX4_AUTO = "PX4_AUTO"  # rely on px4 AUTO_TAKEOFF mode for takeoff
 
 
-class VerticalTakeoffParams(BaseModel):
+class VerticalTakeoffParams(ParamsBase):
     takeoff_height: float = 5.0
     takeoff_method: str = "PX4_AUTO"
 
@@ -24,7 +23,7 @@ class VerticalTakeoffParams(BaseModel):
     id="uav.VerticalTakeoffMode",
     params_cls=VerticalTakeoffParams,
     targets=[UAV],
-    transition_labels=["complete"]
+    transition_labels=["complete"],
 )
 class VerticalTakeoffMode(Mode):
     """Vertical takeoff for any UAV airframe (multicopter or VTOL)."""

--- a/controls/sae_2025_ws/src/uav/uav/modes/WaypointMission.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/WaypointMission.py
@@ -5,15 +5,13 @@ import math
 import time
 from typing import List, override
 
-from pydantic import BaseModel
-
 from uav.vehicles.UAV import UAV
 
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 
-class WaypointMissionParams(BaseModel):
+class WaypointMissionParams(ParamsBase):
     waypoints: List[List[float]] = None
     waypoint_tolerance: float = 0.5
     speed: float = 1.0
@@ -22,9 +20,7 @@ class WaypointMissionParams(BaseModel):
 
 
 @register_mode(
-    id="uav.WaypointMission",
-    params_cls=WaypointMissionParams,
-    targets=[UAV]
+    id="uav.WaypointMission", params_cls=WaypointMissionParams, targets=[UAV]
 )
 class WaypointMission(Mode):
     """
@@ -150,6 +146,7 @@ class WaypointMission(Mode):
         """Arm the vehicle."""
         self.vehicle.arm()
         self.node.get_logger().info("Arming vehicle...")
+
 
 def main(args=None):
     rclpy.init(args=args)

--- a/controls/sae_2025_ws/src/uav/uav/modes/WaypointMission.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/WaypointMission.py
@@ -21,7 +21,11 @@ class WaypointMissionParams(BaseModel):
     altitude: float = 2.0
 
 
-@register_mode(id="uav.WaypointMission", targets=[UAV])
+@register_mode(
+    id="uav.WaypointMission",
+    params_cls=WaypointMissionParams,
+    targets=[UAV]
+)
 class WaypointMission(Mode):
     """
     Simple waypoint mission for testing scoring node.
@@ -146,12 +150,6 @@ class WaypointMission(Mode):
         """Arm the vehicle."""
         self.vehicle.arm()
         self.node.get_logger().info("Arming vehicle...")
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return WaypointMissionParams
-
 
 def main(args=None):
     rclpy.init(args=args)

--- a/controls/sae_2025_ws/src/uav/uav/modes/vtol/TakeoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/vtol/TakeoffMode.py
@@ -2,7 +2,6 @@ import time
 from typing import Literal, override
 
 import numpy as np
-from pydantic import BaseModel
 from px4_msgs.msg import VehicleStatus, VtolVehicleStatus
 from rclpy.node import Node
 
@@ -10,10 +9,10 @@ from uav.vehicles.UAV import get_nav_state_str, UAV
 from uav.vehicles.VTOL import VTOL
 
 from vehicle_common.mode import Mode
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 
-class TakeoffParams(BaseModel):
+class TakeoffParams(ParamsBase):
     takeoff_type: Literal["vertical", "horizontal"] = "vertical"
     fw_tko_pitch: float = float("nan")
     yaw: float = float("nan")
@@ -26,7 +25,7 @@ class TakeoffParams(BaseModel):
     id="uav.vtol.TakeoffMode",
     params_cls=TakeoffParams,
     targets=[UAV],
-    transition_labels=["complete"]
+    transition_labels=["complete"],
 )
 class TakeoffMode(Mode):
     """

--- a/controls/sae_2025_ws/src/uav/uav/modes/vtol/TakeoffMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/vtol/TakeoffMode.py
@@ -22,7 +22,12 @@ class TakeoffParams(BaseModel):
     altitude: float = float("nan")
 
 
-@register_mode(id="uav.vtol.TakeoffMode", targets=[UAV], transition_labels=["complete"])
+@register_mode(
+    id="uav.vtol.TakeoffMode",
+    params_cls=TakeoffParams,
+    targets=[UAV],
+    transition_labels=["complete"]
+)
 class TakeoffMode(Mode):
     """
     A VTOL takeoff mode that supports both vertical and runway-style launches.
@@ -177,8 +182,3 @@ class TakeoffMode(Mode):
             self.log("Takeoff complete, in offboard mode.")
             return "complete"
         return "continue"
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return TakeoffParams

--- a/controls/sae_2025_ws/src/uav/uav/modes/vtol/TransitionMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/vtol/TransitionMode.py
@@ -1,5 +1,4 @@
 import numpy as np
-from pydantic import BaseModel
 from rclpy.node import Node
 from typing import Literal, override
 
@@ -8,10 +7,10 @@ from uav.vehicles.UAV import UAV
 
 from vehicle_common.mode import Mode
 
-from vehicle_common.mode_loader import register_mode
+from vehicle_common.mode_loader import ParamsBase, register_mode
 
 
-class TransitionParams(BaseModel):
+class TransitionParams(ParamsBase):
     to_mode: Literal["MC", "FW"]
 
 
@@ -19,7 +18,7 @@ class TransitionParams(BaseModel):
     id="uav.vtol.TransitionMode",
     params_cls=TransitionParams,
     targets=[UAV],
-    transition_labels=["complete"]
+    transition_labels=["complete"],
 )
 class TransitionMode(Mode):
     """

--- a/controls/sae_2025_ws/src/uav/uav/modes/vtol/TransitionMode.py
+++ b/controls/sae_2025_ws/src/uav/uav/modes/vtol/TransitionMode.py
@@ -16,7 +16,10 @@ class TransitionParams(BaseModel):
 
 
 @register_mode(
-    id="uav.vtol.TransitionMode", targets=[UAV], transition_labels=["complete"]
+    id="uav.vtol.TransitionMode",
+    params_cls=TransitionParams,
+    targets=[UAV],
+    transition_labels=["complete"]
 )
 class TransitionMode(Mode):
     """
@@ -114,8 +117,3 @@ class TransitionMode(Mode):
             return "continue"
         self.log(f"Transition to {self.p.to_mode} complete")
         return "complete"
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return TransitionParams

--- a/controls/sae_2025_ws/src/vehicle_common/test/mock_classes.py
+++ b/controls/sae_2025_ws/src/vehicle_common/test/mock_classes.py
@@ -1,10 +1,8 @@
-from typing import override
-
 from pydantic import BaseModel
+
 from vehicle_common.vehicle import Vehicle
 from vehicle_common.mode import Mode
 from vehicle_common.base import VisionNode
-
 from vehicle_common.mode_loader import (
     register_mode,
 )
@@ -22,13 +20,13 @@ class MockParams(BaseModel):
     pass
 
 
-@register_mode(id="mock", targets=[MockVehicle])
+@register_mode(id="mock", params_cls=MockParams, targets=[MockVehicle])
 class MockMode(Mode):
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return MockParams
+    pass
 
+@register_mode(id="no_params", targets=[MockVehicle])
+class NoParamsMock(Mode):
+    pass
 
 class MockVerticalTakeoffParams(BaseModel):
     takeoff_height: float = 5.0
@@ -37,6 +35,7 @@ class MockVerticalTakeoffParams(BaseModel):
 
 @register_mode(
     id="mock.VerticalTakeoffMode",
+    params_cls=MockVerticalTakeoffParams,
     targets=[MockVehicle],
     required_vision_nodes=[MockVisionNode],
     peer_vehicle_names=["peer1"],
@@ -47,20 +46,10 @@ class MockVerticalTakeoffMode(Mode):
     """Copy of uav.modes.VerticalTakeoffMode.VerticalTakeoffMode, stripped of its
     PX4/ROS dependencies so it can be registered and validated in plain-Python tests."""
 
-    transition_labels = ("complete",)
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return MockVerticalTakeoffParams
-
-
-class MockLoiterParams(BaseModel):
-    pass
-
 
 @register_mode(
     id="mock.loiter",
+    params_cls=MockParams,
     targets=[MockVehicle],
     required_vision_nodes=[MockVisionNode],
     peer_vehicle_names=["peer1"],
@@ -69,8 +58,3 @@ class MockLoiterMode(Mode):
     """Second mock mode sharing vision/peer requirements with MockVerticalTakeoffMode
     but not requiring a camera, so RuntimeMission's intersection/union aggregation
     across modes can be exercised."""
-
-    @classmethod
-    @override
-    def get_params_cls(cls) -> type[BaseModel]:
-        return MockLoiterParams

--- a/controls/sae_2025_ws/src/vehicle_common/test/mock_classes.py
+++ b/controls/sae_2025_ws/src/vehicle_common/test/mock_classes.py
@@ -1,9 +1,8 @@
-from pydantic import BaseModel
-
 from vehicle_common.vehicle import Vehicle
 from vehicle_common.mode import Mode
 from vehicle_common.base import VisionNode
 from vehicle_common.mode_loader import (
+    ParamsBase,
     register_mode,
 )
 
@@ -16,7 +15,7 @@ class MockVisionNode(VisionNode):
     pass
 
 
-class MockParams(BaseModel):
+class MockParams(ParamsBase):
     pass
 
 
@@ -24,13 +23,19 @@ class MockParams(BaseModel):
 class MockMode(Mode):
     pass
 
+
 @register_mode(id="no_params", targets=[MockVehicle])
 class NoParamsMock(Mode):
     pass
 
-class MockVerticalTakeoffParams(BaseModel):
+
+class MockVerticalTakeoffParams(ParamsBase):
     takeoff_height: float = 5.0
     takeoff_method: str = "PX4_AUTO"
+
+
+class MockRequiredParams(ParamsBase):
+    required_field: float
 
 
 @register_mode(
@@ -58,3 +63,12 @@ class MockLoiterMode(Mode):
     """Second mock mode sharing vision/peer requirements with MockVerticalTakeoffMode
     but not requiring a camera, so RuntimeMission's intersection/union aggregation
     across modes can be exercised."""
+
+
+@register_mode(
+    id="mock.required_params",
+    params_cls=MockRequiredParams,
+    targets=[MockVehicle],
+)
+class MockRequiredParamsMode(Mode):
+    pass

--- a/controls/sae_2025_ws/src/vehicle_common/test/test_mission_loading.py
+++ b/controls/sae_2025_ws/src/vehicle_common/test/test_mission_loading.py
@@ -1,10 +1,9 @@
 import pytest
 from pydantic import ValidationError
+import yaml
 
 from vehicle_common.runtime.mission_loader import RuntimeMode, RuntimeMission
 from vehicle_common.mode_loader import ModeRegistry
-import yaml
-
 from mock_classes import (
     MockParams,
     MockVehicle,

--- a/controls/sae_2025_ws/src/vehicle_common/test/test_mission_loading.py
+++ b/controls/sae_2025_ws/src/vehicle_common/test/test_mission_loading.py
@@ -3,7 +3,7 @@ from pydantic import ValidationError
 import yaml
 
 from vehicle_common.runtime.mission_loader import RuntimeMode, RuntimeMission
-from vehicle_common.mode_loader import ModeRegistry
+from vehicle_common.mode_loader import ModeRegistry, ParamsBase
 from mock_classes import (
     MockParams,
     MockVehicle,
@@ -84,7 +84,7 @@ modes:
 """
 
 
-def test_runtime_mission_vision_nodes_empty_when_not_shared_by_all_modes():
+def test_vision_nodes_union_across_modes():
     mission = RuntimeMission.model_validate(yaml.safe_load(mock_mission_yaml_2))
     print(mission._vision_nodes)
     expected = {MockVisionNode}
@@ -100,9 +100,25 @@ modes:
 """
 
 
-def test_runtime_mission_requires_camera_false_if_no_mode_requires_it():
+def test_requires_camera_false_without_camera_modes():
     mission = RuntimeMission.model_validate(yaml.safe_load(mission_3))
     assert mission._requires_camera is False
+
+
+mission_no_params_field = """
+modes:
+  no_params_mode:
+    mode: no_params
+"""
+
+
+def test_missing_params_defaults_to_empty():
+    mission = RuntimeMission.model_validate(yaml.safe_load(mission_no_params_field))
+    runtime_mode = mission.modes["no_params_mode"]
+
+    assert runtime_mode.params == {}
+    assert runtime_mode._validated_params == ParamsBase()
+    assert runtime_mode.transitions == {}
 
 
 def test_runtime_mission_forbids_extra_fields():
@@ -142,6 +158,18 @@ modes:
 def test_runtime_mission_invalid_params_raises():
     with pytest.raises(ValidationError):
         RuntimeMission.model_validate(yaml.safe_load(bad_params))
+
+
+missing_required_params = """
+modes:
+  required:
+    mode: mock.required_params
+"""
+
+
+def test_missing_params_fails_with_required_model():
+    with pytest.raises(ValidationError):
+        RuntimeMission.model_validate(yaml.safe_load(missing_required_params))
 
 
 def test_runtime_mission_requires_at_least_one_mode():

--- a/controls/sae_2025_ws/src/vehicle_common/test/test_mode_loader.py
+++ b/controls/sae_2025_ws/src/vehicle_common/test/test_mode_loader.py
@@ -1,11 +1,13 @@
 import pytest
+from pydantic import BaseModel
+from pydantic import ValidationError
 from vehicle_common.mode_loader import (
     serialize_type,
     deserialize_type,
     RegisteredMode,
     ModeRegistry,
 )
-from mock_classes import MockMode, MockVehicle, MockVisionNode
+from mock_classes import MockMode, MockParams, MockVehicle, MockVisionNode, NoParamsMock
 
 
 from vehicle_common.mode import Mode
@@ -36,6 +38,7 @@ def test_registered_mode_creation():
     mode = RegisteredMode(
         id="test",
         mode_cls=MockMode,
+        params_cls=MockParams,
         targets=[MockVehicle],
         required_vision_nodes=[MockVisionNode],
     )
@@ -44,6 +47,20 @@ def test_registered_mode_creation():
     assert mode.mode_cls is MockMode
     assert mode.targets == [MockVehicle]
     assert mode.required_vision_nodes == [MockVisionNode]
+
+
+def test_registered_mode_creation_no_params_mode():
+    mode = RegisteredMode(
+        id="no_params_test",
+        mode_cls=NoParamsMock,
+        targets=[MockVehicle],
+    )
+
+    assert mode.id == "no_params_test"
+    assert mode.mode_cls is NoParamsMock
+    assert mode.params_cls is BaseModel
+    assert mode.targets == [MockVehicle]
+    assert mode.required_vision_nodes == []
 
 
 def test_get_registered_mode():
@@ -60,6 +77,7 @@ def test_registered_mode_to_json():
     mode = RegisteredMode(
         id="test",
         mode_cls=MockMode,
+        params_cls=MockParams,
         targets=[MockVehicle],
         required_vision_nodes=[MockVisionNode],
     )
@@ -70,6 +88,7 @@ def test_registered_mode_to_json():
     assert data["id"] == "test"
 
     assert data["mode_cls"] == serialize_type(MockMode)
+    assert data["params_cls"] == serialize_type(MockParams)
 
     assert data["targets"] == [serialize_type(MockVehicle)]
 
@@ -84,24 +103,22 @@ def test_registered_mode_from_json():
     mode = RegisteredMode(
         id="test",
         mode_cls=MockMode,
+        params_cls=MockParams,
         targets=[MockVehicle],
         required_vision_nodes=[MockVisionNode],
     )
 
     json_str = mode.model_dump_json()
 
-    loaded = RegisteredMode.model_validate_json(json_str)
-
-    assert loaded.id == mode.id
-    assert loaded.mode_cls is MockMode
-    assert loaded.targets == [MockVehicle]
-    assert loaded.required_vision_nodes == [MockVisionNode]
+    with pytest.raises(ValidationError):
+        RegisteredMode.model_validate_json(json_str)
 
 
 def test_registered_mode_json_round_trip():
     original = RegisteredMode(
         id="round_trip",
         mode_cls=MockMode,
+        params_cls=MockParams,
         targets=[MockVehicle],
         required_vision_nodes=[MockVisionNode],
         peer_vehicle_names=["vehicle1"],
@@ -109,14 +126,8 @@ def test_registered_mode_json_round_trip():
         transition_labels=["done"],
     )
 
-    loaded = RegisteredMode.model_validate_json(original.model_dump_json())
-    print(loaded.model_dump())
-    print()
-    print()
-    print()
-    print(original.model_dump())
-
-    assert loaded.model_dump() == original.model_dump()
+    with pytest.raises(ValidationError):
+        RegisteredMode.model_validate_json(original.model_dump_json())
 
 
 def test_registered_mode_from_json_invalid_mode_type():
@@ -172,6 +183,9 @@ def test_mode_registry_json_round_trip():
     assert mode.targets == [MockVehicle]
 
     output_json = registry.model_dump_json(indent=4)
+    output = json.loads(output_json)
+    expected = json.loads(original_json)
+    expected["modes"]["mock"]["params_cls"] = "pydantic.main:BaseModel"
 
     # Compare parsed JSON, not raw strings
-    assert json.loads(output_json) == json.loads(original_json)
+    assert output == expected

--- a/controls/sae_2025_ws/src/vehicle_common/test/test_mode_loader.py
+++ b/controls/sae_2025_ws/src/vehicle_common/test/test_mode_loader.py
@@ -1,11 +1,11 @@
 import pytest
-from pydantic import BaseModel
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from vehicle_common.mode_loader import (
     serialize_type,
     deserialize_type,
     RegisteredMode,
     ModeRegistry,
+    ParamsBase,
 )
 from mock_classes import MockMode, MockParams, MockVehicle, MockVisionNode, NoParamsMock
 
@@ -58,7 +58,7 @@ def test_registered_mode_creation_no_params_mode():
 
     assert mode.id == "no_params_test"
     assert mode.mode_cls is NoParamsMock
-    assert mode.params_cls is BaseModel
+    assert mode.params_cls is ParamsBase
     assert mode.targets == [MockVehicle]
     assert mode.required_vision_nodes == []
 
@@ -110,8 +110,13 @@ def test_registered_mode_from_json():
 
     json_str = mode.model_dump_json()
 
-    with pytest.raises(ValidationError):
-        RegisteredMode.model_validate_json(json_str)
+    loaded = RegisteredMode.model_validate_json(json_str)
+
+    assert loaded.id == mode.id
+    assert loaded.mode_cls is MockMode
+    assert loaded.params_cls is MockParams
+    assert loaded.targets == [MockVehicle]
+    assert loaded.required_vision_nodes == [MockVisionNode]
 
 
 def test_registered_mode_json_round_trip():
@@ -126,8 +131,9 @@ def test_registered_mode_json_round_trip():
         transition_labels=["done"],
     )
 
-    with pytest.raises(ValidationError):
-        RegisteredMode.model_validate_json(original.model_dump_json())
+    loaded = RegisteredMode.model_validate_json(original.model_dump_json())
+
+    assert loaded.model_dump() == original.model_dump()
 
 
 def test_registered_mode_from_json_invalid_mode_type():
@@ -152,6 +158,19 @@ def test_registered_mode_from_json_invalid_path():
 
     with pytest.raises((ValueError, ModuleNotFoundError)):
         RegisteredMode.model_validate(data)
+
+
+def test_registered_mode_rejects_non_paramsbase_params_cls():
+    with pytest.raises(ValidationError):
+        RegisteredMode.model_validate(
+            {
+                "id": "bad_params_cls",
+                "mode_cls": MockMode,
+                "params_cls": BaseModel,
+                "targets": [MockVehicle],
+                "required_vision_nodes": [],
+            }
+        )
 
 
 def test_mode_registry_json_round_trip():
@@ -185,7 +204,7 @@ def test_mode_registry_json_round_trip():
     output_json = registry.model_dump_json(indent=4)
     output = json.loads(output_json)
     expected = json.loads(original_json)
-    expected["modes"]["mock"]["params_cls"] = "pydantic.main:BaseModel"
+    expected["modes"]["mock"]["params_cls"] = "vehicle_common.mode_loader:ParamsBase"
 
     # Compare parsed JSON, not raw strings
     assert output == expected

--- a/controls/sae_2025_ws/src/vehicle_common/vehicle_common/mode.py
+++ b/controls/sae_2025_ws/src/vehicle_common/vehicle_common/mode.py
@@ -1,18 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, ClassVar, Mapping
+from typing import ClassVar, Mapping
+
+from rclpy.node import Node
+from pydantic import BaseModel
 
 from vehicle_common.vehicle import Vehicle
 from vehicle_common.runtime.vision_loader import canonical_vision_node_path
-from pydantic import BaseModel
-
-if TYPE_CHECKING:
-    from rclpy.node import Node
-    from vehicle_common.base import VisionNode
-else:
-    # Avoid forcing ROS imports on pure-Python consumers (mission/fleet spec loading, integration backend)
-    # Node is annotation-only but must exist at runtime for get_type_hints().
-    Node = object
-
 
 class Mode[VehicleT: Vehicle, ParamsT: BaseModel](ABC):
     """
@@ -30,7 +23,7 @@ class Mode[VehicleT: Vehicle, ParamsT: BaseModel](ABC):
     pending_requests = {}
 
     @abstractmethod
-    def initialize(self, node: Node, vehicle: VehicleT, params: ParamsT):
+    def initialize(self, node: Node, vehicle: VehicleT, params: ParamsT) -> None:
         """Abstract method for initializing a mode
 
         Args:
@@ -38,10 +31,6 @@ class Mode[VehicleT: Vehicle, ParamsT: BaseModel](ABC):
             vehicle: The vehicle instance that the current mode has control over
             params: A validated pydantic params model that the mode class has defined
         """
-
-    @abstractmethod
-    def get_params_cls(self) -> type[BaseModel]:
-        """Get the Pydantic params model defined for this Mode subclass. Used for validating and instantiating the mode"""
 
     @classmethod
     def required_vision_node_paths(cls) -> tuple[str, ...]:

--- a/controls/sae_2025_ws/src/vehicle_common/vehicle_common/mode.py
+++ b/controls/sae_2025_ws/src/vehicle_common/vehicle_common/mode.py
@@ -5,7 +5,9 @@ from rclpy.node import Node
 from pydantic import BaseModel
 
 from vehicle_common.vehicle import Vehicle
+from vehicle_common.base import VisionNode
 from vehicle_common.runtime.vision_loader import canonical_vision_node_path
+
 
 class Mode[VehicleT: Vehicle, ParamsT: BaseModel](ABC):
     """

--- a/controls/sae_2025_ws/src/vehicle_common/vehicle_common/mode_loader.py
+++ b/controls/sae_2025_ws/src/vehicle_common/vehicle_common/mode_loader.py
@@ -6,7 +6,6 @@ import pkgutil
 
 from pydantic import BaseModel, ConfigDict, field_validator, field_serializer
 
-
 from vehicle_common.mode import Mode
 from vehicle_common.vehicle import Vehicle
 from vehicle_common.base import VisionNode  # don't want to depend on uav package
@@ -57,14 +56,20 @@ class RegisteredMode(BaseModel):
 
     id: str
     mode_cls: type[Mode]
+    params_cls: type[BaseModel] = BaseModel
     targets: list[type[Vehicle]] = []
     required_vision_nodes: list[type[VisionNode]] = []
     peer_vehicle_names: list[str] = []
     requires_camera: bool = False
     transition_labels: list[str] = []
 
+    # define field serializers if we want future static inspection w/ JSONs
     @field_serializer("mode_cls")
     def serialize_mode_cls(self, value: type[Mode]) -> str:
+        return serialize_type(value)
+
+    @field_serializer("params_cls")
+    def serialize_params_cls(self, value: type[BaseModel]) -> str:
         return serialize_type(value)
 
     @field_serializer("targets")
@@ -77,7 +82,6 @@ class RegisteredMode(BaseModel):
 
     # Each field_validator needs to support both actual types and strings so
     # manual instantiation and loading from json is valid
-
     @field_validator("mode_cls", mode="before")
     @classmethod
     def deserialize_mode_cls(cls, path) -> type[Mode]:
@@ -159,6 +163,7 @@ class ModeRegistry(BaseModel):
 def register_mode(
     id: str,
     targets: list[type[Vehicle]],
+    params_cls: type[BaseModel] = BaseModel,
     required_vision_nodes: list[type[VisionNode]] = [],
     peer_vehicle_names: list[str] = [],
     requires_camera: bool = False,
@@ -189,6 +194,7 @@ def register_mode(
                 id=id,
                 targets=targets,
                 mode_cls=registered_mode_cls,
+                params_cls=params_cls,
                 required_vision_nodes=required_vision_nodes,
                 peer_vehicle_names=peer_vehicle_names,
                 requires_camera=requires_camera,

--- a/controls/sae_2025_ws/src/vehicle_common/vehicle_common/mode_loader.py
+++ b/controls/sae_2025_ws/src/vehicle_common/vehicle_common/mode_loader.py
@@ -11,6 +11,12 @@ from vehicle_common.vehicle import Vehicle
 from vehicle_common.base import VisionNode  # don't want to depend on uav package
 
 
+class ParamsBase(BaseModel):
+    """Wrapper around BaseModel that every Mode's Params Type should inherit from"""
+
+    # doing this allows a default "Empty" instantiation since BaseModel() cannot be instantiated.
+
+
 def serialize_type(cls: type) -> str:
     return f"{cls.__module__}:{cls.__qualname__}"
 
@@ -56,7 +62,7 @@ class RegisteredMode(BaseModel):
 
     id: str
     mode_cls: type[Mode]
-    params_cls: type[BaseModel] = BaseModel
+    params_cls: type[ParamsBase] = ParamsBase
     targets: list[type[Vehicle]] = []
     required_vision_nodes: list[type[VisionNode]] = []
     peer_vehicle_names: list[str] = []
@@ -69,7 +75,7 @@ class RegisteredMode(BaseModel):
         return serialize_type(value)
 
     @field_serializer("params_cls")
-    def serialize_params_cls(self, value: type[BaseModel]) -> str:
+    def serialize_params_cls(self, value: type[ParamsBase]) -> str:
         return serialize_type(value)
 
     @field_serializer("targets")
@@ -88,6 +94,15 @@ class RegisteredMode(BaseModel):
         if isinstance(path, str):
             return deserialize_type(path, Mode)
         return path  # mode type
+
+    @field_validator("params_cls", mode="before")
+    @classmethod
+    def deserialize_params_cls(cls, path) -> type[ParamsBase]:
+        if isinstance(path, str):
+            return deserialize_type(path, ParamsBase)
+        if not isinstance(path, type) or not issubclass(path, ParamsBase):
+            raise ValueError(f"{path} must be a {ParamsBase.__name__}")
+        return path
 
     @field_validator("targets", mode="before")
     @classmethod
@@ -163,7 +178,7 @@ class ModeRegistry(BaseModel):
 def register_mode(
     id: str,
     targets: list[type[Vehicle]],
-    params_cls: type[BaseModel] = BaseModel,
+    params_cls: type[ParamsBase] = ParamsBase,
     required_vision_nodes: list[type[VisionNode]] = [],
     peer_vehicle_names: list[str] = [],
     requires_camera: bool = False,

--- a/controls/sae_2025_ws/src/vehicle_common/vehicle_common/runtime/mission_loader.py
+++ b/controls/sae_2025_ws/src/vehicle_common/vehicle_common/runtime/mission_loader.py
@@ -26,8 +26,7 @@ class RuntimeMode(BaseModel):
     def model_post_init(self, context: Any, /) -> None:
         mode_registry = ModeRegistry.get()
         self._registered = mode_registry.get_registered_mode(self.mode)
-        mode_cls = self._registered.mode_cls
-        self._validated_params = mode_cls.get_params_cls().model_validate(self.params)
+        self._validated_params = self._registered.params_cls.model_validate(self.params)
 
     def instantiate_mode(self, node: Node, vehicle: Vehicle) -> Mode:
         mode = self._registered.mode_cls()


### PR DESCRIPTION
## Issue(s) addressed:
fixes #297 

## Description:
instead of getting a params_cls from abstract method to validate params it is a registered mdoe field for cleaner mode creation. 


## Testing Done
ran vehicle_common tests locally
ran main launch locally