### PR TITLE
add title to macos installation page and fix toctree rendering

### DIFF
--- a/docs/installation/macos_utm.md
+++ b/docs/installation/macos_utm.md
@@ -1,3 +1,5 @@
+# macOS Installation
+
 **Note**: the following has not been fully tested yet. Please @frankie on Slack if there are any issues with the installation or setup.
 
 ## Setting Up

--- a/docs/installation/macos_utm.rst
+++ b/docs/installation/macos_utm.rst
@@ -1,2 +1,0 @@
-macOS Installation
-===================


### PR DESCRIPTION
## Issue(s) addressed:
documentation website


## Description:
Add title to macos installation page


## Testing Done:
docs built
