### PR TITLE
Create shortcuts for running unit tests and sim tests

### DIFF
--- a/controls/sae_2025_ws/.aliasrc
+++ b/controls/sae_2025_ws/.aliasrc
@@ -8,15 +8,11 @@ alias cbp='colcon build --packages-select'
 alias cbpsi='colcon build --symlink-install --packages-select'
 
 # TESTING
-#
-# alias ct='colcon test --event-handlers console_cohesion+'
-
+ctp() {
 # 1. runs colcon tests on selected packages
 # 2. merges xml test results into build/merged_results.xml
 # 3. Views merged_result.xml with xunit-viewer
-
 # runs unit tests from the selected packages
-ctp() {
     local pkgs=("$@")
     colcon test --packages-select "${pkgs[@]}"
 

--- a/controls/sae_2025_ws/.aliasrc
+++ b/controls/sae_2025_ws/.aliasrc
@@ -9,7 +9,7 @@ alias cbpsi='colcon build --symlink-install --packages-select'
 
 # TESTING
 #
-alias ct='colcon test --event-handlers console_cohesion+'
+# alias ct='colcon test --event-handlers console_cohesion+'
 
 # 1. runs colcon tests on selected packages
 # 2. merges xml test results into build/merged_results.xml
@@ -35,3 +35,10 @@ ctp() {
 	junitparser merge --glob "${paths[@]}" build/merged_results.xml
     xunit-viewer -r build/merged_results.xml --console -C false -o build/merged_results.html
 }
+
+
+ct() {
+    mapfile -t pkgs < <(colcon list -n)
+    ctp "${pkgs[@]}"
+}
+

--- a/controls/sae_2025_ws/.aliasrc
+++ b/controls/sae_2025_ws/.aliasrc
@@ -14,6 +14,8 @@ alias cbpsi='colcon build --symlink-install --packages-select'
 # 1. runs colcon tests on selected packages
 # 2. merges xml test results into build/merged_results.xml
 # 3. Views merged_result.xml with xunit-viewer
+
+# runs unit tests from the selected packages
 ctp() {
     local pkgs=("$@")
     colcon test --packages-select "${pkgs[@]}"
@@ -36,9 +38,17 @@ ctp() {
     xunit-viewer -r build/merged_results.xml --console -C false -o build/merged_results.html
 }
 
-
+# Runs unit tests from ALL packages
 ct() {
     mapfile -t pkgs < <(colcon list -n)
     ctp "${pkgs[@]}"
 }
 
+# Runs all sim tests from ALL packages. Only supports ament_python packages so far.
+ctsim() {
+    mapfile -t pkgs < <(colcon list | grep 'ament_python' | awk '{print $1}')
+    colcon test --packages-select "${pkgs[@]}" --event-handlers console_direct+ --pytest-args -s -o python_files="sim_test_*.py"
+}
+
+# Runs all sim tests from the selected/specified packages
+alias ctpsim='colcon test --pytest-args -s -o python_files="sim_test_*.py" --event-handlers console_direct+ --packages-select'

--- a/controls/sae_2025_ws/src/payload/setup.cfg
+++ b/controls/sae_2025_ws/src/payload/setup.cfg
@@ -5,3 +5,5 @@ install_scripts=$base/lib/payload
 [tool:pytest]
 markers =
     live: requires real hardware or a running peer stack; excluded from default CI
+junit_suite_name = payload
+

--- a/controls/sae_2025_ws/src/sim/setup.cfg
+++ b/controls/sae_2025_ws/src/sim/setup.cfg
@@ -5,3 +5,4 @@ install_scripts=$base/lib/sim
 [tool:pytest]
 markers =
     live: requires real hardware or a running peer stack; excluded from default CI
+junit_suite_name = sim

--- a/controls/sae_2025_ws/src/tools/setup.cfg
+++ b/controls/sae_2025_ws/src/tools/setup.cfg
@@ -2,3 +2,7 @@
 script_dir=$base/lib/tools
 [install]
 install_scripts=$base/lib/tools
+[tool:pytest]
+junit_suite_name = tools
+
+

--- a/controls/sae_2025_ws/src/uav/setup.cfg
+++ b/controls/sae_2025_ws/src/uav/setup.cfg
@@ -5,3 +5,5 @@ install_scripts=$base/lib/uav
 [tool:pytest]
 markers =
     live: requires real hardware or a running peer stack; excluded from default CI
+    sim_test: runs a fully integrated gazebo simulation test
+junit_suite_name = uav

--- a/controls/sae_2025_ws/src/uav/test/sim_test_headless.py
+++ b/controls/sae_2025_ws/src/uav/test/sim_test_headless.py
@@ -21,8 +21,9 @@ TIMEOUT_S = float(os.environ.get("SIM_SMOKE_TIMEOUT", "180"))
 
 
 @pytest.mark.launch_test
+@pytest.mark.sim_test
 def generate_test_description():
-    px4_path = os.environ["PX4_PATH"]
+    px4_path = os.environ["PENNAIR_PX4_PATH"]
     params_file = os.path.join(
         get_package_share_directory("uav"), "launch", "ci", "launch_params_basic.yaml"
     )

--- a/controls/sae_2025_ws/src/uav/test/sim_test_headless_tailsitter.py
+++ b/controls/sae_2025_ws/src/uav/test/sim_test_headless_tailsitter.py
@@ -21,8 +21,9 @@ TIMEOUT_S = float(os.environ.get("SIM_SMOKE_TIMEOUT", "180"))
 
 
 @pytest.mark.launch_test
+@pytest.mark.sim_test
 def generate_test_description():
-    px4_path = os.environ["PX4_PATH"]
+    px4_path = os.environ["PENNAIR_PX4_PATH"]
     params_file = os.path.join(
         get_package_share_directory("uav"),
         "launch",

--- a/controls/sae_2025_ws/src/uav/test/test_copyright.py
+++ b/controls/sae_2025_ws/src/uav/test/test_copyright.py
@@ -25,3 +25,7 @@ import pytest
 def test_copyright():
     rc = main(argv=[".", "test"])
     assert rc == 0, "Found errors"
+
+
+def test_stub():
+    assert(True)

--- a/controls/sae_2025_ws/src/uav/test/test_copyright.py
+++ b/controls/sae_2025_ws/src/uav/test/test_copyright.py
@@ -28,4 +28,4 @@ def test_copyright():
 
 
 def test_stub():
-    assert(True)
+    assert True

--- a/controls/sae_2025_ws/src/udp_bridge/setup.cfg
+++ b/controls/sae_2025_ws/src/udp_bridge/setup.cfg
@@ -2,3 +2,5 @@
 script_dir=$base/lib/udp_bridge
 [install]
 install_scripts=$base/lib/udp_bridge
+[tool:pytest]
+junit_suite_name = udp_bridge

--- a/controls/sae_2025_ws/src/vehicle_common/setup.cfg
+++ b/controls/sae_2025_ws/src/vehicle_common/setup.cfg
@@ -5,3 +5,4 @@ install_scripts=$base/lib/vehicle_common
 [tool:pytest]
 markers =
     live: requires real hardware or a running peer stack; excluded from default CI
+junit_suite_name = vehicle_common

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 dependencies = [ # these should be packages that AREN'T already installed system wide via apt by rosdep to avoid conflicts
     "pydantic>=2.0,<3",
     "apriltag",
-    "junitparser"
+    "junitparser",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
**Issue(s) addressed:** #333 


**Description:** Renames all sim tests to start with "sim_test_*.py". that way you can put in `--pytest-args -o python_files="sim_test_*.py"` to run only the sim_tests

regular colcon test pytest looks only for regular file pattern, "test_*"

added new aliasrc commands:
ctsim: tests all files with sim_test_ prefix over all ament_python packages
ctpsim: tests all specified/selected packages test files with sim_test_prefix pytest arg 


**Testing Done:** Ran shortcuts locally to test.